### PR TITLE
feat: soft delete 적용 및 컨텍스트 필터 개선

### DIFF
--- a/src/main/kotlin/com/pluxity/weekly/chat/context/ContextBuilder.kt
+++ b/src/main/kotlin/com/pluxity/weekly/chat/context/ContextBuilder.kt
@@ -97,7 +97,6 @@ class ContextBuilder(
         val epicsByProject = epics.groupBy { it.projectId }
         context["projects"] =
             projects
-//                .filter { epicsByProject.containsKey(it.id) }
                 .map { project ->
                     mapOf(
                         "id" to project.id,

--- a/src/main/kotlin/com/pluxity/weekly/chat/context/ContextBuilder.kt
+++ b/src/main/kotlin/com/pluxity/weekly/chat/context/ContextBuilder.kt
@@ -2,14 +2,15 @@ package com.pluxity.weekly.chat.context
 
 import com.pluxity.weekly.auth.user.repository.UserRepository
 import com.pluxity.weekly.authorization.AuthorizationService
+import com.pluxity.weekly.chat.dto.EpicSearchFilter
+import com.pluxity.weekly.chat.dto.ProjectSearchFilter
+import com.pluxity.weekly.chat.dto.TaskSearchFilter
 import com.pluxity.weekly.chat.util.ChatScope
 import com.pluxity.weekly.epic.dto.EpicResponse
 import com.pluxity.weekly.epic.entity.EpicStatus
 import com.pluxity.weekly.epic.service.EpicService
-import com.pluxity.weekly.project.entity.ProjectStatus
 import com.pluxity.weekly.project.service.ProjectService
 import com.pluxity.weekly.task.dto.TaskResponse
-import com.pluxity.weekly.task.entity.TaskStatus
 import com.pluxity.weekly.task.service.TaskService
 import com.pluxity.weekly.team.service.TeamService
 import org.springframework.data.domain.Sort
@@ -73,10 +74,12 @@ class ContextBuilder(
         excludeDone: Boolean,
     ) {
         val projects =
-            projectService
-                .findAll()
-                .filter { ChatScope.isWithinScope(it.startDate) || it.status != ProjectStatus.DONE }
-                .filter { !excludeDone || it.status != ProjectStatus.DONE }
+            projectService.search(
+                ProjectSearchFilter(
+                    excludeDone = excludeDone,
+                    scopeStartDate = ChatScope.scopeStartDate(),
+                ),
+            )
         context["projects"] =
             projects.map {
                 mapOf("id" to it.id, "name" to it.name, "status" to it.status.name)
@@ -90,10 +93,12 @@ class ContextBuilder(
     ) {
         val projects = projectService.findAll()
         val epics =
-            epicService
-                .findAll()
-                .filter { ChatScope.isWithinScope(it.startDate) || it.status != EpicStatus.DONE }
-                .filter { !excludeDone || it.status != EpicStatus.DONE }
+            epicService.search(
+                EpicSearchFilter(
+                    excludeDone = excludeDone,
+                    scopeStartDate = ChatScope.scopeStartDate(),
+                ),
+            )
         val epicsByProject = epics.groupBy { it.projectId }
         context["projects"] =
             projects
@@ -122,10 +127,12 @@ class ContextBuilder(
             context["projects"] = groupByProject(activeEpics)
         } else {
             val tasks =
-                taskService
-                    .findAll()
-                    .filter { ChatScope.isWithinScope(it.startDate) || it.status != TaskStatus.DONE }
-                    .filter { !excludeDone || it.status != TaskStatus.DONE }
+                taskService.search(
+                    TaskSearchFilter(
+                        excludeDone = excludeDone,
+                        scopeStartDate = ChatScope.scopeStartDate(),
+                    ),
+                )
             val tasksByEpicId = tasks.groupBy { it.epicId }
             val activeEpics = epics.filter { tasksByEpicId.containsKey(it.id) }
             context["projects"] = groupByProjectFull(activeEpics, tasksByEpicId)

--- a/src/main/kotlin/com/pluxity/weekly/chat/dto/EpicSearchFilter.kt
+++ b/src/main/kotlin/com/pluxity/weekly/chat/dto/EpicSearchFilter.kt
@@ -11,4 +11,6 @@ data class EpicSearchFilter(
     val dueDateFrom: LocalDate? = null,
     val dueDateTo: LocalDate? = null,
     val epicIds: List<Long>? = null,
+    val excludeDone: Boolean = false,
+    val scopeStartDate: LocalDate? = null,
 )

--- a/src/main/kotlin/com/pluxity/weekly/chat/dto/ProjectSearchFilter.kt
+++ b/src/main/kotlin/com/pluxity/weekly/chat/dto/ProjectSearchFilter.kt
@@ -10,4 +10,6 @@ data class ProjectSearchFilter(
     val dueDateFrom: LocalDate? = null,
     val dueDateTo: LocalDate? = null,
     val projectIds: List<Long>? = null,
+    val excludeDone: Boolean = false,
+    val scopeStartDate: LocalDate? = null,
 )

--- a/src/main/kotlin/com/pluxity/weekly/chat/dto/TaskSearchFilter.kt
+++ b/src/main/kotlin/com/pluxity/weekly/chat/dto/TaskSearchFilter.kt
@@ -12,4 +12,6 @@ data class TaskSearchFilter(
     val dueDateFrom: LocalDate? = null,
     val dueDateTo: LocalDate? = null,
     val epicIds: List<Long>? = null,
+    val excludeDone: Boolean = false,
+    val scopeStartDate: LocalDate? = null,
 )

--- a/src/main/kotlin/com/pluxity/weekly/chat/service/ChatReadHandler.kt
+++ b/src/main/kotlin/com/pluxity/weekly/chat/service/ChatReadHandler.kt
@@ -1,12 +1,12 @@
 package com.pluxity.weekly.chat.service
 
-import com.pluxity.weekly.chat.util.ChatScope
 import com.pluxity.weekly.chat.dto.ChatReadResponse
 import com.pluxity.weekly.chat.dto.EpicSearchFilter
 import com.pluxity.weekly.chat.dto.LlmAction
 import com.pluxity.weekly.chat.dto.ProjectSearchFilter
 import com.pluxity.weekly.chat.dto.TaskSearchFilter
 import com.pluxity.weekly.chat.dto.TeamSearchFilter
+import com.pluxity.weekly.chat.util.ChatScope
 import com.pluxity.weekly.epic.entity.EpicStatus
 import com.pluxity.weekly.epic.service.EpicService
 import com.pluxity.weekly.project.entity.ProjectStatus

--- a/src/main/kotlin/com/pluxity/weekly/chat/util/ChatScope.kt
+++ b/src/main/kotlin/com/pluxity/weekly/chat/util/ChatScope.kt
@@ -5,6 +5,7 @@ import java.time.LocalDate
 object ChatScope {
     private const val WEEKS = 2L
 
-    fun isWithinScope(startDate: LocalDate?): Boolean =
-        startDate != null && startDate >= LocalDate.now().minusWeeks(WEEKS)
+    fun scopeStartDate(): LocalDate = LocalDate.now().minusWeeks(WEEKS)
+
+    fun isWithinScope(startDate: LocalDate?): Boolean = startDate != null && startDate >= scopeStartDate()
 }

--- a/src/main/kotlin/com/pluxity/weekly/core/constant/ErrorCode.kt
+++ b/src/main/kotlin/com/pluxity/weekly/core/constant/ErrorCode.kt
@@ -36,6 +36,8 @@ enum class ErrorCode(
     INVALID_STATUS_TRANSITION(HttpStatus.BAD_REQUEST, "상태 %s에서는 %s 동작을 수행할 수 없습니다."),
     EPIC_NOT_ALL_DONE(HttpStatus.BAD_REQUEST, "프로젝트를 완료하려면 모든 하위 에픽을 먼저 완료해야 합니다."),
     TASK_NOT_ALL_DONE(HttpStatus.BAD_REQUEST, "에픽을 완료하려면 모든 하위 태스크를 먼저 완료해야 합니다."),
+    PROJECT_HAS_EPICS(HttpStatus.CONFLICT, "하위 에픽이 존재하는 프로젝트는 삭제할 수 없습니다."),
+    EPIC_HAS_TASKS(HttpStatus.CONFLICT, "하위 태스크가 존재하는 에픽은 삭제할 수 없습니다."),
 
     // ── Chat / LLM ──
     LLM_SERVICE_UNAVAILABLE(HttpStatus.SERVICE_UNAVAILABLE, "LLM 서비스에 연결할 수 없습니다."),

--- a/src/main/kotlin/com/pluxity/weekly/epic/entity/Epic.kt
+++ b/src/main/kotlin/com/pluxity/weekly/epic/entity/Epic.kt
@@ -13,10 +13,12 @@ import jakarta.persistence.JoinColumn
 import jakarta.persistence.ManyToOne
 import jakarta.persistence.OneToMany
 import jakarta.persistence.Table
+import org.hibernate.annotations.SoftDelete
 import java.time.LocalDate
 
 @Entity
 @Table(name = "epics")
+@SoftDelete(columnName = "deleted")
 class Epic(
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "project_id", nullable = false)

--- a/src/main/kotlin/com/pluxity/weekly/epic/repository/EpicCustomRepositoryImpl.kt
+++ b/src/main/kotlin/com/pluxity/weekly/epic/repository/EpicCustomRepositoryImpl.kt
@@ -6,6 +6,7 @@ import com.pluxity.weekly.chat.dto.EpicSearchFilter
 import com.pluxity.weekly.core.utils.findAllNotNull
 import com.pluxity.weekly.epic.entity.Epic
 import com.pluxity.weekly.epic.entity.EpicAssignment
+import com.pluxity.weekly.epic.entity.EpicStatus
 import com.pluxity.weekly.project.entity.Project
 
 class EpicCustomRepositoryImpl(
@@ -25,6 +26,13 @@ class EpicCustomRepositoryImpl(
                     filter.dueDateFrom?.let { path(Epic::dueDate).greaterThanOrEqualTo(it) },
                     filter.dueDateTo?.let { path(Epic::dueDate).lessThanOrEqualTo(it) },
                     filter.epicIds?.let { path(Epic::id).`in`(it) },
+                    if (filter.excludeDone) path(Epic::status).notEqual(EpicStatus.DONE) else null,
+                    filter.scopeStartDate?.let {
+                        or(
+                            path(Epic::startDate).greaterThanOrEqualTo(it),
+                            path(Epic::status).notEqual(EpicStatus.DONE),
+                        )
+                    },
                 )
         }
 }

--- a/src/main/kotlin/com/pluxity/weekly/epic/repository/EpicRepository.kt
+++ b/src/main/kotlin/com/pluxity/weekly/epic/repository/EpicRepository.kt
@@ -17,6 +17,8 @@ interface EpicRepository :
         epicId: Long,
     ): Boolean
 
+    fun existsByProjectId(projectId: Long): Boolean
+
     fun findByProjectId(projectId: Long): List<Epic>
 
     fun findByProjectIdIn(projectIds: List<Long>): List<Epic>

--- a/src/main/kotlin/com/pluxity/weekly/epic/service/EpicService.kt
+++ b/src/main/kotlin/com/pluxity/weekly/epic/service/EpicService.kt
@@ -118,6 +118,9 @@ class EpicService(
         val user = authorizationService.currentUser()
         val epic = getEpicById(id)
         authorizationService.requireEpicManage(user, epic.project.requiredId)
+        if (taskRepository.existsByEpicId(id)) {
+            throw CustomException(ErrorCode.EPIC_HAS_TASKS)
+        }
         epicRepository.delete(epic)
     }
 

--- a/src/main/kotlin/com/pluxity/weekly/epic/service/EpicService.kt
+++ b/src/main/kotlin/com/pluxity/weekly/epic/service/EpicService.kt
@@ -156,6 +156,7 @@ class EpicService(
             throw CustomException(ErrorCode.NOT_FOUND_EPIC_ASSIGNMENT, epicId, userId)
         }
         epic.unassign(assignee)
+        taskRepository.deleteByEpicIdAndAssigneeId(epicId, userId)
         eventPublisher.publishEvent(
             TeamsNotificationEvent(userId, "${epic.name} 에픽에서 해제되었습니다"),
         )

--- a/src/main/kotlin/com/pluxity/weekly/project/entity/Project.kt
+++ b/src/main/kotlin/com/pluxity/weekly/project/entity/Project.kt
@@ -6,10 +6,12 @@ import jakarta.persistence.Entity
 import jakarta.persistence.EnumType
 import jakarta.persistence.Enumerated
 import jakarta.persistence.Table
+import org.hibernate.annotations.SoftDelete
 import java.time.LocalDate
 
 @Entity
 @Table(name = "projects")
+@SoftDelete(columnName = "deleted")
 class Project(
     @Column(name = "name", nullable = false)
     var name: String,

--- a/src/main/kotlin/com/pluxity/weekly/project/repository/ProjectCustomRepositoryImpl.kt
+++ b/src/main/kotlin/com/pluxity/weekly/project/repository/ProjectCustomRepositoryImpl.kt
@@ -4,6 +4,7 @@ import com.linecorp.kotlinjdsl.support.spring.data.jpa.repository.KotlinJdslJpql
 import com.pluxity.weekly.chat.dto.ProjectSearchFilter
 import com.pluxity.weekly.core.utils.findAllNotNull
 import com.pluxity.weekly.project.entity.Project
+import com.pluxity.weekly.project.entity.ProjectStatus
 
 class ProjectCustomRepositoryImpl(
     private val executor: KotlinJdslJpqlExecutor,
@@ -19,6 +20,13 @@ class ProjectCustomRepositoryImpl(
                     filter.dueDateFrom?.let { path(Project::dueDate).greaterThanOrEqualTo(it) },
                     filter.dueDateTo?.let { path(Project::dueDate).lessThanOrEqualTo(it) },
                     filter.projectIds?.let { path(Project::id).`in`(it) },
+                    if (filter.excludeDone) path(Project::status).notEqual(ProjectStatus.DONE) else null,
+                    filter.scopeStartDate?.let {
+                        or(
+                            path(Project::startDate).greaterThanOrEqualTo(it),
+                            path(Project::status).notEqual(ProjectStatus.DONE),
+                        )
+                    },
                 )
         }
 }

--- a/src/main/kotlin/com/pluxity/weekly/project/service/ProjectService.kt
+++ b/src/main/kotlin/com/pluxity/weekly/project/service/ProjectService.kt
@@ -103,6 +103,9 @@ class ProjectService(
     fun delete(id: Long) {
         val user = authorizationService.currentUser()
         authorizationService.requireProjectManager(user, id)
+        if (epicRepository.existsByProjectId(id)) {
+            throw CustomException(ErrorCode.PROJECT_HAS_EPICS)
+        }
         projectRepository.delete(getById(id))
     }
 

--- a/src/main/kotlin/com/pluxity/weekly/task/entity/Task.kt
+++ b/src/main/kotlin/com/pluxity/weekly/task/entity/Task.kt
@@ -11,10 +11,12 @@ import jakarta.persistence.FetchType
 import jakarta.persistence.JoinColumn
 import jakarta.persistence.ManyToOne
 import jakarta.persistence.Table
+import org.hibernate.annotations.SoftDelete
 import java.time.LocalDate
 
 @Entity
 @Table(name = "tasks")
+@SoftDelete(columnName = "deleted")
 class Task(
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "epic_id", nullable = false)

--- a/src/main/kotlin/com/pluxity/weekly/task/repository/TaskCustomRepositoryImpl.kt
+++ b/src/main/kotlin/com/pluxity/weekly/task/repository/TaskCustomRepositoryImpl.kt
@@ -7,6 +7,7 @@ import com.pluxity.weekly.core.utils.findAllNotNull
 import com.pluxity.weekly.epic.entity.Epic
 import com.pluxity.weekly.project.entity.Project
 import com.pluxity.weekly.task.entity.Task
+import com.pluxity.weekly.task.entity.TaskStatus
 
 class TaskCustomRepositoryImpl(
     private val executor: KotlinJdslJpqlExecutor,
@@ -24,6 +25,13 @@ class TaskCustomRepositoryImpl(
                     filter.dueDateFrom?.let { path(Task::dueDate).greaterThanOrEqualTo(it) },
                     filter.dueDateTo?.let { path(Task::dueDate).lessThanOrEqualTo(it) },
                     filter.epicIds?.let { path(Task::epic)(Epic::id).`in`(it) },
+                    if (filter.excludeDone) path(Task::status).notEqual(TaskStatus.DONE) else null,
+                    filter.scopeStartDate?.let {
+                        or(
+                            path(Task::startDate).greaterThanOrEqualTo(it),
+                            path(Task::status).notEqual(TaskStatus.DONE),
+                        )
+                    },
                 )
         }
 }

--- a/src/main/kotlin/com/pluxity/weekly/task/repository/TaskRepository.kt
+++ b/src/main/kotlin/com/pluxity/weekly/task/repository/TaskRepository.kt
@@ -30,4 +30,6 @@ interface TaskRepository :
         status: TaskStatus,
         projectIds: List<Long>,
     ): List<Task>
+
+    fun deleteByEpicIdAndAssigneeId(epicId: Long, assigneeId: Long)
 }

--- a/src/main/kotlin/com/pluxity/weekly/task/repository/TaskRepository.kt
+++ b/src/main/kotlin/com/pluxity/weekly/task/repository/TaskRepository.kt
@@ -31,5 +31,8 @@ interface TaskRepository :
         projectIds: List<Long>,
     ): List<Task>
 
-    fun deleteByEpicIdAndAssigneeId(epicId: Long, assigneeId: Long)
+    fun deleteByEpicIdAndAssigneeId(
+        epicId: Long,
+        assigneeId: Long,
+    )
 }

--- a/src/main/kotlin/com/pluxity/weekly/task/repository/TaskRepository.kt
+++ b/src/main/kotlin/com/pluxity/weekly/task/repository/TaskRepository.kt
@@ -14,6 +14,8 @@ interface TaskRepository :
         name: String,
     ): Boolean
 
+    fun existsByEpicId(epicId: Long): Boolean
+
     fun findByAssigneeId(assigneeId: Long): List<Task>
 
     fun findByAssigneeIdIn(assigneeIds: List<Long>): List<Task>

--- a/src/main/resources/db/migration/V20260414_001__add_soft_delete_columns.sql
+++ b/src/main/resources/db/migration/V20260414_001__add_soft_delete_columns.sql
@@ -1,0 +1,6 @@
+-- Project, Epic, Task 엔티티에 @SoftDelete 적용을 위한 deleted 컬럼 추가
+-- Hibernate @SoftDelete(columnName = "deleted") 기본값은 false
+
+ALTER TABLE projects ADD COLUMN deleted BOOLEAN NOT NULL DEFAULT FALSE;
+ALTER TABLE epics ADD COLUMN deleted BOOLEAN NOT NULL DEFAULT FALSE;
+ALTER TABLE tasks ADD COLUMN deleted BOOLEAN NOT NULL DEFAULT FALSE;

--- a/src/test/kotlin/com/pluxity/weekly/dashboard/service/DashboardServiceTest.kt
+++ b/src/test/kotlin/com/pluxity/weekly/dashboard/service/DashboardServiceTest.kt
@@ -465,7 +465,10 @@ class DashboardServiceTest :
                 val result = service.getWorkerDashboard()
 
                 Then("requestDate는 오늘 날짜이다") {
-                    result.epics[0].tasks[0].requestDate.toLocalDate() shouldBe LocalDate.now()
+                    result.epics[0]
+                        .tasks[0]
+                        .requestDate
+                        .toLocalDate() shouldBe LocalDate.now()
                 }
             }
         }
