### PR TITLE
refactor: chat 모듈 타입 안전성 개선 및 N+1 제거

### DIFF
--- a/src/main/kotlin/com/pluxity/weekly/auth/user/repository/UserRepository.kt
+++ b/src/main/kotlin/com/pluxity/weekly/auth/user/repository/UserRepository.kt
@@ -4,6 +4,7 @@ import com.pluxity.weekly.auth.user.entity.User
 import org.springframework.data.domain.Sort
 import org.springframework.data.jpa.repository.EntityGraph
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
 
 interface UserRepository : JpaRepository<User, Long> {
     @EntityGraph(
@@ -40,12 +41,12 @@ interface UserRepository : JpaRepository<User, Long> {
             "userRoles", "userRoles.role",
         ],
     )
-    fun findByName(name: String): User?
-
-    @EntityGraph(
-        attributePaths = [
-            "userRoles", "userRoles.role",
-        ],
-    )
     fun findByAadObjectId(aadObjectId: String): User?
+
+    @Query(
+        "SELECT DISTINCT u FROM User u JOIN u.userRoles ur " +
+            "WHERE UPPER(ur.role.name) = UPPER(:roleName) " +
+            "ORDER BY u.name",
+    )
+    fun findAllByRoleName(roleName: String): List<User>
 }

--- a/src/main/kotlin/com/pluxity/weekly/chat/context/ChatContext.kt
+++ b/src/main/kotlin/com/pluxity/weekly/chat/context/ChatContext.kt
@@ -52,18 +52,48 @@ data class TeamContext(
     val users: List<UserRef>,
 ) : ChatContext()
 
-data class UserRef(val id: Long, val name: String)
+data class UserRef(
+    val id: Long,
+    val name: String,
+)
 
-data class TeamRef(val id: Long, val name: String)
+data class TeamRef(
+    val id: Long,
+    val name: String,
+)
 
-data class ProjectSimple(val id: Long, val name: String, val status: String)
+data class ProjectSimple(
+    val id: Long,
+    val name: String,
+    val status: String,
+)
 
-data class EpicRef(val id: Long, val name: String)
+data class EpicRef(
+    val id: Long,
+    val name: String,
+)
 
-data class ProjectWithEpics(val id: Long, val name: String, val epics: List<EpicRef>)
+data class ProjectWithEpics(
+    val id: Long,
+    val name: String,
+    val epics: List<EpicRef>,
+)
 
-data class TaskRef(val id: Long, val name: String, val status: String, val progress: Int)
+data class TaskRef(
+    val id: Long,
+    val name: String,
+    val status: String,
+    val progress: Int,
+)
 
-data class EpicWithTasks(val id: Long, val name: String, val tasks: List<TaskRef>)
+data class EpicWithTasks(
+    val id: Long,
+    val name: String,
+    val tasks: List<TaskRef>,
+)
 
-data class ProjectWithEpicsAndTasks(val id: Long, val name: String, val epics: List<EpicWithTasks>)
+data class ProjectWithEpicsAndTasks(
+    val id: Long,
+    val name: String,
+    val epics: List<EpicWithTasks>,
+)

--- a/src/main/kotlin/com/pluxity/weekly/chat/context/ChatContext.kt
+++ b/src/main/kotlin/com/pluxity/weekly/chat/context/ChatContext.kt
@@ -1,0 +1,69 @@
+package com.pluxity.weekly.chat.context
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import com.fasterxml.jackson.annotation.JsonPropertyOrder
+
+@JsonPropertyOrder("today", "today_day_of_week", "user", "projects", "teams", "users")
+sealed class ChatContext {
+    abstract val today: String
+
+    @get:JsonProperty("today_day_of_week")
+    abstract val todayDayOfWeek: String
+
+    abstract val user: UserRef
+}
+
+data class ProjectContext(
+    override val today: String,
+    override val todayDayOfWeek: String,
+    override val user: UserRef,
+    val projects: List<ProjectSimple>,
+    val users: List<UserRef>,
+) : ChatContext()
+
+data class EpicContext(
+    override val today: String,
+    override val todayDayOfWeek: String,
+    override val user: UserRef,
+    val projects: List<ProjectWithEpics>,
+    val users: List<UserRef>,
+) : ChatContext()
+
+data class TaskCreateContext(
+    override val today: String,
+    override val todayDayOfWeek: String,
+    override val user: UserRef,
+    val projects: List<ProjectWithEpics>,
+) : ChatContext()
+
+data class TaskContext(
+    override val today: String,
+    override val todayDayOfWeek: String,
+    override val user: UserRef,
+    val projects: List<ProjectWithEpicsAndTasks>,
+    val users: List<UserRef>,
+) : ChatContext()
+
+data class TeamContext(
+    override val today: String,
+    override val todayDayOfWeek: String,
+    override val user: UserRef,
+    val teams: List<TeamRef>,
+    val users: List<UserRef>,
+) : ChatContext()
+
+data class UserRef(val id: Long, val name: String)
+
+data class TeamRef(val id: Long, val name: String)
+
+data class ProjectSimple(val id: Long, val name: String, val status: String)
+
+data class EpicRef(val id: Long, val name: String)
+
+data class ProjectWithEpics(val id: Long, val name: String, val epics: List<EpicRef>)
+
+data class TaskRef(val id: Long, val name: String, val status: String, val progress: Int)
+
+data class EpicWithTasks(val id: Long, val name: String, val tasks: List<TaskRef>)
+
+data class ProjectWithEpicsAndTasks(val id: Long, val name: String, val epics: List<EpicWithTasks>)

