### PR TITLE
refactor: chat context/read scope 필터 추가 (startDate 2주 + DONE 제외)

### DIFF
--- a/src/main/kotlin/com/pluxity/weekly/chat/context/ContextBuilder.kt
+++ b/src/main/kotlin/com/pluxity/weekly/chat/context/ContextBuilder.kt
@@ -8,6 +8,9 @@ import com.pluxity.weekly.project.service.ProjectService
 import com.pluxity.weekly.task.dto.TaskResponse
 import com.pluxity.weekly.task.service.TaskService
 import com.pluxity.weekly.team.service.TeamService
+import com.pluxity.weekly.epic.entity.EpicStatus
+import com.pluxity.weekly.project.entity.ProjectStatus
+import com.pluxity.weekly.task.entity.TaskStatus
 import org.springframework.data.domain.Sort
 import org.springframework.stereotype.Component
 import org.springframework.transaction.annotation.Transactional
@@ -36,6 +39,13 @@ class ContextBuilder(
     private val authorizationService: AuthorizationService,
     private val objectMapper: ObjectMapper,
 ) {
+    companion object {
+        private const val SCOPE_WEEKS = 2L
+    }
+
+    private fun isWithinScope(startDate: LocalDate?): Boolean =
+        startDate != null && startDate >= LocalDate.now().minusWeeks(SCOPE_WEEKS)
+
     fun build(
         target: String,
         actions: List<String>,
@@ -52,19 +62,22 @@ class ContextBuilder(
             )
 
         val hasCreateOnly = "create" in actions && "update" !in actions
+        val excludeDone = "update" in actions || "delete" in actions
 
         when (target) {
-            "project" -> buildProjectContext(context)
-            "epic" -> buildEpicContext(context)
+            "project" -> buildProjectContext(context, excludeDone)
+            "epic" -> buildEpicContext(context, excludeDone)
             "team" -> buildTeamContext(context)
-            else -> buildTaskContext(context, hasCreateOnly)
+            else -> buildTaskContext(context, hasCreateOnly, excludeDone)
         }
 
         return objectMapper.writeValueAsString(context)
     }
 
-    private fun buildProjectContext(context: MutableMap<String, Any?>) {
+    private fun buildProjectContext(context: MutableMap<String, Any?>, excludeDone: Boolean) {
         val projects = projectService.findAll()
+            .filter { isWithinScope(it.startDate) || it.status != ProjectStatus.DONE }
+            .filter { !excludeDone || it.status != ProjectStatus.DONE }
         context["projects"] =
             projects.map {
                 mapOf("id" to it.id, "name" to it.name, "status" to it.status.name)
@@ -72,34 +85,42 @@ class ContextBuilder(
         context["users"] = findUsersByRole("PM")
     }
 
-    private fun buildEpicContext(context: MutableMap<String, Any?>) {
+    private fun buildEpicContext(context: MutableMap<String, Any?>, excludeDone: Boolean) {
         val projects = projectService.findAll()
         val epics = epicService.findAll()
+            .filter { isWithinScope(it.startDate) || it.status != EpicStatus.DONE }
+            .filter { !excludeDone || it.status != EpicStatus.DONE }
         val epicsByProject = epics.groupBy { it.projectId }
         context["projects"] =
-            projects.map { project ->
-                mapOf(
-                    "id" to project.id,
-                    "name" to project.name,
-                    "epics" to
-                        (epicsByProject[project.id] ?: emptyList()).map {
-                            mapOf("id" to it.id, "name" to it.name)
-                        },
-                )
-            }
+            projects
+                .filter { epicsByProject.containsKey(it.id) }
+                .map { project ->
+                    mapOf(
+                        "id" to project.id,
+                        "name" to project.name,
+                        "epics" to
+                            (epicsByProject[project.id] ?: emptyList()).map {
+                                mapOf("id" to it.id, "name" to it.name)
+                            },
+                    )
+                }
         context["users"] = findAllUsers()
     }
 
     private fun buildTaskContext(
         context: MutableMap<String, Any?>,
         createOnly: Boolean,
+        excludeDone: Boolean,
     ) {
         val epics = epicService.findAll()
 
         if (createOnly) {
-            context["projects"] = groupByProject(epics)
+            val activeEpics = epics.filter { it.status != EpicStatus.DONE }
+            context["projects"] = groupByProject(activeEpics)
         } else {
             val tasks = taskService.findAll()
+                .filter { isWithinScope(it.startDate) || it.status != TaskStatus.DONE }
+                .filter { !excludeDone || it.status != TaskStatus.DONE }
             val tasksByEpicId = tasks.groupBy { it.epicId }
             context["projects"] = groupByProjectFull(epics, tasksByEpicId)
             context["users"] = findAllUsers()

--- a/src/main/kotlin/com/pluxity/weekly/chat/context/ContextBuilder.kt
+++ b/src/main/kotlin/com/pluxity/weekly/chat/context/ContextBuilder.kt
@@ -2,6 +2,7 @@ package com.pluxity.weekly.chat.context
 
 import com.pluxity.weekly.auth.user.repository.UserRepository
 import com.pluxity.weekly.authorization.AuthorizationService
+import com.pluxity.weekly.chat.util.ChatScope
 import com.pluxity.weekly.epic.dto.EpicResponse
 import com.pluxity.weekly.epic.entity.EpicStatus
 import com.pluxity.weekly.epic.service.EpicService
@@ -39,12 +40,6 @@ class ContextBuilder(
     private val authorizationService: AuthorizationService,
     private val objectMapper: ObjectMapper,
 ) {
-    companion object {
-        private const val SCOPE_WEEKS = 2L
-    }
-
-    private fun isWithinScope(startDate: LocalDate?): Boolean = startDate != null && startDate >= LocalDate.now().minusWeeks(SCOPE_WEEKS)
-
     fun build(
         target: String,
         actions: List<String>,
@@ -80,7 +75,7 @@ class ContextBuilder(
         val projects =
             projectService
                 .findAll()
-                .filter { isWithinScope(it.startDate) || it.status != ProjectStatus.DONE }
+                .filter { ChatScope.isWithinScope(it.startDate) || it.status != ProjectStatus.DONE }
                 .filter { !excludeDone || it.status != ProjectStatus.DONE }
         context["projects"] =
             projects.map {
@@ -97,7 +92,7 @@ class ContextBuilder(
         val epics =
             epicService
                 .findAll()
-                .filter { isWithinScope(it.startDate) || it.status != EpicStatus.DONE }
+                .filter { ChatScope.isWithinScope(it.startDate) || it.status != EpicStatus.DONE }
                 .filter { !excludeDone || it.status != EpicStatus.DONE }
         val epicsByProject = epics.groupBy { it.projectId }
         context["projects"] =
@@ -130,7 +125,7 @@ class ContextBuilder(
             val tasks =
                 taskService
                     .findAll()
-                    .filter { isWithinScope(it.startDate) || it.status != TaskStatus.DONE }
+                    .filter { ChatScope.isWithinScope(it.startDate) || it.status != TaskStatus.DONE }
                     .filter { !excludeDone || it.status != TaskStatus.DONE }
             val tasksByEpicId = tasks.groupBy { it.epicId }
             context["projects"] = groupByProjectFull(epics, tasksByEpicId)

--- a/src/main/kotlin/com/pluxity/weekly/chat/context/ContextBuilder.kt
+++ b/src/main/kotlin/com/pluxity/weekly/chat/context/ContextBuilder.kt
@@ -3,14 +3,14 @@ package com.pluxity.weekly.chat.context
 import com.pluxity.weekly.auth.user.repository.UserRepository
 import com.pluxity.weekly.authorization.AuthorizationService
 import com.pluxity.weekly.epic.dto.EpicResponse
+import com.pluxity.weekly.epic.entity.EpicStatus
 import com.pluxity.weekly.epic.service.EpicService
+import com.pluxity.weekly.project.entity.ProjectStatus
 import com.pluxity.weekly.project.service.ProjectService
 import com.pluxity.weekly.task.dto.TaskResponse
+import com.pluxity.weekly.task.entity.TaskStatus
 import com.pluxity.weekly.task.service.TaskService
 import com.pluxity.weekly.team.service.TeamService
-import com.pluxity.weekly.epic.entity.EpicStatus
-import com.pluxity.weekly.project.entity.ProjectStatus
-import com.pluxity.weekly.task.entity.TaskStatus
 import org.springframework.data.domain.Sort
 import org.springframework.stereotype.Component
 import org.springframework.transaction.annotation.Transactional
@@ -43,8 +43,7 @@ class ContextBuilder(
         private const val SCOPE_WEEKS = 2L
     }
 
-    private fun isWithinScope(startDate: LocalDate?): Boolean =
-        startDate != null && startDate >= LocalDate.now().minusWeeks(SCOPE_WEEKS)
+    private fun isWithinScope(startDate: LocalDate?): Boolean = startDate != null && startDate >= LocalDate.now().minusWeeks(SCOPE_WEEKS)
 
     fun build(
         target: String,
@@ -74,10 +73,15 @@ class ContextBuilder(
         return objectMapper.writeValueAsString(context)
     }
 
-    private fun buildProjectContext(context: MutableMap<String, Any?>, excludeDone: Boolean) {
-        val projects = projectService.findAll()
-            .filter { isWithinScope(it.startDate) || it.status != ProjectStatus.DONE }
-            .filter { !excludeDone || it.status != ProjectStatus.DONE }
+    private fun buildProjectContext(
+        context: MutableMap<String, Any?>,
+        excludeDone: Boolean,
+    ) {
+        val projects =
+            projectService
+                .findAll()
+                .filter { isWithinScope(it.startDate) || it.status != ProjectStatus.DONE }
+                .filter { !excludeDone || it.status != ProjectStatus.DONE }
         context["projects"] =
             projects.map {
                 mapOf("id" to it.id, "name" to it.name, "status" to it.status.name)
@@ -85,11 +89,16 @@ class ContextBuilder(
         context["users"] = findUsersByRole("PM")
     }
 
-    private fun buildEpicContext(context: MutableMap<String, Any?>, excludeDone: Boolean) {
+    private fun buildEpicContext(
+        context: MutableMap<String, Any?>,
+        excludeDone: Boolean,
+    ) {
         val projects = projectService.findAll()
-        val epics = epicService.findAll()
-            .filter { isWithinScope(it.startDate) || it.status != EpicStatus.DONE }
-            .filter { !excludeDone || it.status != EpicStatus.DONE }
+        val epics =
+            epicService
+                .findAll()
+                .filter { isWithinScope(it.startDate) || it.status != EpicStatus.DONE }
+                .filter { !excludeDone || it.status != EpicStatus.DONE }
         val epicsByProject = epics.groupBy { it.projectId }
         context["projects"] =
             projects
@@ -118,9 +127,11 @@ class ContextBuilder(
             val activeEpics = epics.filter { it.status != EpicStatus.DONE }
             context["projects"] = groupByProject(activeEpics)
         } else {
-            val tasks = taskService.findAll()
-                .filter { isWithinScope(it.startDate) || it.status != TaskStatus.DONE }
-                .filter { !excludeDone || it.status != TaskStatus.DONE }
+            val tasks =
+                taskService
+                    .findAll()
+                    .filter { isWithinScope(it.startDate) || it.status != TaskStatus.DONE }
+                    .filter { !excludeDone || it.status != TaskStatus.DONE }
             val tasksByEpicId = tasks.groupBy { it.epicId }
             context["projects"] = groupByProjectFull(epics, tasksByEpicId)
             context["users"] = findAllUsers()

--- a/src/main/kotlin/com/pluxity/weekly/chat/context/ContextBuilder.kt
+++ b/src/main/kotlin/com/pluxity/weekly/chat/context/ContextBuilder.kt
@@ -128,7 +128,8 @@ class ContextBuilder(
                     .filter { ChatScope.isWithinScope(it.startDate) || it.status != TaskStatus.DONE }
                     .filter { !excludeDone || it.status != TaskStatus.DONE }
             val tasksByEpicId = tasks.groupBy { it.epicId }
-            context["projects"] = groupByProjectFull(epics, tasksByEpicId)
+            val activeEpics = epics.filter { tasksByEpicId.containsKey(it.id) }
+            context["projects"] = groupByProjectFull(activeEpics, tasksByEpicId)
             context["users"] = findAllUsers()
         }
     }

--- a/src/main/kotlin/com/pluxity/weekly/chat/service/ChatReadHandler.kt
+++ b/src/main/kotlin/com/pluxity/weekly/chat/service/ChatReadHandler.kt
@@ -26,19 +26,21 @@ class ChatReadHandler(
     fun handle(action: LlmAction): ChatReadResponse {
         val target = action.target ?: "task"
         val filters = action.filters ?: emptyMap()
-
         return when (target) {
             "task" ->
                 ChatReadResponse(
-                    tasks = taskService.search(buildTaskFilter(filters)),
+                    tasks = taskService.search(buildTaskFilter(filters))
+                        .filter { isWithinScope(it.startDate) || it.status != TaskStatus.DONE },
                 )
             "project" ->
                 ChatReadResponse(
-                    projects = projectService.search(buildProjectFilter(filters)),
+                    projects = projectService.search(buildProjectFilter(filters))
+                        .filter { isWithinScope(it.startDate) || it.status != ProjectStatus.DONE },
                 )
             "epic" ->
                 ChatReadResponse(
-                    epics = epicService.search(buildEpicFilter(filters)),
+                    epics = epicService.search(buildEpicFilter(filters))
+                        .filter { isWithinScope(it.startDate) || it.status != EpicStatus.DONE },
                 )
             "team" ->
                 ChatReadResponse(
@@ -50,10 +52,14 @@ class ChatReadHandler(
                 )
             else ->
                 ChatReadResponse(
-                    tasks = taskService.search(buildTaskFilter(filters)),
+                    tasks = taskService.search(buildTaskFilter(filters))
+                        .filter { isWithinScope(it.startDate) || it.status != TaskStatus.DONE },
                 )
         }
     }
+
+    private fun isWithinScope(startDate: LocalDate?): Boolean =
+        startDate != null && startDate >= LocalDate.now().minusWeeks(2)
 
     private fun buildTaskFilter(filters: Map<String, Any?>): TaskSearchFilter =
         TaskSearchFilter(

--- a/src/main/kotlin/com/pluxity/weekly/chat/service/ChatReadHandler.kt
+++ b/src/main/kotlin/com/pluxity/weekly/chat/service/ChatReadHandler.kt
@@ -1,5 +1,6 @@
 package com.pluxity.weekly.chat.service
 
+import com.pluxity.weekly.chat.util.ChatScope
 import com.pluxity.weekly.chat.dto.ChatReadResponse
 import com.pluxity.weekly.chat.dto.EpicSearchFilter
 import com.pluxity.weekly.chat.dto.LlmAction
@@ -32,21 +33,21 @@ class ChatReadHandler(
                     tasks =
                         taskService
                             .search(buildTaskFilter(filters))
-                            .filter { isWithinScope(it.startDate) || it.status != TaskStatus.DONE },
+                            .filter { ChatScope.isWithinScope(it.startDate) || it.status != TaskStatus.DONE },
                 )
             "project" ->
                 ChatReadResponse(
                     projects =
                         projectService
                             .search(buildProjectFilter(filters))
-                            .filter { isWithinScope(it.startDate) || it.status != ProjectStatus.DONE },
+                            .filter { ChatScope.isWithinScope(it.startDate) || it.status != ProjectStatus.DONE },
                 )
             "epic" ->
                 ChatReadResponse(
                     epics =
                         epicService
                             .search(buildEpicFilter(filters))
-                            .filter { isWithinScope(it.startDate) || it.status != EpicStatus.DONE },
+                            .filter { ChatScope.isWithinScope(it.startDate) || it.status != EpicStatus.DONE },
                 )
             "team" ->
                 ChatReadResponse(
@@ -61,12 +62,10 @@ class ChatReadHandler(
                     tasks =
                         taskService
                             .search(buildTaskFilter(filters))
-                            .filter { isWithinScope(it.startDate) || it.status != TaskStatus.DONE },
+                            .filter { ChatScope.isWithinScope(it.startDate) || it.status != TaskStatus.DONE },
                 )
         }
     }
-
-    private fun isWithinScope(startDate: LocalDate?): Boolean = startDate != null && startDate >= LocalDate.now().minusWeeks(2)
 
     private fun buildTaskFilter(filters: Map<String, Any?>): TaskSearchFilter =
         TaskSearchFilter(

--- a/src/main/kotlin/com/pluxity/weekly/chat/service/ChatReadHandler.kt
+++ b/src/main/kotlin/com/pluxity/weekly/chat/service/ChatReadHandler.kt
@@ -29,18 +29,24 @@ class ChatReadHandler(
         return when (target) {
             "task" ->
                 ChatReadResponse(
-                    tasks = taskService.search(buildTaskFilter(filters))
-                        .filter { isWithinScope(it.startDate) || it.status != TaskStatus.DONE },
+                    tasks =
+                        taskService
+                            .search(buildTaskFilter(filters))
+                            .filter { isWithinScope(it.startDate) || it.status != TaskStatus.DONE },
                 )
             "project" ->
                 ChatReadResponse(
-                    projects = projectService.search(buildProjectFilter(filters))
-                        .filter { isWithinScope(it.startDate) || it.status != ProjectStatus.DONE },
+                    projects =
+                        projectService
+                            .search(buildProjectFilter(filters))
+                            .filter { isWithinScope(it.startDate) || it.status != ProjectStatus.DONE },
                 )
             "epic" ->
                 ChatReadResponse(
-                    epics = epicService.search(buildEpicFilter(filters))
-                        .filter { isWithinScope(it.startDate) || it.status != EpicStatus.DONE },
+                    epics =
+                        epicService
+                            .search(buildEpicFilter(filters))
+                            .filter { isWithinScope(it.startDate) || it.status != EpicStatus.DONE },
                 )
             "team" ->
                 ChatReadResponse(
@@ -52,14 +58,15 @@ class ChatReadHandler(
                 )
             else ->
                 ChatReadResponse(
-                    tasks = taskService.search(buildTaskFilter(filters))
-                        .filter { isWithinScope(it.startDate) || it.status != TaskStatus.DONE },
+                    tasks =
+                        taskService
+                            .search(buildTaskFilter(filters))
+                            .filter { isWithinScope(it.startDate) || it.status != TaskStatus.DONE },
                 )
         }
     }
 
-    private fun isWithinScope(startDate: LocalDate?): Boolean =
-        startDate != null && startDate >= LocalDate.now().minusWeeks(2)
+    private fun isWithinScope(startDate: LocalDate?): Boolean = startDate != null && startDate >= LocalDate.now().minusWeeks(2)
 
     private fun buildTaskFilter(filters: Map<String, Any?>): TaskSearchFilter =
         TaskSearchFilter(

--- a/src/main/kotlin/com/pluxity/weekly/chat/util/ChatScope.kt
+++ b/src/main/kotlin/com/pluxity/weekly/chat/util/ChatScope.kt
@@ -1,0 +1,10 @@
+package com.pluxity.weekly.chat.util
+
+import java.time.LocalDate
+
+object ChatScope {
+    private const val WEEKS = 2L
+
+    fun isWithinScope(startDate: LocalDate?): Boolean =
+        startDate != null && startDate >= LocalDate.now().minusWeeks(WEEKS)
+}

--- a/src/main/kotlin/com/pluxity/weekly/teams/converter/TaskReviewCardBuilder.kt
+++ b/src/main/kotlin/com/pluxity/weekly/teams/converter/TaskReviewCardBuilder.kt
@@ -21,65 +21,65 @@ class TaskReviewCardBuilder {
             "type" to "AdaptiveCard",
             "version" to "1.2",
             "body" to
-                    listOf(
-                        mapOf(
-                            "type" to "TextBlock",
-                            "text" to "리뷰 요청",
-                            "weight" to "bolder",
-                            "size" to "medium",
-                            "color" to "accent",
-                        ),
-                        factRow("프로젝트", projectName, separator = true),
-                        factRow("에픽", epicName, separator = true),
-                        factRow("태스크", taskName, separator = true),
-                        factRow("요청자", requesterName, separator = true),
+                listOf(
+                    mapOf(
+                        "type" to "TextBlock",
+                        "text" to "리뷰 요청",
+                        "weight" to "bolder",
+                        "size" to "medium",
+                        "color" to "accent",
                     ),
+                    factRow("프로젝트", projectName, separator = true),
+                    factRow("에픽", epicName, separator = true),
+                    factRow("태스크", taskName, separator = true),
+                    factRow("요청자", requesterName, separator = true),
+                ),
             "actions" to
-                    listOf(
-                        mapOf(
-                            "type" to "Action.Submit",
-                            "title" to "승인",
-                            "style" to "positive",
-                            "data" to
-                                    mapOf(
-                                        "action" to "approve",
-                                        "target" to "task",
-                                        "taskId" to taskId,
-                                    ),
-                        ),
-                        mapOf(
-                            "type" to "Action.ShowCard",
-                            "title" to "반려",
-                            "card" to
-                                    mapOf(
-                                        "type" to "AdaptiveCard",
-                                        "body" to
-                                                listOf(
-                                                    mapOf(
-                                                        "type" to "Input.Text",
-                                                        "id" to "reason",
-                                                        "label" to "반려 사유 (선택)",
-                                                        "isMultiline" to true,
-                                                        "placeholder" to "반려 사유를 입력하세요",
-                                                    ),
-                                                ),
-                                        "actions" to
-                                                listOf(
-                                                    mapOf(
-                                                        "type" to "Action.Submit",
-                                                        "title" to "반려 확인",
-                                                        "style" to "destructive",
-                                                        "data" to
-                                                                mapOf(
-                                                                    "action" to "reject",
-                                                                    "target" to "task",
-                                                                    "taskId" to taskId,
-                                                                ),
-                                                    ),
-                                                ),
-                                    ),
-                        ),
+                listOf(
+                    mapOf(
+                        "type" to "Action.Submit",
+                        "title" to "승인",
+                        "style" to "positive",
+                        "data" to
+                            mapOf(
+                                "action" to "approve",
+                                "target" to "task",
+                                "taskId" to taskId,
+                            ),
                     ),
+                    mapOf(
+                        "type" to "Action.ShowCard",
+                        "title" to "반려",
+                        "card" to
+                            mapOf(
+                                "type" to "AdaptiveCard",
+                                "body" to
+                                    listOf(
+                                        mapOf(
+                                            "type" to "Input.Text",
+                                            "id" to "reason",
+                                            "label" to "반려 사유 (선택)",
+                                            "isMultiline" to true,
+                                            "placeholder" to "반려 사유를 입력하세요",
+                                        ),
+                                    ),
+                                "actions" to
+                                    listOf(
+                                        mapOf(
+                                            "type" to "Action.Submit",
+                                            "title" to "반려 확인",
+                                            "style" to "destructive",
+                                            "data" to
+                                                mapOf(
+                                                    "action" to "reject",
+                                                    "target" to "task",
+                                                    "taskId" to taskId,
+                                                ),
+                                        ),
+                                    ),
+                            ),
+                    ),
+                ),
         )
 
     private fun factRow(


### PR DESCRIPTION
Summary
 
- ContextBuilder: startDate 기준 최근 2주 + 미완료 항목만 컨텍스트에 노출 (2주 이전 DONE 제외, startDate null + DONE 제외)
- ContextBuilder: update/delete 액션 시 DONE 항목 컨텍스트에서 제외
- ContextBuilder: task create 시 DONE epic 선택지에서 제외
- ChatReadHandler: 동일 scope 필터 적용 (read 결과에도 2주 이전 DONE 미노출)

### 관련 이슈
#8 