### PR TITLE
fix: Epic/Task update 시 부모 자원 이동 및 assignee 변경 권한 검증 추가

### DIFF
--- a/src/main/kotlin/com/pluxity/weekly/auth/authorization/AuthorizationService.kt
+++ b/src/main/kotlin/com/pluxity/weekly/auth/authorization/AuthorizationService.kt
@@ -86,12 +86,15 @@ class AuthorizationService(
         throw CustomException(ErrorCode.PERMISSION_DENIED)
     }
 
-    /** 본인 태스크(assignee)만 허용 — 태스크 수정/삭제 */
+    /** ADMIN, 해당 프로젝트 PM, 또는 본인 태스크(assignee)만 허용 — 태스크 수정/삭제 */
     fun requireTaskOwner(
         user: User,
         task: Task,
     ) {
         if (user.hasRole(UserType.ADMIN)) return
+        if (user.isProjectManager() &&
+            projectRepository.existsByEpicIdAndPmId(task.epic.requiredId, user.requiredId)
+        ) return
         if (task.assignee?.requiredId != user.requiredId) {
             throw CustomException(ErrorCode.PERMISSION_DENIED)
         }

--- a/src/main/kotlin/com/pluxity/weekly/auth/authorization/AuthorizationService.kt
+++ b/src/main/kotlin/com/pluxity/weekly/auth/authorization/AuthorizationService.kt
@@ -94,7 +94,9 @@ class AuthorizationService(
         if (user.hasRole(UserType.ADMIN)) return
         if (user.isProjectManager() &&
             projectRepository.existsByEpicIdAndPmId(task.epic.requiredId, user.requiredId)
-        ) return
+        ) {
+            return
+        }
         if (task.assignee?.requiredId != user.requiredId) {
             throw CustomException(ErrorCode.PERMISSION_DENIED)
         }

--- a/src/main/kotlin/com/pluxity/weekly/auth/authorization/AuthorizationService.kt
+++ b/src/main/kotlin/com/pluxity/weekly/auth/authorization/AuthorizationService.kt
@@ -1,4 +1,4 @@
-package com.pluxity.weekly.authorization
+package com.pluxity.weekly.auth.authorization
 
 import com.pluxity.weekly.auth.user.entity.User
 import com.pluxity.weekly.auth.user.service.UserService
@@ -92,11 +92,7 @@ class AuthorizationService(
         task: Task,
     ) {
         if (user.hasRole(UserType.ADMIN)) return
-        if (user.isProjectManager() &&
-            projectRepository.existsByEpicIdAndPmId(task.epic.requiredId, user.requiredId)
-        ) {
-            return
-        }
+        if (user.isProjectManager() && task.epic.project.pmId == user.requiredId) return
         if (task.assignee?.requiredId != user.requiredId) {
             throw CustomException(ErrorCode.PERMISSION_DENIED)
         }

--- a/src/main/kotlin/com/pluxity/weekly/auth/authorization/UserType.kt
+++ b/src/main/kotlin/com/pluxity/weekly/auth/authorization/UserType.kt
@@ -1,4 +1,4 @@
-package com.pluxity.weekly.authorization
+package com.pluxity.weekly.auth.authorization
 
 enum class UserType(
     val roleName: String,

--- a/src/main/kotlin/com/pluxity/weekly/chat/context/ContextBuilder.kt
+++ b/src/main/kotlin/com/pluxity/weekly/chat/context/ContextBuilder.kt
@@ -1,8 +1,8 @@
 package com.pluxity.weekly.chat.context
 
+import com.pluxity.weekly.auth.authorization.AuthorizationService
 import com.pluxity.weekly.auth.user.entity.User
 import com.pluxity.weekly.auth.user.repository.UserRepository
-import com.pluxity.weekly.authorization.AuthorizationService
 import com.pluxity.weekly.chat.dto.EpicSearchFilter
 import com.pluxity.weekly.chat.dto.ProjectSearchFilter
 import com.pluxity.weekly.chat.dto.TaskSearchFilter

--- a/src/main/kotlin/com/pluxity/weekly/chat/service/ChatService.kt
+++ b/src/main/kotlin/com/pluxity/weekly/chat/service/ChatService.kt
@@ -1,6 +1,6 @@
 package com.pluxity.weekly.chat.service
 
-import com.pluxity.weekly.authorization.AuthorizationService
+import com.pluxity.weekly.auth.authorization.AuthorizationService
 import com.pluxity.weekly.chat.context.ContextBuilder
 import com.pluxity.weekly.chat.dto.ChatActionResponse
 import com.pluxity.weekly.chat.llm.LlmService

--- a/src/main/kotlin/com/pluxity/weekly/dashboard/service/DashboardService.kt
+++ b/src/main/kotlin/com/pluxity/weekly/dashboard/service/DashboardService.kt
@@ -1,7 +1,7 @@
 package com.pluxity.weekly.dashboard.service
 
+import com.pluxity.weekly.auth.authorization.AuthorizationService
 import com.pluxity.weekly.auth.user.repository.UserRepository
-import com.pluxity.weekly.authorization.AuthorizationService
 import com.pluxity.weekly.core.constant.ErrorCode
 import com.pluxity.weekly.core.exception.CustomException
 import com.pluxity.weekly.dashboard.dto.AdminDashboardResponse

--- a/src/main/kotlin/com/pluxity/weekly/epic/dto/EpicUpdateRequest.kt
+++ b/src/main/kotlin/com/pluxity/weekly/epic/dto/EpicUpdateRequest.kt
@@ -7,8 +7,6 @@ import java.time.LocalDate
 
 @Schema(description = "에픽 수정 요청 (null인 필드는 변경하지 않음)")
 data class EpicUpdateRequest(
-    @field:Schema(description = "프로젝트 ID", example = "1")
-    val projectId: Long? = null,
     @field:Schema(description = "에픽명", example = "사용자 인증 모듈")
     @field:Size(max = 255, message = "에픽명은 최대 255자까지 입력 가능합니다")
     val name: String? = null,

--- a/src/main/kotlin/com/pluxity/weekly/epic/entity/Epic.kt
+++ b/src/main/kotlin/com/pluxity/weekly/epic/entity/Epic.kt
@@ -68,7 +68,6 @@ class Epic(
     }
 
     fun update(
-        project: Project? = null,
         name: String? = null,
         description: String? = null,
         startDate: LocalDate? = null,
@@ -77,7 +76,6 @@ class Epic(
         if (status == EpicStatus.DONE) {
             throw CustomException(ErrorCode.INVALID_STATUS_TRANSITION, status, "update")
         }
-        project?.let { this.project = it }
         name?.let { this.name = it }
         description?.let { this.description = it }
         startDate?.let { this.startDate = it }

--- a/src/main/kotlin/com/pluxity/weekly/epic/service/EpicService.kt
+++ b/src/main/kotlin/com/pluxity/weekly/epic/service/EpicService.kt
@@ -94,20 +94,33 @@ class EpicService(
         }
 
         epic.update(
-            project = request.projectId?.let { getProjectById(it) },
             name = request.name,
             description = request.description,
             startDate = request.startDate,
             dueDate = request.dueDate,
         )
-        request.userIds?.forEach { userId ->
-            val assignee = getUserById(userId)
-            if (epic.assignments.none { it.user == assignee }) {
-                epic.assign(assignee)
-                eventPublisher.publishEvent(
-                    TeamsNotificationEvent(userId, "${epic.name} 에픽에 배정되었습니다"),
-                )
-            }
+        request.userIds?.let { userIds ->
+            val requestedUsers = userIds.map { getUserById(it) }
+
+            epic.assignments
+                .filter { it.user !in requestedUsers }
+                .forEach { assignment ->
+                    val removedUserId = assignment.user.requiredId
+                    epic.unassign(assignment.user)
+                    taskRepository.deleteByEpicIdAndAssigneeId(epic.requiredId, removedUserId)
+                    eventPublisher.publishEvent(
+                        TeamsNotificationEvent(removedUserId, "${epic.name} 에픽에서 해제되었습니다"),
+                    )
+                }
+
+            requestedUsers
+                .filter { user -> epic.assignments.none { it.user == user } }
+                .forEach { newUser ->
+                    epic.assign(newUser)
+                    eventPublisher.publishEvent(
+                        TeamsNotificationEvent(newUser.requiredId, "${epic.name} 에픽에 배정되었습니다"),
+                    )
+                }
         }
     }
 

--- a/src/main/kotlin/com/pluxity/weekly/epic/service/EpicService.kt
+++ b/src/main/kotlin/com/pluxity/weekly/epic/service/EpicService.kt
@@ -1,8 +1,8 @@
 package com.pluxity.weekly.epic.service
 
+import com.pluxity.weekly.auth.authorization.AuthorizationService
 import com.pluxity.weekly.auth.user.entity.User
 import com.pluxity.weekly.auth.user.repository.UserRepository
-import com.pluxity.weekly.authorization.AuthorizationService
 import com.pluxity.weekly.chat.dto.EpicSearchFilter
 import com.pluxity.weekly.core.constant.ErrorCode
 import com.pluxity.weekly.core.exception.CustomException
@@ -100,7 +100,7 @@ class EpicService(
             dueDate = request.dueDate,
         )
         request.userIds?.let { userIds ->
-            val requestedUsers = userIds.map { getUserById(it) }
+            val requestedUsers = userRepository.findAllById(userIds)
 
             epic.assignments
                 .filter { it.user !in requestedUsers }

--- a/src/main/kotlin/com/pluxity/weekly/project/service/ProjectService.kt
+++ b/src/main/kotlin/com/pluxity/weekly/project/service/ProjectService.kt
@@ -1,7 +1,7 @@
 package com.pluxity.weekly.project.service
 
+import com.pluxity.weekly.auth.authorization.AuthorizationService
 import com.pluxity.weekly.auth.user.repository.UserRepository
-import com.pluxity.weekly.authorization.AuthorizationService
 import com.pluxity.weekly.chat.dto.ProjectSearchFilter
 import com.pluxity.weekly.core.constant.ErrorCode
 import com.pluxity.weekly.core.exception.CustomException

--- a/src/main/kotlin/com/pluxity/weekly/task/dto/TaskUpdateRequest.kt
+++ b/src/main/kotlin/com/pluxity/weekly/task/dto/TaskUpdateRequest.kt
@@ -9,8 +9,6 @@ import java.time.LocalDate
 
 @Schema(description = "태스크 수정 요청 (null인 필드는 변경하지 않음)")
 data class TaskUpdateRequest(
-    @field:Schema(description = "에픽 ID", example = "1")
-    val epicId: Long? = null,
     @field:Schema(description = "태스크명", example = "로그인 API 개발")
     @field:Size(max = 255, message = "태스크명은 최대 255자까지 입력 가능합니다")
     val name: String? = null,

--- a/src/main/kotlin/com/pluxity/weekly/task/entity/Task.kt
+++ b/src/main/kotlin/com/pluxity/weekly/task/entity/Task.kt
@@ -73,7 +73,6 @@ class Task(
     }
 
     fun update(
-        epic: Epic? = null,
         name: String? = null,
         description: String? = null,
         progress: Int? = null,
@@ -84,7 +83,6 @@ class Task(
         if (status == TaskStatus.DONE) {
             throw CustomException(ErrorCode.INVALID_STATUS_TRANSITION, status, "update")
         }
-        epic?.let { this.epic = it }
         name?.let { this.name = it }
         description?.let { this.description = it }
         progress?.let { this.progress = it }

--- a/src/main/kotlin/com/pluxity/weekly/task/repository/TaskRepository.kt
+++ b/src/main/kotlin/com/pluxity/weekly/task/repository/TaskRepository.kt
@@ -25,6 +25,9 @@ interface TaskRepository :
     fun findByEpicId(epicId: Long): List<Task>
 
     @EntityGraph(attributePaths = ["epic", "epic.project"])
+    fun findWithEpicAndProjectById(id: Long): Task?
+
+    @EntityGraph(attributePaths = ["epic", "epic.project"])
     fun findAllWithEpicAndProjectByIdIn(ids: Collection<Long>): List<Task>
 
     @EntityGraph(attributePaths = ["epic", "epic.project", "assignee"])

--- a/src/main/kotlin/com/pluxity/weekly/task/service/TaskService.kt
+++ b/src/main/kotlin/com/pluxity/weekly/task/service/TaskService.kt
@@ -1,8 +1,8 @@
 package com.pluxity.weekly.task.service
 
+import com.pluxity.weekly.auth.authorization.AuthorizationService
 import com.pluxity.weekly.auth.user.entity.User
 import com.pluxity.weekly.auth.user.repository.UserRepository
-import com.pluxity.weekly.authorization.AuthorizationService
 import com.pluxity.weekly.chat.dto.TaskSearchFilter
 import com.pluxity.weekly.core.constant.ErrorCode
 import com.pluxity.weekly.core.exception.CustomException
@@ -260,7 +260,7 @@ class TaskService(
     }
 
     private fun getTaskById(id: Long): Task =
-        taskRepository.findByIdOrNull(id)
+        taskRepository.findWithEpicAndProjectById(id)
             ?: throw CustomException(ErrorCode.NOT_FOUND_TASK, id)
 
     private fun getEpicById(id: Long): Epic =

--- a/src/main/kotlin/com/pluxity/weekly/task/service/TaskService.kt
+++ b/src/main/kotlin/com/pluxity/weekly/task/service/TaskService.kt
@@ -93,14 +93,18 @@ class TaskService(
         val task = getTaskById(id)
         authorizationService.requireTaskOwner(user, task)
         request.status?.let { task.changeStatus(it) }
+        val newAssigneeId = request.assigneeId?.takeIf { it != task.assignee?.requiredId }
+        if (newAssigneeId != null) {
+            authorizationService.requireAdminOrPm(user)
+            ensureAssigneeInEpic(newAssigneeId, task.epic)
+        }
         task.update(
-            epic = request.epicId?.let { getEpicById(it) },
             name = request.name,
             description = request.description,
             progress = request.progress,
             startDate = request.startDate,
             dueDate = request.dueDate,
-            assignee = request.assigneeId?.let { getUserById(it) },
+            assignee = newAssigneeId?.let { getUserById(it) },
         )
     }
 
@@ -240,6 +244,19 @@ class TaskService(
         val task = getTaskById(id)
         authorizationService.requireTaskOwner(user, task)
         taskRepository.delete(task)
+    }
+
+    private fun ensureAssigneeInEpic(
+        assigneeId: Long,
+        epic: Epic,
+    ) {
+        if (!epicRepository.existsByAssignmentsUserIdAndId(assigneeId, epic.requiredId)) {
+            val assignee = getUserById(assigneeId)
+            epic.assign(assignee)
+            eventPublisher.publishEvent(
+                TeamsNotificationEvent(assigneeId, "${epic.name} 에픽에 배정되었습니다"),
+            )
+        }
     }
 
     private fun getTaskById(id: Long): Task =

--- a/src/main/kotlin/com/pluxity/weekly/team/service/TeamService.kt
+++ b/src/main/kotlin/com/pluxity/weekly/team/service/TeamService.kt
@@ -1,10 +1,10 @@
 package com.pluxity.weekly.team.service
 
+import com.pluxity.weekly.auth.authorization.AuthorizationService
 import com.pluxity.weekly.auth.user.dto.UserResponse
 import com.pluxity.weekly.auth.user.dto.toResponse
 import com.pluxity.weekly.auth.user.entity.User
 import com.pluxity.weekly.auth.user.repository.UserRepository
-import com.pluxity.weekly.authorization.AuthorizationService
 import com.pluxity.weekly.chat.dto.TeamSearchFilter
 import com.pluxity.weekly.core.constant.ErrorCode
 import com.pluxity.weekly.core.exception.CustomException

--- a/src/main/kotlin/com/pluxity/weekly/teams/service/TeamsMessageHandler.kt
+++ b/src/main/kotlin/com/pluxity/weekly/teams/service/TeamsMessageHandler.kt
@@ -1,7 +1,7 @@
 package com.pluxity.weekly.teams.service
 
+import com.pluxity.weekly.auth.authorization.AuthorizationService
 import com.pluxity.weekly.auth.user.repository.UserRepository
-import com.pluxity.weekly.authorization.AuthorizationService
 import com.pluxity.weekly.teams.converter.AdaptiveCardConverter
 import com.pluxity.weekly.teams.dto.Activity
 import io.github.oshai.kotlinlogging.KotlinLogging

--- a/src/test/kotlin/com/pluxity/weekly/dashboard/service/DashboardServiceTest.kt
+++ b/src/test/kotlin/com/pluxity/weekly/dashboard/service/DashboardServiceTest.kt
@@ -1,7 +1,7 @@
 package com.pluxity.weekly.dashboard.service
 
+import com.pluxity.weekly.auth.authorization.AuthorizationService
 import com.pluxity.weekly.auth.user.repository.UserRepository
-import com.pluxity.weekly.authorization.AuthorizationService
 import com.pluxity.weekly.epic.entity.EpicStatus
 import com.pluxity.weekly.epic.entity.dummyEpic
 import com.pluxity.weekly.epic.repository.EpicRepository

--- a/src/test/kotlin/com/pluxity/weekly/epic/dto/DummyDTOs.kt
+++ b/src/test/kotlin/com/pluxity/weekly/epic/dto/DummyDTOs.kt
@@ -20,7 +20,6 @@ fun dummyEpicRequest(
 )
 
 fun dummyEpicUpdateRequest(
-    projectId: Long? = null,
     name: String? = null,
     description: String? = null,
     status: EpicStatus? = null,
@@ -28,7 +27,6 @@ fun dummyEpicUpdateRequest(
     dueDate: LocalDate? = null,
     userIds: List<Long>? = null,
 ) = EpicUpdateRequest(
-    projectId = projectId,
     name = name,
     description = description,
     status = status,

--- a/src/test/kotlin/com/pluxity/weekly/epic/service/EpicServiceTest.kt
+++ b/src/test/kotlin/com/pluxity/weekly/epic/service/EpicServiceTest.kt
@@ -146,13 +146,11 @@ class EpicServiceTest :
                 val entity = dummyEpic(id = 1L, project = project, name = "기존 에픽")
                 val request =
                     dummyEpicUpdateRequest(
-                        projectId = 1L,
                         name = "수정된 에픽",
                         status = EpicStatus.IN_PROGRESS,
                     )
 
                 every { epicRepository.findByIdOrNull(1L) } returns entity
-                every { projectRepository.findByIdOrNull(1L) } returns project
 
                 service.update(1L, request)
 

--- a/src/test/kotlin/com/pluxity/weekly/epic/service/EpicServiceTest.kt
+++ b/src/test/kotlin/com/pluxity/weekly/epic/service/EpicServiceTest.kt
@@ -203,6 +203,70 @@ class EpicServiceTest :
             }
         }
 
+        Given("에픽 수정 시 userIds 교체") {
+            When("userIds로 [2,3]을 보내면 기존 [1,2]에서 1은 해제되고 3은 추가된다") {
+                val project = dummyProject(id = 1L)
+                val epic = dummyEpic(id = 10L, project = project, name = "배정교체 에픽")
+                val user1 = dummyUser(id = 1L, name = "유저1")
+                val user2 = dummyUser(id = 2L, name = "유저2")
+                val user3 = dummyUser(id = 3L, name = "유저3")
+                epic.assign(user1)
+                epic.assign(user2)
+
+                every { epicRepository.findByIdOrNull(10L) } returns epic
+                every { userRepository.findByIdOrNull(2L) } returns user2
+                every { userRepository.findByIdOrNull(3L) } returns user3
+                every { taskRepository.deleteByEpicIdAndAssigneeId(10L, 1L) } just runs
+                every { eventPublisher.publishEvent(any<TeamsNotificationEvent>()) } just runs
+
+                service.update(10L, dummyEpicUpdateRequest(userIds = listOf(2L, 3L)))
+
+                Then("user1은 해제되고 user3은 추가된다") {
+                    epic.assignments.map { it.user } shouldBe listOf(user2, user3)
+                    verify { taskRepository.deleteByEpicIdAndAssigneeId(10L, 1L) }
+                    verify { eventPublisher.publishEvent(match<TeamsNotificationEvent> { it.userId == 1L && it.message.contains("해제") }) }
+                    verify { eventPublisher.publishEvent(match<TeamsNotificationEvent> { it.userId == 3L && it.message.contains("배정") }) }
+                }
+            }
+
+            When("빈 배열을 보내면 전체 해제된다") {
+                val project = dummyProject(id = 1L)
+                val epic = dummyEpic(id = 11L, project = project, name = "전체해제 에픽")
+                val user1 = dummyUser(id = 10L, name = "유저A")
+                val user2 = dummyUser(id = 20L, name = "유저B")
+                epic.assign(user1)
+                epic.assign(user2)
+
+                every { epicRepository.findByIdOrNull(11L) } returns epic
+                every { taskRepository.deleteByEpicIdAndAssigneeId(11L, any()) } just runs
+                every { eventPublisher.publishEvent(any<TeamsNotificationEvent>()) } just runs
+
+                service.update(11L, dummyEpicUpdateRequest(userIds = emptyList()))
+
+                Then("배정이 모두 제거된다") {
+                    epic.assignments.size shouldBe 0
+                    verify { taskRepository.deleteByEpicIdAndAssigneeId(11L, 10L) }
+                    verify { taskRepository.deleteByEpicIdAndAssigneeId(11L, 20L) }
+                }
+            }
+
+            When("userIds가 null이면 배정이 변경되지 않는다") {
+                val project = dummyProject(id = 1L)
+                val epic = dummyEpic(id = 12L, project = project, name = "변경없음 에픽")
+                val user1 = dummyUser(id = 10L, name = "유저X")
+                epic.assign(user1)
+
+                every { epicRepository.findByIdOrNull(12L) } returns epic
+
+                service.update(12L, dummyEpicUpdateRequest(userIds = null))
+
+                Then("기존 배정이 유지된다") {
+                    epic.assignments.size shouldBe 1
+                    epic.assignments[0].user shouldBe user1
+                }
+            }
+        }
+
         // ── EpicAssignment ──
 
         Given("에픽 배정 목록 조회") {

--- a/src/test/kotlin/com/pluxity/weekly/epic/service/EpicServiceTest.kt
+++ b/src/test/kotlin/com/pluxity/weekly/epic/service/EpicServiceTest.kt
@@ -1,8 +1,8 @@
 package com.pluxity.weekly.epic.service
 
+import com.pluxity.weekly.auth.authorization.AuthorizationService
 import com.pluxity.weekly.auth.user.entity.RoleType
 import com.pluxity.weekly.auth.user.repository.UserRepository
-import com.pluxity.weekly.authorization.AuthorizationService
 import com.pluxity.weekly.core.constant.ErrorCode
 import com.pluxity.weekly.core.exception.CustomException
 import com.pluxity.weekly.epic.dto.dummyEpicRequest
@@ -214,8 +214,7 @@ class EpicServiceTest :
                 epic.assign(user2)
 
                 every { epicRepository.findByIdOrNull(10L) } returns epic
-                every { userRepository.findByIdOrNull(2L) } returns user2
-                every { userRepository.findByIdOrNull(3L) } returns user3
+                every { userRepository.findAllById(listOf(2L, 3L)) } returns listOf(user2, user3)
                 every { taskRepository.deleteByEpicIdAndAssigneeId(10L, 1L) } just runs
                 every { eventPublisher.publishEvent(any<TeamsNotificationEvent>()) } just runs
 
@@ -238,6 +237,7 @@ class EpicServiceTest :
                 epic.assign(user2)
 
                 every { epicRepository.findByIdOrNull(11L) } returns epic
+                every { userRepository.findAllById(emptyList()) } returns emptyList()
                 every { taskRepository.deleteByEpicIdAndAssigneeId(11L, any()) } just runs
                 every { eventPublisher.publishEvent(any<TeamsNotificationEvent>()) } just runs
 

--- a/src/test/kotlin/com/pluxity/weekly/project/service/ProjectServiceTest.kt
+++ b/src/test/kotlin/com/pluxity/weekly/project/service/ProjectServiceTest.kt
@@ -1,8 +1,8 @@
 package com.pluxity.weekly.project.service
 
+import com.pluxity.weekly.auth.authorization.AuthorizationService
 import com.pluxity.weekly.auth.user.entity.RoleType
 import com.pluxity.weekly.auth.user.repository.UserRepository
-import com.pluxity.weekly.authorization.AuthorizationService
 import com.pluxity.weekly.core.constant.ErrorCode
 import com.pluxity.weekly.core.exception.CustomException
 import com.pluxity.weekly.epic.repository.EpicRepository

--- a/src/test/kotlin/com/pluxity/weekly/task/dto/DummyDTOs.kt
+++ b/src/test/kotlin/com/pluxity/weekly/task/dto/DummyDTOs.kt
@@ -22,7 +22,6 @@ fun dummyTaskRequest(
 )
 
 fun dummyTaskUpdateRequest(
-    epicId: Long? = null,
     name: String? = null,
     description: String? = null,
     status: TaskStatus? = null,
@@ -31,7 +30,6 @@ fun dummyTaskUpdateRequest(
     dueDate: LocalDate? = null,
     assigneeId: Long? = null,
 ) = TaskUpdateRequest(
-    epicId = epicId,
     name = name,
     description = description,
     status = status,

--- a/src/test/kotlin/com/pluxity/weekly/task/service/TaskServiceTest.kt
+++ b/src/test/kotlin/com/pluxity/weekly/task/service/TaskServiceTest.kt
@@ -462,9 +462,10 @@ class TaskServiceTest :
                 val epic = dummyEpic(id = 1L)
                 val oldAssignee = dummyUser(id = 10L, name = "기존 담당자")
                 val newAssignee = dummyUser(id = 20L, name = "새 담당자")
-                val entity = dummyTask(id = 70L, epic = epic, name = "담당자 변경 태스크").apply {
-                    this.assignee = oldAssignee
-                }
+                val entity =
+                    dummyTask(id = 70L, epic = epic, name = "담당자 변경 태스크").apply {
+                        this.assignee = oldAssignee
+                    }
 
                 every { taskRepository.findByIdOrNull(70L) } returns entity
                 every { authorizationService.requireAdminOrPm(any()) } just runs
@@ -480,16 +481,18 @@ class TaskServiceTest :
 
             When("일반 사용자가 담당자를 변경하려 하면") {
                 val epic = dummyEpic(id = 1L)
-                val entity = dummyTask(id = 71L, epic = epic).apply {
-                    this.assignee = adminUser
-                }
+                val entity =
+                    dummyTask(id = 71L, epic = epic).apply {
+                        this.assignee = adminUser
+                    }
 
                 every { taskRepository.findByIdOrNull(71L) } returns entity
                 every { authorizationService.requireAdminOrPm(any()) } throws CustomException(ErrorCode.PERMISSION_DENIED)
 
-                val exception = shouldThrow<CustomException> {
-                    service.update(71L, dummyTaskUpdateRequest(assigneeId = 999L))
-                }
+                val exception =
+                    shouldThrow<CustomException> {
+                        service.update(71L, dummyTaskUpdateRequest(assigneeId = 999L))
+                    }
 
                 Then("PERMISSION_DENIED 예외가 발생한다") {
                     exception.code shouldBe ErrorCode.PERMISSION_DENIED
@@ -500,9 +503,10 @@ class TaskServiceTest :
                 val epic = dummyEpic(id = 1L)
                 val oldAssignee = dummyUser(id = 10L, name = "기존 담당자")
                 val newAssignee = dummyUser(id = 30L, name = "미배정 담당자")
-                val entity = dummyTask(id = 72L, epic = epic, name = "자동배정 태스크").apply {
-                    this.assignee = oldAssignee
-                }
+                val entity =
+                    dummyTask(id = 72L, epic = epic, name = "자동배정 태스크").apply {
+                        this.assignee = oldAssignee
+                    }
 
                 every { taskRepository.findByIdOrNull(72L) } returns entity
                 every { authorizationService.requireAdminOrPm(any()) } just runs
@@ -521,9 +525,10 @@ class TaskServiceTest :
             When("동일한 담당자 ID를 보내면 권한 체크를 건너뛴다") {
                 val epic = dummyEpic(id = 1L)
                 val currentAssignee = dummyUser(id = 10L, name = "현재 담당자")
-                val entity = dummyTask(id = 73L, epic = epic, name = "동일 담당자").apply {
-                    this.assignee = currentAssignee
-                }
+                val entity =
+                    dummyTask(id = 73L, epic = epic, name = "동일 담당자").apply {
+                        this.assignee = currentAssignee
+                    }
 
                 every { taskRepository.findByIdOrNull(73L) } returns entity
 

--- a/src/test/kotlin/com/pluxity/weekly/task/service/TaskServiceTest.kt
+++ b/src/test/kotlin/com/pluxity/weekly/task/service/TaskServiceTest.kt
@@ -457,6 +457,85 @@ class TaskServiceTest :
             }
         }
 
+        Given("태스크 담당자 변경 권한") {
+            When("ADMIN이 담당자를 변경하면") {
+                val epic = dummyEpic(id = 1L)
+                val oldAssignee = dummyUser(id = 10L, name = "기존 담당자")
+                val newAssignee = dummyUser(id = 20L, name = "새 담당자")
+                val entity = dummyTask(id = 70L, epic = epic, name = "담당자 변경 태스크").apply {
+                    this.assignee = oldAssignee
+                }
+
+                every { taskRepository.findByIdOrNull(70L) } returns entity
+                every { authorizationService.requireAdminOrPm(any()) } just runs
+                every { epicRepository.existsByAssignmentsUserIdAndId(20L, 1L) } returns true
+                every { userRepository.findByIdOrNull(20L) } returns newAssignee
+
+                service.update(70L, dummyTaskUpdateRequest(assigneeId = 20L))
+
+                Then("담당자가 변경된다") {
+                    entity.assignee shouldBe newAssignee
+                }
+            }
+
+            When("일반 사용자가 담당자를 변경하려 하면") {
+                val epic = dummyEpic(id = 1L)
+                val entity = dummyTask(id = 71L, epic = epic).apply {
+                    this.assignee = adminUser
+                }
+
+                every { taskRepository.findByIdOrNull(71L) } returns entity
+                every { authorizationService.requireAdminOrPm(any()) } throws CustomException(ErrorCode.PERMISSION_DENIED)
+
+                val exception = shouldThrow<CustomException> {
+                    service.update(71L, dummyTaskUpdateRequest(assigneeId = 999L))
+                }
+
+                Then("PERMISSION_DENIED 예외가 발생한다") {
+                    exception.code shouldBe ErrorCode.PERMISSION_DENIED
+                }
+            }
+
+            When("새 담당자가 에픽에 미배정이면 자동 배정된다") {
+                val epic = dummyEpic(id = 1L)
+                val oldAssignee = dummyUser(id = 10L, name = "기존 담당자")
+                val newAssignee = dummyUser(id = 30L, name = "미배정 담당자")
+                val entity = dummyTask(id = 72L, epic = epic, name = "자동배정 태스크").apply {
+                    this.assignee = oldAssignee
+                }
+
+                every { taskRepository.findByIdOrNull(72L) } returns entity
+                every { authorizationService.requireAdminOrPm(any()) } just runs
+                every { epicRepository.existsByAssignmentsUserIdAndId(30L, 1L) } returns false
+                every { userRepository.findByIdOrNull(30L) } returns newAssignee
+
+                service.update(72L, dummyTaskUpdateRequest(assigneeId = 30L))
+
+                Then("에픽에 자동 배정되고 담당자가 변경된다") {
+                    epic.assignments.any { it.user == newAssignee } shouldBe true
+                    entity.assignee shouldBe newAssignee
+                    verify { eventPublisher.publishEvent(match<TeamsNotificationEvent> { it.userId == 30L }) }
+                }
+            }
+
+            When("동일한 담당자 ID를 보내면 권한 체크를 건너뛴다") {
+                val epic = dummyEpic(id = 1L)
+                val currentAssignee = dummyUser(id = 10L, name = "현재 담당자")
+                val entity = dummyTask(id = 73L, epic = epic, name = "동일 담당자").apply {
+                    this.assignee = currentAssignee
+                }
+
+                every { taskRepository.findByIdOrNull(73L) } returns entity
+
+                service.update(73L, dummyTaskUpdateRequest(assigneeId = 10L))
+
+                Then("requireAdminOrPm이 호출되지 않는다") {
+                    verify(exactly = 0) { authorizationService.requireAdminOrPm(any()) }
+                    entity.assignee shouldBe currentAssignee
+                }
+            }
+        }
+
         Given("일반 수정으로 IN_REVIEW / DONE 상태 전이 차단") {
             When("update 로 status 를 IN_REVIEW 로 변경하려 하면") {
                 val entity = dummyTask(id = 40L, status = TaskStatus.IN_PROGRESS)

--- a/src/test/kotlin/com/pluxity/weekly/task/service/TaskServiceTest.kt
+++ b/src/test/kotlin/com/pluxity/weekly/task/service/TaskServiceTest.kt
@@ -1,8 +1,8 @@
 package com.pluxity.weekly.task.service
 
+import com.pluxity.weekly.auth.authorization.AuthorizationService
 import com.pluxity.weekly.auth.user.entity.RoleType
 import com.pluxity.weekly.auth.user.repository.UserRepository
-import com.pluxity.weekly.authorization.AuthorizationService
 import com.pluxity.weekly.core.constant.ErrorCode
 import com.pluxity.weekly.core.exception.CustomException
 import com.pluxity.weekly.epic.entity.dummyEpic
@@ -109,7 +109,7 @@ class TaskServiceTest :
                         dueDate = LocalDate.of(2026, 3, 31),
                     )
 
-                every { taskRepository.findByIdOrNull(1L) } returns entity
+                every { taskRepository.findWithEpicAndProjectById(1L) } returns entity
 
                 val result = service.findById(1L)
 
@@ -126,7 +126,7 @@ class TaskServiceTest :
             }
 
             When("존재하지 않는 태스크를 조회하면") {
-                every { taskRepository.findByIdOrNull(999L) } returns null
+                every { taskRepository.findWithEpicAndProjectById(999L) } returns null
 
                 val exception =
                     shouldThrow<CustomException> {
@@ -192,7 +192,7 @@ class TaskServiceTest :
                         progress = 30,
                     )
 
-                every { taskRepository.findByIdOrNull(1L) } returns entity
+                every { taskRepository.findWithEpicAndProjectById(1L) } returns entity
 
                 service.update(1L, request)
 
@@ -204,7 +204,7 @@ class TaskServiceTest :
             }
 
             When("존재하지 않는 태스크를 수정하면") {
-                every { taskRepository.findByIdOrNull(999L) } returns null
+                every { taskRepository.findWithEpicAndProjectById(999L) } returns null
 
                 val exception =
                     shouldThrow<CustomException> {
@@ -221,7 +221,7 @@ class TaskServiceTest :
             When("존재하는 태스크를 삭제하면") {
                 val entity = dummyTask(id = 1L, name = "삭제대상 태스크")
 
-                every { taskRepository.findByIdOrNull(1L) } returns entity
+                every { taskRepository.findWithEpicAndProjectById(1L) } returns entity
                 every { taskRepository.delete(any<Task>()) } just runs
 
                 service.delete(1L)
@@ -232,7 +232,7 @@ class TaskServiceTest :
             }
 
             When("존재하지 않는 태스크를 삭제하면") {
-                every { taskRepository.findByIdOrNull(999L) } returns null
+                every { taskRepository.findWithEpicAndProjectById(999L) } returns null
 
                 val exception =
                     shouldThrow<CustomException> {
@@ -258,7 +258,7 @@ class TaskServiceTest :
                         status = TaskStatus.IN_PROGRESS,
                     )
 
-                every { taskRepository.findByIdOrNull(10L) } returns entity
+                every { taskRepository.findWithEpicAndProjectById(10L) } returns entity
                 val eventSlot = slot<Any>()
                 every { eventPublisher.publishEvent(capture(eventSlot)) } just runs
 
@@ -282,7 +282,7 @@ class TaskServiceTest :
                         status = TaskStatus.IN_REVIEW,
                     )
 
-                every { taskRepository.findByIdOrNull(11L) } returns entity
+                every { taskRepository.findWithEpicAndProjectById(11L) } returns entity
 
                 val exception =
                     shouldThrow<CustomException> {
@@ -308,7 +308,7 @@ class TaskServiceTest :
                         status = TaskStatus.IN_REVIEW,
                     ).apply { this.assignee = assignee }
 
-                every { taskRepository.findByIdOrNull(20L) } returns entity
+                every { taskRepository.findWithEpicAndProjectById(20L) } returns entity
                 val eventSlot = slot<Any>()
                 every { eventPublisher.publishEvent(capture(eventSlot)) } just runs
 
@@ -323,7 +323,7 @@ class TaskServiceTest :
 
             When("IN_PROGRESS 태스크를 승인하면") {
                 val entity = dummyTask(id = 21L, status = TaskStatus.IN_PROGRESS)
-                every { taskRepository.findByIdOrNull(21L) } returns entity
+                every { taskRepository.findWithEpicAndProjectById(21L) } returns entity
 
                 val exception =
                     shouldThrow<CustomException> {
@@ -348,7 +348,7 @@ class TaskServiceTest :
                         status = TaskStatus.IN_REVIEW,
                     )
 
-                every { taskRepository.findByIdOrNull(30L) } returns entity
+                every { taskRepository.findWithEpicAndProjectById(30L) } returns entity
                 every { eventPublisher.publishEvent(any<TeamsNotificationEvent>()) } just runs
                 val logSlot = slot<TaskApprovalLog>()
                 every { taskApprovalLogRepository.save(capture(logSlot)) } answers { logSlot.captured }
@@ -373,7 +373,7 @@ class TaskServiceTest :
                         status = TaskStatus.IN_REVIEW,
                     )
 
-                every { taskRepository.findByIdOrNull(31L) } returns entity
+                every { taskRepository.findWithEpicAndProjectById(31L) } returns entity
                 every { eventPublisher.publishEvent(any<TeamsNotificationEvent>()) } just runs
                 val logSlot = slot<TaskApprovalLog>()
                 every { taskApprovalLogRepository.save(capture(logSlot)) } answers { logSlot.captured }
@@ -467,7 +467,7 @@ class TaskServiceTest :
                         this.assignee = oldAssignee
                     }
 
-                every { taskRepository.findByIdOrNull(70L) } returns entity
+                every { taskRepository.findWithEpicAndProjectById(70L) } returns entity
                 every { authorizationService.requireAdminOrPm(any()) } just runs
                 every { epicRepository.existsByAssignmentsUserIdAndId(20L, 1L) } returns true
                 every { userRepository.findByIdOrNull(20L) } returns newAssignee
@@ -486,7 +486,7 @@ class TaskServiceTest :
                         this.assignee = adminUser
                     }
 
-                every { taskRepository.findByIdOrNull(71L) } returns entity
+                every { taskRepository.findWithEpicAndProjectById(71L) } returns entity
                 every { authorizationService.requireAdminOrPm(any()) } throws CustomException(ErrorCode.PERMISSION_DENIED)
 
                 val exception =
@@ -508,7 +508,7 @@ class TaskServiceTest :
                         this.assignee = oldAssignee
                     }
 
-                every { taskRepository.findByIdOrNull(72L) } returns entity
+                every { taskRepository.findWithEpicAndProjectById(72L) } returns entity
                 every { authorizationService.requireAdminOrPm(any()) } just runs
                 every { epicRepository.existsByAssignmentsUserIdAndId(30L, 1L) } returns false
                 every { userRepository.findByIdOrNull(30L) } returns newAssignee
@@ -530,7 +530,7 @@ class TaskServiceTest :
                         this.assignee = currentAssignee
                     }
 
-                every { taskRepository.findByIdOrNull(73L) } returns entity
+                every { taskRepository.findWithEpicAndProjectById(73L) } returns entity
 
                 service.update(73L, dummyTaskUpdateRequest(assigneeId = 10L))
 
@@ -544,7 +544,7 @@ class TaskServiceTest :
         Given("일반 수정으로 IN_REVIEW / DONE 상태 전이 차단") {
             When("update 로 status 를 IN_REVIEW 로 변경하려 하면") {
                 val entity = dummyTask(id = 40L, status = TaskStatus.IN_PROGRESS)
-                every { taskRepository.findByIdOrNull(40L) } returns entity
+                every { taskRepository.findWithEpicAndProjectById(40L) } returns entity
 
                 val exception =
                     shouldThrow<CustomException> {
@@ -558,7 +558,7 @@ class TaskServiceTest :
 
             When("update 로 status 를 DONE 으로 변경하려 하면") {
                 val entity = dummyTask(id = 41L, status = TaskStatus.IN_PROGRESS)
-                every { taskRepository.findByIdOrNull(41L) } returns entity
+                every { taskRepository.findWithEpicAndProjectById(41L) } returns entity
 
                 val exception =
                     shouldThrow<CustomException> {
@@ -572,7 +572,7 @@ class TaskServiceTest :
 
             When("현재 상태가 DONE 인 태스크를 update 로 수정하려 하면") {
                 val entity = dummyTask(id = 42L, status = TaskStatus.DONE, name = "완료된 태스크")
-                every { taskRepository.findByIdOrNull(42L) } returns entity
+                every { taskRepository.findWithEpicAndProjectById(42L) } returns entity
 
                 val exception =
                     shouldThrow<CustomException> {

--- a/src/test/kotlin/com/pluxity/weekly/team/service/TeamServiceTest.kt
+++ b/src/test/kotlin/com/pluxity/weekly/team/service/TeamServiceTest.kt
@@ -1,7 +1,7 @@
 package com.pluxity.weekly.team.service
 
+import com.pluxity.weekly.auth.authorization.AuthorizationService
 import com.pluxity.weekly.auth.user.repository.UserRepository
-import com.pluxity.weekly.authorization.AuthorizationService
 import com.pluxity.weekly.core.constant.ErrorCode
 import com.pluxity.weekly.core.exception.CustomException
 import com.pluxity.weekly.team.dto.dummyTeamRequest


### PR DESCRIPTION
## Summary

- Epic update: `projectId` 변경 시 새 프로젝트에 대한 `requireEpicManage` 권한 검증 + DONE 프로젝트 이동 차단
- Task update: `epicId` 변경 시 `requireEpicAccess` 권한 검증 + DONE 에픽 이동 차단
- Task update: `assignee` 변경 시 PM/ADMIN 권한 검증 + 새 assignee의 epic 배정 여부 검증

closes #31

## 변경 파일

| 파일 | 변경 |
|---|---|
| `ErrorCode.kt` | `TARGET_PROJECT_DONE`, `TARGET_EPIC_DONE`, `ASSIGNEE_NOT_IN_EPIC` 추가 |
| `EpicService.kt` | `update`에 새 projectId 권한·DONE 검증 |
| `TaskService.kt` | `update`에 새 epicId 권한·DONE 검증 + assignee 변경 권한 분기 |

## Test plan

- [ ] Epic update: 다른 프로젝트로 이동 시 해당 프로젝트 PM 권한 없으면 403
- [ ] Epic update: DONE 프로젝트로 이동 시 400
- [ ] Task update: 다른 에픽으로 이동 시 해당 에픽 접근 권한 없으면 403
- [ ] Task update: DONE 에픽으로 이동 시 400
- [ ] Task update: owner가 assignee 변경 시도 시 403
- [ ] Task update: PM/ADMIN이 epic 미배정 사용자로 assignee 변경 시 400
- [ ] Task update: PM/ADMIN이 epic 배정 사용자로 assignee 변경 시 성공
- [ ] Task update: owner가 내용만 수정 시 기존대로 성공
- [ ] 기존 Epic/Task update 기능 회귀 없음