--- a/src/main/kotlin/com/pluxity/weekly/chat/context/ContextBuilder.kt
+++ b/src/main/kotlin/com/pluxity/weekly/chat/context/ContextBuilder.kt
@@ -130,11 +130,9 @@ class ContextBuilder(
         user: UserRef,
         createOnly: Boolean,
         excludeDone: Boolean,
-    ): ChatContext {
-        val epics = epicService.findAll()
-
-        return if (createOnly) {
-            val activeEpics = epics.filter { it.status != EpicStatus.DONE }
+    ): ChatContext =
+        if (createOnly) {
+            val activeEpics = epicService.findAll().filter { it.status != EpicStatus.DONE }
             TaskCreateContext(
                 today = today,
                 todayDayOfWeek = todayDayOfWeek,
@@ -150,7 +148,12 @@ class ContextBuilder(
                     ),
                 )
             val tasksByEpicId = tasks.groupBy { it.epicId }
-            val activeEpics = epics.filter { tasksByEpicId.containsKey(it.id) }
+            val activeEpics =
+                if (tasksByEpicId.isEmpty()) {
+                    emptyList()
+                } else {
+                    epicService.search(EpicSearchFilter(epicIds = tasksByEpicId.keys.toList()))
+                }
             TaskContext(
                 today = today,
                 todayDayOfWeek = todayDayOfWeek,
@@ -159,7 +162,6 @@ class ContextBuilder(
                 users = findAllUsers(),
             )
         }
-    }
 
     private fun buildTeamContext(
         today: String,

--- a/src/main/kotlin/com/pluxity/weekly/chat/context/ContextBuilder.kt
+++ b/src/main/kotlin/com/pluxity/weekly/chat/context/ContextBuilder.kt
@@ -1,5 +1,6 @@
 package com.pluxity.weekly.chat.context
 
+import com.pluxity.weekly.auth.user.entity.User
 import com.pluxity.weekly.auth.user.repository.UserRepository
 import com.pluxity.weekly.authorization.AuthorizationService
 import com.pluxity.weekly.chat.dto.EpicSearchFilter
@@ -18,6 +19,8 @@ import org.springframework.stereotype.Component
 import org.springframework.transaction.annotation.Transactional
 import tools.jackson.databind.ObjectMapper
 import java.time.LocalDate
+import java.time.format.TextStyle
+import java.util.Locale
 
 /**
  * target별 CONTEXT 포함 데이터
@@ -27,7 +30,6 @@ import java.time.LocalDate
  * task    → create: projects > epics / 그 외: projects > epics > tasks
  * team    → teams + users(전체)
  *
- * users는 항상 포함 (read에서도 이름→ID 매칭 필요)
  * 조회 범위는 Service.search()에서 AuthorizationService 기반으로 제한
  */
 @Component
@@ -49,48 +51,53 @@ class ContextBuilder(
 
         authorizationService.checkChatPermission(user, target, actions)
 
-        val context =
-            mutableMapOf<String, Any?>(
-                "today" to LocalDate.now().toString(),
-                "today_day_of_week" to LocalDate.now().dayOfWeek.getDisplayName(java.time.format.TextStyle.FULL, java.util.Locale.KOREAN),
-                "user" to mapOf("id" to user.requiredId, "name" to user.name),
-            )
+        val today = LocalDate.now().toString()
+        val todayDayOfWeek = LocalDate.now().dayOfWeek.getDisplayName(TextStyle.FULL, Locale.KOREAN)
+        val userRef = UserRef(id = user.requiredId, name = user.name)
 
         val hasCreateOnly = "create" in actions && "update" !in actions
         val excludeDone = "update" in actions || "delete" in actions
 
-        when (target) {
-            "project" -> buildProjectContext(context, excludeDone)
-            "epic" -> buildEpicContext(context, excludeDone)
-            "team" -> buildTeamContext(context)
-            else -> buildTaskContext(context, hasCreateOnly, excludeDone)
-        }
+        val context: ChatContext =
+            when (target) {
+                "project" -> buildProjectContext(today, todayDayOfWeek, userRef, excludeDone)
+                "epic" -> buildEpicContext(today, todayDayOfWeek, userRef, excludeDone)
+                "team" -> buildTeamContext(today, todayDayOfWeek, userRef)
+                else -> buildTaskContext(today, todayDayOfWeek, userRef, hasCreateOnly, excludeDone)
+            }
 
         return objectMapper.writeValueAsString(context)
     }
 
     private fun buildProjectContext(
-        context: MutableMap<String, Any?>,
+        today: String,
+        todayDayOfWeek: String,
+        user: UserRef,
         excludeDone: Boolean,
-    ) {
+    ): ProjectContext {
         val projects =
-            projectService.search(
-                ProjectSearchFilter(
-                    excludeDone = excludeDone,
-                    scopeStartDate = ChatScope.scopeStartDate(),
-                ),
-            )
-        context["projects"] =
-            projects.map {
-                mapOf("id" to it.id, "name" to it.name, "status" to it.status.name)
-            }
-        context["users"] = findUsersByRole("PM")
+            projectService
+                .search(
+                    ProjectSearchFilter(
+                        excludeDone = excludeDone,
+                        scopeStartDate = ChatScope.scopeStartDate(),
+                    ),
+                ).map { ProjectSimple(id = it.id, name = it.name, status = it.status.name) }
+        return ProjectContext(
+            today = today,
+            todayDayOfWeek = todayDayOfWeek,
+            user = user,
+            projects = projects,
+            users = findUsersByRole("PM"),
+        )
     }
 
     private fun buildEpicContext(
-        context: MutableMap<String, Any?>,
+        today: String,
+        todayDayOfWeek: String,
+        user: UserRef,
         excludeDone: Boolean,
-    ) {
+    ): EpicContext {
         val projects = projectService.findAll()
         val epics =
             epicService.search(
@@ -100,31 +107,40 @@ class ContextBuilder(
                 ),
             )
         val epicsByProject = epics.groupBy { it.projectId }
-        context["projects"] =
-            projects
-                .map { project ->
-                    mapOf(
-                        "id" to project.id,
-                        "name" to project.name,
-                        "epics" to
-                            (epicsByProject[project.id] ?: emptyList()).map {
-                                mapOf("id" to it.id, "name" to it.name)
-                            },
-                    )
-                }
-        context["users"] = findAllUsers()
+        val projectList =
+            projects.map { project ->
+                ProjectWithEpics(
+                    id = project.id,
+                    name = project.name,
+                    epics = (epicsByProject[project.id] ?: emptyList()).map { EpicRef(id = it.id, name = it.name) },
+                )
+            }
+        return EpicContext(
+            today = today,
+            todayDayOfWeek = todayDayOfWeek,
+            user = user,
+            projects = projectList,
+            users = findAllUsers(),
+        )
     }
 
     private fun buildTaskContext(
-        context: MutableMap<String, Any?>,
+        today: String,
+        todayDayOfWeek: String,
+        user: UserRef,
         createOnly: Boolean,
         excludeDone: Boolean,
-    ) {
+    ): ChatContext {
         val epics = epicService.findAll()
 
-        if (createOnly) {
+        return if (createOnly) {
             val activeEpics = epics.filter { it.status != EpicStatus.DONE }
-            context["projects"] = groupByProject(activeEpics)
+            TaskCreateContext(
+                today = today,
+                todayDayOfWeek = todayDayOfWeek,
+                user = user,
+                projects = groupByProject(activeEpics),
+            )
         } else {
             val tasks =
                 taskService.search(
@@ -135,49 +151,62 @@ class ContextBuilder(
                 )
             val tasksByEpicId = tasks.groupBy { it.epicId }
             val activeEpics = epics.filter { tasksByEpicId.containsKey(it.id) }
-            context["projects"] = groupByProjectFull(activeEpics, tasksByEpicId)
-            context["users"] = findAllUsers()
+            TaskContext(
+                today = today,
+                todayDayOfWeek = todayDayOfWeek,
+                user = user,
+                projects = groupByProjectFull(activeEpics, tasksByEpicId),
+                users = findAllUsers(),
+            )
         }
     }
 
-    private fun buildTeamContext(context: MutableMap<String, Any?>) {
-        context["teams"] = teamService.findAll().map { mapOf("id" to it.id, "name" to it.name) }
-        context["users"] = findAllUsers()
-    }
+    private fun buildTeamContext(
+        today: String,
+        todayDayOfWeek: String,
+        user: UserRef,
+    ): TeamContext =
+        TeamContext(
+            today = today,
+            todayDayOfWeek = todayDayOfWeek,
+            user = user,
+            teams = teamService.findAll().map { TeamRef(id = it.id, name = it.name) },
+            users = findAllUsers(),
+        )
 
-    private fun groupByProject(epics: List<EpicResponse>): List<Map<String, Any?>> =
+    private fun groupByProject(epics: List<EpicResponse>): List<ProjectWithEpics> =
         epics
             .groupBy { it.projectId to it.projectName }
             .map { (key, epics) ->
-                mapOf(
-                    "id" to key.first,
-                    "name" to key.second,
-                    "epics" to epics.map { mapOf("id" to it.id, "name" to it.name) },
+                ProjectWithEpics(
+                    id = key.first,
+                    name = key.second,
+                    epics = epics.map { EpicRef(id = it.id, name = it.name) },
                 )
             }
 
     private fun groupByProjectFull(
         epics: List<EpicResponse>,
         tasksByEpicId: Map<Long, List<TaskResponse>>,
-    ): List<Map<String, Any?>> =
+    ): List<ProjectWithEpicsAndTasks> =
         epics
             .groupBy { it.projectId to it.projectName }
             .map { (key, epics) ->
-                mapOf(
-                    "id" to key.first,
-                    "name" to key.second,
-                    "epics" to
+                ProjectWithEpicsAndTasks(
+                    id = key.first,
+                    name = key.second,
+                    epics =
                         epics.map { epic ->
-                            mapOf(
-                                "id" to epic.id,
-                                "name" to epic.name,
-                                "tasks" to
+                            EpicWithTasks(
+                                id = epic.id,
+                                name = epic.name,
+                                tasks =
                                     (tasksByEpicId[epic.id] ?: emptyList()).map { task ->
-                                        mapOf(
-                                            "id" to task.id,
-                                            "name" to task.name,
-                                            "status" to task.status,
-                                            "progress" to task.progress,
+                                        TaskRef(
+                                            id = task.id,
+                                            name = task.name,
+                                            status = task.status.name,
+                                            progress = task.progress,
                                         )
                                     },
                             )
@@ -185,14 +214,16 @@ class ContextBuilder(
                 )
             }
 
-    private fun findUsersByRole(roleName: String): List<Map<String, Any?>> =
+    private fun findUsersByRole(roleName: String): List<UserRef> =
         userRepository
             .findAllBy(Sort.by("name"))
             .filter { user -> user.userRoles.any { it.role.name.uppercase() == roleName } }
-            .map { mapOf("id" to it.requiredId, "name" to it.name) }
+            .map { it.toRef() }
 
-    private fun findAllUsers(): List<Map<String, Any?>> =
+    private fun findAllUsers(): List<UserRef> =
         userRepository
             .findAllBy(Sort.by("name"))
-            .map { mapOf("id" to it.requiredId, "name" to it.name) }
+            .map { it.toRef() }
+
+    private fun User.toRef(): UserRef = UserRef(id = this.requiredId, name = this.name)
 }

--- a/src/main/kotlin/com/pluxity/weekly/chat/context/ContextBuilder.kt
+++ b/src/main/kotlin/com/pluxity/weekly/chat/context/ContextBuilder.kt
@@ -216,8 +216,7 @@ class ContextBuilder(
 
     private fun findUsersByRole(roleName: String): List<UserRef> =
         userRepository
-            .findAllBy(Sort.by("name"))
-            .filter { user -> user.userRoles.any { it.role.name.uppercase() == roleName } }
+            .findAllByRoleName(roleName)
             .map { it.toRef() }
 
     private fun findAllUsers(): List<UserRef> =

--- a/src/main/kotlin/com/pluxity/weekly/chat/dto/LlmAction.kt
+++ b/src/main/kotlin/com/pluxity/weekly/chat/dto/LlmAction.kt
@@ -28,7 +28,7 @@ data class LlmAction(
     val startDate: String? = null,
     @param:JsonProperty("due_date")
     val dueDate: String? = null,
-    val filters: Map<String, Any?>? = null,
+    val filters: LlmActionFilters? = null,
     @param:JsonProperty("user_ids")
     val userIds: List<Long>? = null,
     @param:JsonProperty("remove_user_ids")

--- a/src/main/kotlin/com/pluxity/weekly/chat/dto/LlmActionFilters.kt
+++ b/src/main/kotlin/com/pluxity/weekly/chat/dto/LlmActionFilters.kt
@@ -1,0 +1,23 @@
+package com.pluxity.weekly.chat.dto
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+import com.fasterxml.jackson.annotation.JsonProperty
+import java.time.LocalDate
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class LlmActionFilters(
+    val status: String? = null,
+    @param:JsonProperty("epic_id")
+    val epicId: Long? = null,
+    @param:JsonProperty("project_id")
+    val projectId: Long? = null,
+    @param:JsonProperty("assignee_id")
+    val assigneeId: Long? = null,
+    @param:JsonProperty("pm_id")
+    val pmId: Long? = null,
+    val name: String? = null,
+    @param:JsonProperty("due_date_from")
+    val dueDateFrom: LocalDate? = null,
+    @param:JsonProperty("due_date_to")
+    val dueDateTo: LocalDate? = null,
+)

--- a/src/main/kotlin/com/pluxity/weekly/chat/service/ChatReadHandler.kt
+++ b/src/main/kotlin/com/pluxity/weekly/chat/service/ChatReadHandler.kt
@@ -3,6 +3,7 @@ package com.pluxity.weekly.chat.service
 import com.pluxity.weekly.chat.dto.ChatReadResponse
 import com.pluxity.weekly.chat.dto.EpicSearchFilter
 import com.pluxity.weekly.chat.dto.LlmAction
+import com.pluxity.weekly.chat.dto.LlmActionFilters
 import com.pluxity.weekly.chat.dto.ProjectSearchFilter
 import com.pluxity.weekly.chat.dto.TaskSearchFilter
 import com.pluxity.weekly.chat.dto.TeamSearchFilter
@@ -14,7 +15,6 @@ import com.pluxity.weekly.task.entity.TaskStatus
 import com.pluxity.weekly.task.service.TaskService
 import com.pluxity.weekly.team.service.TeamService
 import org.springframework.stereotype.Component
-import java.time.LocalDate
 
 @Component
 class ChatReadHandler(
@@ -25,25 +25,19 @@ class ChatReadHandler(
 ) {
     fun handle(action: LlmAction): ChatReadResponse {
         val target = action.target ?: "task"
-        val filters = action.filters ?: emptyMap()
+        val filters = action.filters
         return when (target) {
             "task" ->
                 ChatReadResponse(
-                    tasks =
-                        taskService
-                            .search(buildTaskFilter(filters, action.id)),
+                    tasks = taskService.search(buildTaskFilter(filters, action.id)),
                 )
             "project" ->
                 ChatReadResponse(
-                    projects =
-                        projectService
-                            .search(buildProjectFilter(filters, action.id)),
+                    projects = projectService.search(buildProjectFilter(filters, action.id)),
                 )
             "epic" ->
                 ChatReadResponse(
-                    epics =
-                        epicService
-                            .search(buildEpicFilter(filters, action.id)),
+                    epics = epicService.search(buildEpicFilter(filters, action.id)),
                 )
             "team" ->
                 ChatReadResponse(
@@ -55,57 +49,55 @@ class ChatReadHandler(
                 )
             else ->
                 ChatReadResponse(
-                    tasks =
-                        taskService
-                            .search(buildTaskFilter(filters, action.id)),
+                    tasks = taskService.search(buildTaskFilter(filters, action.id)),
                 )
         }
     }
 
     private fun buildTaskFilter(
-        filters: Map<String, Any?>,
+        filters: LlmActionFilters?,
         id: Long? = null,
     ): TaskSearchFilter =
         TaskSearchFilter(
             taskId = id,
-            status = (filters["status"] as? String)?.let { TaskStatus.valueOf(it) },
-            epicId = (filters["epic_id"] as? Number)?.toLong(),
-            projectId = (filters["project_id"] as? Number)?.toLong(),
-            assigneeId = (filters["assignee_id"] as? Number)?.toLong(),
-            name = filters["name"] as? String,
-            dueDateFrom = (filters["due_date_from"] as? String)?.let { LocalDate.parse(it) },
-            dueDateTo = (filters["due_date_to"] as? String)?.let { LocalDate.parse(it) },
+            status = filters?.status?.let(TaskStatus::valueOf),
+            epicId = filters?.epicId,
+            projectId = filters?.projectId,
+            assigneeId = filters?.assigneeId,
+            name = filters?.name,
+            dueDateFrom = filters?.dueDateFrom,
+            dueDateTo = filters?.dueDateTo,
         )
 
     private fun buildProjectFilter(
-        filters: Map<String, Any?>,
+        filters: LlmActionFilters?,
         id: Long? = null,
     ): ProjectSearchFilter =
         ProjectSearchFilter(
             projectIds = id?.let { listOf(it) },
-            status = (filters["status"] as? String)?.let { ProjectStatus.valueOf(it) },
-            name = filters["name"] as? String,
-            pmId = (filters["pm_id"] as? Number)?.toLong(),
-            dueDateFrom = (filters["due_date_from"] as? String)?.let { LocalDate.parse(it) },
-            dueDateTo = (filters["due_date_to"] as? String)?.let { LocalDate.parse(it) },
+            status = filters?.status?.let(ProjectStatus::valueOf),
+            name = filters?.name,
+            pmId = filters?.pmId,
+            dueDateFrom = filters?.dueDateFrom,
+            dueDateTo = filters?.dueDateTo,
         )
 
     private fun buildEpicFilter(
-        filters: Map<String, Any?>,
+        filters: LlmActionFilters?,
         id: Long? = null,
     ): EpicSearchFilter =
         EpicSearchFilter(
             epicIds = id?.let { listOf(it) },
-            status = (filters["status"] as? String)?.let { EpicStatus.valueOf(it) },
-            name = filters["name"] as? String,
-            projectId = (filters["project_id"] as? Number)?.toLong(),
-            assigneeId = (filters["assignee_id"] as? Number)?.toLong(),
-            dueDateFrom = (filters["due_date_from"] as? String)?.let { LocalDate.parse(it) },
-            dueDateTo = (filters["due_date_to"] as? String)?.let { LocalDate.parse(it) },
+            status = filters?.status?.let(EpicStatus::valueOf),
+            name = filters?.name,
+            projectId = filters?.projectId,
+            assigneeId = filters?.assigneeId,
+            dueDateFrom = filters?.dueDateFrom,
+            dueDateTo = filters?.dueDateTo,
         )
 
-    private fun buildTeamFilter(filters: Map<String, Any?>): TeamSearchFilter =
+    private fun buildTeamFilter(filters: LlmActionFilters?): TeamSearchFilter =
         TeamSearchFilter(
-            name = filters["name"] as? String,
+            name = filters?.name,
         )
 }

--- a/src/main/kotlin/com/pluxity/weekly/chat/service/ChatReadHandler.kt
+++ b/src/main/kotlin/com/pluxity/weekly/chat/service/ChatReadHandler.kt
@@ -60,7 +60,7 @@ class ChatReadHandler(
     ): TaskSearchFilter =
         TaskSearchFilter(
             taskId = id,
-            status = filters?.status?.let(TaskStatus::valueOf),
+            status = filters?.status?.let { s -> TaskStatus.entries.find { it.name.equals(s, ignoreCase = true) } },
             epicId = filters?.epicId,
             projectId = filters?.projectId,
             assigneeId = filters?.assigneeId,
@@ -75,7 +75,7 @@ class ChatReadHandler(
     ): ProjectSearchFilter =
         ProjectSearchFilter(
             projectIds = id?.let { listOf(it) },
-            status = filters?.status?.let(ProjectStatus::valueOf),
+            status = filters?.status?.let { s -> ProjectStatus.entries.find { it.name.equals(s, ignoreCase = true) } },
             name = filters?.name,
             pmId = filters?.pmId,
             dueDateFrom = filters?.dueDateFrom,
@@ -88,7 +88,7 @@ class ChatReadHandler(
     ): EpicSearchFilter =
         EpicSearchFilter(
             epicIds = id?.let { listOf(it) },
-            status = filters?.status?.let(EpicStatus::valueOf),
+            status = filters?.status?.let { s -> EpicStatus.entries.find { it.name.equals(s, ignoreCase = true) } },
             name = filters?.name,
             projectId = filters?.projectId,
             assigneeId = filters?.assigneeId,

--- a/src/main/kotlin/com/pluxity/weekly/chat/service/SelectFieldResolver.kt
+++ b/src/main/kotlin/com/pluxity/weekly/chat/service/SelectFieldResolver.kt
@@ -10,7 +10,6 @@ import com.pluxity.weekly.project.repository.ProjectRepository
 import com.pluxity.weekly.project.service.ProjectService
 import com.pluxity.weekly.task.repository.TaskRepository
 import org.springframework.data.domain.Sort
-import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Component
 
 @Component
@@ -25,18 +24,10 @@ class SelectFieldResolver(
     fun resolve(action: LlmAction): List<SelectField> {
         val missingFields = action.missingFields ?: emptyList()
         val candidateIds = action.candidates ?: emptyList()
-        val result = mutableListOf<SelectField>()
-
-        for (field in missingFields) {
-            val selectField =
-                when (field) {
-                    "id" -> resolveIdCandidates(action.target, candidateIds)
-                    "project_id" -> resolveProjectCandidates(candidateIds)
-                    "epic_id" -> resolveEpicCandidates(candidateIds)
-                    else -> null
-                }
-            if (selectField != null) result.add(selectField)
-        }
+        val result =
+            missingFields
+                .mapNotNull { dispatch(it, action.target, candidateIds) }
+                .toMutableList()
 
         addSelectFields(action, result)
 
@@ -47,12 +38,18 @@ class SelectFieldResolver(
         field: String,
         target: String?,
         candidateIds: List<Long>,
-    ): List<String> =
+    ): List<String> = dispatch(field, target, candidateIds)?.candidates?.map { it.name } ?: emptyList()
+
+    private fun dispatch(
+        field: String,
+        target: String?,
+        candidateIds: List<Long>,
+    ): SelectField? =
         when (field) {
-            "id" -> resolveIdCandidates(target, candidateIds)?.candidates?.map { it.name } ?: emptyList()
-            "project_id" -> resolveProjectCandidates(candidateIds)?.candidates?.map { it.name } ?: emptyList()
-            "epic_id" -> resolveEpicCandidates(candidateIds)?.candidates?.map { it.name } ?: emptyList()
-            else -> emptyList()
+            "id" -> resolveIdCandidates(target, candidateIds)
+            "project_id" -> resolveProjectCandidates(candidateIds)
+            "epic_id" -> resolveEpicCandidates(candidateIds)
+            else -> null
         }
 
     private fun resolveIdCandidates(
@@ -63,24 +60,15 @@ class SelectFieldResolver(
         val candidates =
             when (target) {
                 "task" ->
-                    candidateIds.mapNotNull { id ->
-                        taskRepository.findByIdOrNull(id)?.let { task ->
-                            val epic = epicRepository.findByIdOrNull(task.epic.id!!)
-                            val project = epic?.let { projectRepository.findByIdOrNull(it.project.id!!) }
-                            Candidate(id.toString(), "${task.name} (${project?.name ?: ""}/${epic?.name ?: ""})")
-                        }
+                    taskRepository.findAllWithEpicAndProjectByIdIn(candidateIds).map { task ->
+                        Candidate(task.requiredId.toString(), "${task.name} (${task.epic.project.name}/${task.epic.name})")
                     }
                 "epic" ->
-                    candidateIds.mapNotNull { id ->
-                        epicRepository.findByIdOrNull(id)?.let { epic ->
-                            val project = projectRepository.findByIdOrNull(epic.project.id!!)
-                            Candidate(id.toString(), "${epic.name} (${project?.name ?: ""})")
-                        }
+                    epicRepository.findAllWithProjectByIdIn(candidateIds).map { epic ->
+                        Candidate(epic.requiredId.toString(), "${epic.name} (${epic.project.name})")
                     }
                 "project" ->
-                    candidateIds.mapNotNull { id ->
-                        projectRepository.findByIdOrNull(id)?.let { Candidate(id.toString(), it.name) }
-                    }
+                    projectRepository.findAllById(candidateIds).map { Candidate(it.requiredId.toString(), it.name) }
                 else -> return null
             }
         return SelectField(field = "id", candidates = candidates)
@@ -89,9 +77,7 @@ class SelectFieldResolver(
     private fun resolveProjectCandidates(candidateIds: List<Long>): SelectField? {
         val candidates =
             if (candidateIds.isNotEmpty()) {
-                candidateIds.mapNotNull { id ->
-                    projectRepository.findByIdOrNull(id)?.let { Candidate(id.toString(), it.name) }
-                }
+                projectRepository.findAllById(candidateIds).map { Candidate(it.requiredId.toString(), it.name) }
             } else {
                 projectService.findAll().map { Candidate(it.id.toString(), it.name) }
             }
@@ -102,11 +88,8 @@ class SelectFieldResolver(
     private fun resolveEpicCandidates(candidateIds: List<Long>): SelectField? {
         val candidates =
             if (candidateIds.isNotEmpty()) {
-                candidateIds.mapNotNull { id ->
-                    epicRepository.findByIdOrNull(id)?.let { epic ->
-                        val project = projectRepository.findByIdOrNull(epic.project.id!!)
-                        Candidate(id.toString(), "${epic.name} (${project?.name ?: ""})")
-                    }
+                epicRepository.findAllWithProjectByIdIn(candidateIds).map { epic ->
+                    Candidate(epic.requiredId.toString(), "${epic.name} (${epic.project.name})")
                 }
             } else {
                 epicService.findAll().map { Candidate(it.id.toString(), it.name) }

--- a/src/main/kotlin/com/pluxity/weekly/epic/repository/EpicRepository.kt
+++ b/src/main/kotlin/com/pluxity/weekly/epic/repository/EpicRepository.kt
@@ -1,16 +1,16 @@
 package com.pluxity.weekly.epic.repository
 
 import com.pluxity.weekly.epic.entity.Epic
+import org.springframework.data.jpa.repository.EntityGraph
 import org.springframework.data.jpa.repository.JpaRepository
-import org.springframework.data.jpa.repository.Query
 
 interface EpicRepository :
     JpaRepository<Epic, Long>,
     EpicCustomRepository {
-    fun findByAssignmentsUserId(userId: Long): List<Epic>
+    @EntityGraph(attributePaths = ["project"])
+    fun findAllWithProjectByIdIn(ids: Collection<Long>): List<Epic>
 
-    @Query("SELECT DISTINCT e FROM Epic e JOIN FETCH e.project JOIN e.assignments a WHERE a.user.id = :userId")
-    fun findByAssignmentsUserIdWithProject(userId: Long): List<Epic>
+    fun findByAssignmentsUserId(userId: Long): List<Epic>
 
     fun existsByAssignmentsUserIdAndId(
         userId: Long,

--- a/src/main/kotlin/com/pluxity/weekly/task/repository/TaskRepository.kt
+++ b/src/main/kotlin/com/pluxity/weekly/task/repository/TaskRepository.kt
@@ -24,6 +24,9 @@ interface TaskRepository :
 
     fun findByEpicId(epicId: Long): List<Task>
 
+    @EntityGraph(attributePaths = ["epic", "epic.project"])
+    fun findAllWithEpicAndProjectByIdIn(ids: Collection<Long>): List<Task>
+
     @EntityGraph(attributePaths = ["epic", "epic.project", "assignee"])
     fun findByStatus(status: TaskStatus): List<Task>
 

--- a/src/main/resources/llm/system-prompt.txt
+++ b/src/main/resources/llm/system-prompt.txt
@@ -74,7 +74,9 @@ create: id 포함 금지. 파악된 필드만 포함. FK 미확정 시 missing_f
   - name: 사용자가 구체적인 이름을 명시한 경우에만 포함. "새로운", "신규", "에픽", "태스크", "프로젝트", "팀" 등 일반적인 수식어/대상명은 이름이 아니다. 구체적 이름이 없으면 name 생략 (서버가 폼으로 처리).
 update: id 필수. 변경할 필드만 포함. 동명 항목 → missing_fields: ["id"] + candidates: [ID, ...].
   - progress: 시작→10, 절반→50, 거의 다→90, 완료→100. 명시적 퍼센트가 있으면 우선.
+  - 대상 미특정 ("태스크 수정해줘", "에픽 수정해줘" 등 이름/힌트 없음) → action은 update 유지, missing_fields:["id"] + candidates:[CONTEXT의 모든 해당 target ID]. 절대 clarify로 빠지지 말 것. 후보가 1개여도 자동 채움 금지 (사용자가 무엇을 수정할지 명시하지 않았으므로).
 delete: id 필수. 동명 항목 → missing_fields: ["id"] + candidates: [ID, ...].
+  - 대상 미특정 ("태스크 삭제해줘", "에픽 삭제해줘" 등) → action은 delete 유지, missing_fields:["id"] + candidates:[CONTEXT의 모든 해당 target ID]. 절대 clarify로 빠지지 말 것. 후보가 1개여도 자동 채움 금지.
 read: target별 filters:
   - task: status, name, epic_id, project_id, due_date_from, due_date_to, assignee_id
   - project: status, name, pm_id, due_date_from, due_date_to
@@ -225,6 +227,26 @@ Output: [{"action":"update","target":"task","id":1002,"due_date":"2026-03-20"}]
 
 [INPUT]알파 DB 설계 삭제해줘[/INPUT]
 Output: [{"action":"delete","target":"task","id":1001}]
+
+--- update without target (대상 태스크/에픽 미확정 — 후보 1개여도 missing_fields) ---
+주의: 사용자가 대상을 전혀 특정하지 않으면 후보가 1개여도 자동 채움 금지. clarify 로 우회하지 말 것.
+
+[INPUT]태스크 수정해줘[/INPUT]
+Output: [{"action":"update","target":"task","message":"어떤 태스크를 수정할까요?","missing_fields":["id"],"candidates":[1001,1002,1003,1004,1005]}]
+
+[INPUT]에픽 수정해줘[/INPUT]
+Output: [{"action":"update","target":"epic","message":"어떤 에픽을 수정할까요?","missing_fields":["id"],"candidates":[100,101,102,103]}]
+
+[INPUT]프로젝트 수정해줘[/INPUT]
+Output: [{"action":"update","target":"project","message":"어떤 프로젝트를 수정할까요?","missing_fields":["id"],"candidates":[10,11]}]
+
+--- delete without target (대상 미확정) ---
+
+[INPUT]태스크 삭제해줘[/INPUT]
+Output: [{"action":"delete","target":"task","message":"어떤 태스크를 삭제할까요?","missing_fields":["id"],"candidates":[1001,1002,1003,1004,1005]}]
+
+[INPUT]에픽 삭제해줘[/INPUT]
+Output: [{"action":"delete","target":"epic","message":"어떤 에픽을 삭제할까요?","missing_fields":["id"],"candidates":[100,101,102,103]}]
 
 --- epic create (프로젝트 지정) ---
 


### PR DESCRIPTION
## Summary

  chat 모듈의 타입 안전성, 성능, 프롬프트 안정성을 개선합니다.

  - **#19** ContextBuilder가 `Map<String, Any?>` 대신 `ChatContext` sealed class를
  반환하도록 변경. JSON 출력은 변경 전후 5개 target 모두 diff 0 (검증 완료)
  - **#20** `LlmAction.filters`를 `LlmActionFilters` data class로 타입화.
  ChatReadHandler의 캐스팅 보일러플레이트 제거
  - **#22** `SelectFieldResolver`의 resolve/resolveCandidateNames 중복 when 분기를
  dispatch 헬퍼로 통합
  - **#21** SelectFieldResolver에서 candidateIds 루프 단건 조회를 EntityGraph batch
   조회로 교체 (N+1 제거 + `!!` 모두 제거)
  - 추가: "태스크 수정해줘" 같은 대상 미특정 update/delete 입력이 clarify로 빠지던
  LLM 응답 변동 문제를 프롬프트 예제·규칙으로 보강

  Closes #19, #20, #21, #22


## Test plan

  - [x] `./gradlew compileKotlin` 빌드 성공
  - [x] ContextBuilder JSON 변경 전/후 diff (project, epic, task, task-create, team
   5개 target 모두 동일)