@@ -481,7 +484,8 @@ class DashboardServiceTest :
                     project = project,
                     status = EpicStatus.IN_PROGRESS,
                 )
-            org.springframework.test.util.ReflectionTestUtils.setField(epic, "updatedAt", epicUpdatedAt)
+            org.springframework.test.util.ReflectionTestUtils
+                .setField(epic, "updatedAt", epicUpdatedAt)
 
             When("대시보드를 조회하면") {
                 every { authorizationService.currentUser() } returns currentUser

--- a/src/test/kotlin/com/pluxity/weekly/epic/service/EpicServiceTest.kt
+++ b/src/test/kotlin/com/pluxity/weekly/epic/service/EpicServiceTest.kt
@@ -181,6 +181,7 @@ class EpicServiceTest :
                 val entity = dummyEpic(id = 1L, name = "삭제대상 에픽")
 
                 every { epicRepository.findByIdOrNull(1L) } returns entity
+                every { taskRepository.existsByEpicId(1L) } returns false
                 every { epicRepository.delete(any<Epic>()) } just runs
 
                 service.delete(1L)
@@ -200,6 +201,22 @@ class EpicServiceTest :
 
                 Then("NOT_FOUND 예외가 발생한다") {
                     exception.code shouldBe ErrorCode.NOT_FOUND_EPIC
+                }
+            }
+
+            When("하위 태스크가 존재하면") {
+                val entity = dummyEpic(id = 1L, name = "삭제대상 에픽")
+
+                every { epicRepository.findByIdOrNull(1L) } returns entity
+                every { taskRepository.existsByEpicId(1L) } returns true
+
+                val exception =
+                    shouldThrow<CustomException> {
+                        service.delete(1L)
+                    }
+
+                Then("EPIC_HAS_TASKS 예외가 발생한다.") {
+                    exception.code shouldBe ErrorCode.EPIC_HAS_TASKS
                 }
             }
         }

--- a/src/test/kotlin/com/pluxity/weekly/epic/service/EpicServiceTest.kt
+++ b/src/test/kotlin/com/pluxity/weekly/epic/service/EpicServiceTest.kt
@@ -237,6 +237,7 @@ class EpicServiceTest :
 
                 every { epicRepository.findByIdOrNull(1L) } returns epic
                 every { userRepository.findByIdOrNull(10L) } returns user
+                every { taskRepository.deleteByEpicIdAndAssigneeId(1L, 10L) } just runs
                 every { eventPublisher.publishEvent(event) } just runs
 
                 service.unassign(1L, 10L)

--- a/src/test/kotlin/com/pluxity/weekly/project/service/ProjectServiceTest.kt
+++ b/src/test/kotlin/com/pluxity/weekly/project/service/ProjectServiceTest.kt
@@ -171,6 +171,7 @@ class ProjectServiceTest :
             When("존재하는 프로젝트를 삭제하면") {
                 val entity = dummyProject(id = 1L, name = "삭제대상 프로젝트")
 
+                every { epicRepository.existsByProjectId(1L) } returns false
                 every { projectRepository.findByIdOrNull(1L) } returns entity
                 every { projectRepository.delete(any<Project>()) } just runs
 
@@ -182,6 +183,8 @@ class ProjectServiceTest :
             }
 
             When("존재하지 않는 프로젝트를 삭제하면") {
+
+                every { epicRepository.existsByProjectId(999L) } returns false
                 every { projectRepository.findByIdOrNull(999L) } returns null
 
                 val exception =
@@ -191,6 +194,19 @@ class ProjectServiceTest :
 
                 Then("NOT_FOUND 예외가 발생한다") {
                     exception.code shouldBe ErrorCode.NOT_FOUND_PROJECT
+                }
+            }
+
+            When("하위 에픽이 존재하면") {
+                every { epicRepository.existsByProjectId(1L) } returns true
+
+                val exception =
+                    shouldThrow<CustomException> {
+                        service.delete(1L)
+                    }
+
+                Then("PROJECT_HAS_EPICS 예외가 발생한다") {
+                    exception.code shouldBe ErrorCode.PROJECT_HAS_EPICS
                 }
             }
         }


### PR DESCRIPTION
## 요약 
- Project, Epic, Task에 `@SoftDelete` 적용 (Flyway 마이그레이션 포함)
- 에픽 해제 시 해당 사용자의 태스크도 함께 삭제
- 채팅 컨텍스트 scope 필터링을 메모리에서 쿼리 레벨로 이동