### PR TITLE
refactor: 상태 전이 규칙 Entity 이동 + Repository 정리

### DIFF
--- a/src/main/kotlin/com/pluxity/weekly/dashboard/service/DashboardService.kt
+++ b/src/main/kotlin/com/pluxity/weekly/dashboard/service/DashboardService.kt
@@ -96,7 +96,7 @@ class DashboardService(
         val pmName =
             project.pmId?.let { userRepository.findByIdOrNull(it)?.name } ?: ""
 
-        val epics = epicRepository.findByProjectId(projectId)
+        val epics = epicRepository.findByProjectIdIn(listOf(projectId))
         val tasks = taskRepository.findByEpicIn(epics)
         val tasksByEpicId = tasks.groupBy { it.epic.requiredId }
         val now = LocalDate.now()

--- a/src/main/kotlin/com/pluxity/weekly/epic/entity/Epic.kt
+++ b/src/main/kotlin/com/pluxity/weekly/epic/entity/Epic.kt
@@ -1,7 +1,9 @@
 package com.pluxity.weekly.epic.entity
 
 import com.pluxity.weekly.auth.user.entity.User
+import com.pluxity.weekly.core.constant.ErrorCode
 import com.pluxity.weekly.core.entity.IdentityIdEntity
+import com.pluxity.weekly.core.exception.CustomException
 import com.pluxity.weekly.project.entity.Project
 import com.pluxity.weekly.task.entity.Task
 import jakarta.persistence.CascadeType
@@ -52,18 +54,29 @@ class Epic(
         assignments.removeIf { it.user == user }
     }
 
+    fun changeStatus(
+        newStatus: EpicStatus,
+        allTasksDone: Boolean,
+    ) {
+        if (status == EpicStatus.DONE) {
+            throw CustomException(ErrorCode.INVALID_STATUS_TRANSITION, status, "update")
+        }
+        if (newStatus == EpicStatus.DONE && !allTasksDone) {
+            throw CustomException(ErrorCode.TASK_NOT_ALL_DONE)
+        }
+        status = newStatus
+    }
+
     fun update(
         project: Project? = null,
         name: String? = null,
         description: String? = null,
-        status: EpicStatus? = null,
         startDate: LocalDate? = null,
         dueDate: LocalDate? = null,
     ) {
         project?.let { this.project = it }
         name?.let { this.name = it }
         description?.let { this.description = it }
-        status?.let { this.status = it }
         startDate?.let { this.startDate = it }
         dueDate?.let { this.dueDate = it }
     }

--- a/src/main/kotlin/com/pluxity/weekly/epic/entity/Epic.kt
+++ b/src/main/kotlin/com/pluxity/weekly/epic/entity/Epic.kt
@@ -74,6 +74,9 @@ class Epic(
         startDate: LocalDate? = null,
         dueDate: LocalDate? = null,
     ) {
+        if (status == EpicStatus.DONE) {
+            throw CustomException(ErrorCode.INVALID_STATUS_TRANSITION, status, "update")
+        }
         project?.let { this.project = it }
         name?.let { this.name = it }
         description?.let { this.description = it }

--- a/src/main/kotlin/com/pluxity/weekly/epic/repository/EpicRepository.kt
+++ b/src/main/kotlin/com/pluxity/weekly/epic/repository/EpicRepository.kt
@@ -17,8 +17,6 @@ interface EpicRepository :
         epicId: Long,
     ): Boolean
 
-    fun existsByProjectId(projectId: Long): Boolean
-
     fun findByProjectId(projectId: Long): List<Epic>
 
     fun findByProjectIdIn(projectIds: List<Long>): List<Epic>

--- a/src/main/kotlin/com/pluxity/weekly/epic/repository/EpicRepository.kt
+++ b/src/main/kotlin/com/pluxity/weekly/epic/repository/EpicRepository.kt
@@ -17,7 +17,5 @@ interface EpicRepository :
         epicId: Long,
     ): Boolean
 
-    fun findByProjectId(projectId: Long): List<Epic>
-
     fun findByProjectIdIn(projectIds: List<Long>): List<Epic>
 }

--- a/src/main/kotlin/com/pluxity/weekly/epic/service/EpicService.kt
+++ b/src/main/kotlin/com/pluxity/weekly/epic/service/EpicService.kt
@@ -81,24 +81,18 @@ class EpicService(
         val epic = getEpicById(id)
         authorizationService.requireEpicManage(user, epic.project.requiredId)
 
-        if (epic.status == EpicStatus.DONE) {
-            throw CustomException(ErrorCode.INVALID_STATUS_TRANSITION, epic.status, "update")
-        }
-
         request.status?.let { newStatus ->
-            if (newStatus == EpicStatus.DONE) {
-                val tasks = taskRepository.findByEpicId(id)
-                if (tasks.isEmpty() || tasks.any { it.status != TaskStatus.DONE }) {
-                    throw CustomException(ErrorCode.TASK_NOT_ALL_DONE)
+            val allTasksDone =
+                taskRepository.findByEpicId(id).let { tasks ->
+                    tasks.isNotEmpty() && tasks.all { it.status == TaskStatus.DONE }
                 }
-            }
+            epic.changeStatus(newStatus, allTasksDone)
         }
 
         epic.update(
             project = request.projectId?.let { getProjectById(it) },
             name = request.name,
             description = request.description,
-            status = request.status,
             startDate = request.startDate,
             dueDate = request.dueDate,
         )

--- a/src/main/kotlin/com/pluxity/weekly/epic/service/EpicService.kt
+++ b/src/main/kotlin/com/pluxity/weekly/epic/service/EpicService.kt
@@ -83,8 +83,12 @@ class EpicService(
 
         request.status?.let { newStatus ->
             val allTasksDone =
-                taskRepository.findByEpicId(id).let { tasks ->
-                    tasks.isNotEmpty() && tasks.all { it.status == TaskStatus.DONE }
+                if (newStatus == EpicStatus.DONE) {
+                    taskRepository.findByEpicId(id).let { tasks ->
+                        tasks.isNotEmpty() && tasks.all { it.status == TaskStatus.DONE }
+                    }
+                } else {
+                    false
                 }
             epic.changeStatus(newStatus, allTasksDone)
         }

--- a/src/main/kotlin/com/pluxity/weekly/project/entity/Project.kt
+++ b/src/main/kotlin/com/pluxity/weekly/project/entity/Project.kt
@@ -1,6 +1,8 @@
 package com.pluxity.weekly.project.entity
 
+import com.pluxity.weekly.core.constant.ErrorCode
 import com.pluxity.weekly.core.entity.IdentityIdEntity
+import com.pluxity.weekly.core.exception.CustomException
 import com.pluxity.weekly.epic.entity.Epic
 import jakarta.persistence.CascadeType
 import jakarta.persistence.Column
@@ -33,17 +35,28 @@ class Project(
     @OneToMany(mappedBy = "project", cascade = [CascadeType.REMOVE])
     val epics: MutableList<Epic> = mutableListOf()
 
+    fun changeStatus(
+        newStatus: ProjectStatus,
+        allEpicsDone: Boolean,
+    ) {
+        if (status == ProjectStatus.DONE) {
+            throw CustomException(ErrorCode.INVALID_STATUS_TRANSITION, status, "update")
+        }
+        if (newStatus == ProjectStatus.DONE && !allEpicsDone) {
+            throw CustomException(ErrorCode.EPIC_NOT_ALL_DONE)
+        }
+        status = newStatus
+    }
+
     fun update(
         name: String? = null,
         description: String? = null,
-        status: ProjectStatus? = null,
         startDate: LocalDate? = null,
         dueDate: LocalDate? = null,
         pmId: Long? = null,
     ) {
         name?.let { this.name = it }
         description?.let { this.description = it }
-        status?.let { this.status = it }
         startDate?.let { this.startDate = it }
         dueDate?.let { this.dueDate = it }
         pmId?.let { this.pmId = it }

--- a/src/main/kotlin/com/pluxity/weekly/project/entity/Project.kt
+++ b/src/main/kotlin/com/pluxity/weekly/project/entity/Project.kt
@@ -55,6 +55,9 @@ class Project(
         dueDate: LocalDate? = null,
         pmId: Long? = null,
     ) {
+        if (status == ProjectStatus.DONE) {
+            throw CustomException(ErrorCode.INVALID_STATUS_TRANSITION, status, "update")
+        }
         name?.let { this.name = it }
         description?.let { this.description = it }
         startDate?.let { this.startDate = it }

--- a/src/main/kotlin/com/pluxity/weekly/project/repository/ProjectRepository.kt
+++ b/src/main/kotlin/com/pluxity/weekly/project/repository/ProjectRepository.kt
@@ -37,21 +37,6 @@ interface ProjectRepository :
         JOIN ea.user u
         LEFT JOIN TeamMember tm ON tm.user = u
         LEFT JOIN tm.team t
-        WHERE ea.epic.project.id = :projectId
-        GROUP BY ea.epic.project.id, u.id, u.name, t.id, t.name
-        """,
-    )
-    fun findMembersByProjectId(projectId: Long): List<ProjectMemberResponse>
-
-    @Query(
-        """
-        SELECT new com.pluxity.weekly.project.dto.ProjectMemberResponse(
-            ea.epic.project.id, u.id, u.name, t.id, t.name
-        )
-        FROM EpicAssignment ea
-        JOIN ea.user u
-        LEFT JOIN TeamMember tm ON tm.user = u
-        LEFT JOIN tm.team t
         WHERE ea.epic.project.id IN :projectIds
         GROUP BY ea.epic.project.id, u.id, u.name, t.id, t.name
         """,

--- a/src/main/kotlin/com/pluxity/weekly/project/service/ProjectService.kt
+++ b/src/main/kotlin/com/pluxity/weekly/project/service/ProjectService.kt
@@ -78,8 +78,12 @@ class ProjectService(
 
         request.status?.let { newStatus ->
             val allEpicsDone =
-                epicRepository.findByProjectId(id).let { epics ->
-                    epics.isNotEmpty() && epics.all { it.status == EpicStatus.DONE }
+                if (newStatus == ProjectStatus.DONE) {
+                    epicRepository.findByProjectId(id).let { epics ->
+                        epics.isNotEmpty() && epics.all { it.status == EpicStatus.DONE }
+                    }
+                } else {
+                    false
                 }
             project.changeStatus(newStatus, allEpicsDone)
         }

--- a/src/main/kotlin/com/pluxity/weekly/project/service/ProjectService.kt
+++ b/src/main/kotlin/com/pluxity/weekly/project/service/ProjectService.kt
@@ -76,23 +76,17 @@ class ProjectService(
         authorizationService.requireProjectManager(user, id)
         val project = getById(id)
 
-        if (project.status == ProjectStatus.DONE) {
-            throw CustomException(ErrorCode.INVALID_STATUS_TRANSITION, project.status, "update")
-        }
-
         request.status?.let { newStatus ->
-            if (newStatus == ProjectStatus.DONE) {
-                val epics = epicRepository.findByProjectId(id)
-                if (epics.isEmpty() || epics.any { it.status != EpicStatus.DONE }) {
-                    throw CustomException(ErrorCode.EPIC_NOT_ALL_DONE)
+            val allEpicsDone =
+                epicRepository.findByProjectId(id).let { epics ->
+                    epics.isNotEmpty() && epics.all { it.status == EpicStatus.DONE }
                 }
-            }
+            project.changeStatus(newStatus, allEpicsDone)
         }
 
         project.update(
             name = request.name,
             description = request.description,
-            status = request.status,
             startDate = request.startDate,
             dueDate = request.dueDate,
             pmId = request.pmId,

--- a/src/main/kotlin/com/pluxity/weekly/project/service/ProjectService.kt
+++ b/src/main/kotlin/com/pluxity/weekly/project/service/ProjectService.kt
@@ -47,7 +47,7 @@ class ProjectService(
     fun findById(id: Long): ProjectResponse {
         val project = getById(id)
         val pmName = project.pmId?.let { userRepository.findByIdOrNull(it)?.name }
-        return project.toResponse(projectRepository.findMembersByProjectId(project.requiredId), pmName)
+        return project.toResponse(projectRepository.findMembersByProjectIds(listOf(project.requiredId)), pmName)
     }
 
     @Transactional

--- a/src/main/kotlin/com/pluxity/weekly/project/service/ProjectService.kt
+++ b/src/main/kotlin/com/pluxity/weekly/project/service/ProjectService.kt
@@ -79,7 +79,7 @@ class ProjectService(
         request.status?.let { newStatus ->
             val allEpicsDone =
                 if (newStatus == ProjectStatus.DONE) {
-                    epicRepository.findByProjectId(id).let { epics ->
+                    epicRepository.findByProjectIdIn(listOf(id)).let { epics ->
                         epics.isNotEmpty() && epics.all { it.status == EpicStatus.DONE }
                     }
                 } else {

--- a/src/main/kotlin/com/pluxity/weekly/task/entity/Task.kt
+++ b/src/main/kotlin/com/pluxity/weekly/task/entity/Task.kt
@@ -81,6 +81,9 @@ class Task(
         dueDate: LocalDate? = null,
         assignee: User? = null,
     ) {
+        if (status == TaskStatus.DONE) {
+            throw CustomException(ErrorCode.INVALID_STATUS_TRANSITION, status, "update")
+        }
         epic?.let { this.epic = it }
         name?.let { this.name = it }
         description?.let { this.description = it }

--- a/src/main/kotlin/com/pluxity/weekly/task/entity/Task.kt
+++ b/src/main/kotlin/com/pluxity/weekly/task/entity/Task.kt
@@ -1,7 +1,9 @@
 package com.pluxity.weekly.task.entity
 
 import com.pluxity.weekly.auth.user.entity.User
+import com.pluxity.weekly.core.constant.ErrorCode
 import com.pluxity.weekly.core.entity.IdentityIdEntity
+import com.pluxity.weekly.core.exception.CustomException
 import com.pluxity.weekly.epic.entity.Epic
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
@@ -38,11 +40,42 @@ class Task(
     @JoinColumn(name = "assignee_id")
     var assignee: User? = null,
 ) : IdentityIdEntity() {
+    fun changeStatus(newStatus: TaskStatus) {
+        if (status == TaskStatus.DONE) {
+            throw CustomException(ErrorCode.INVALID_STATUS_TRANSITION, status, "update")
+        }
+        if (status == TaskStatus.IN_REVIEW || newStatus == TaskStatus.IN_REVIEW || newStatus == TaskStatus.DONE) {
+            throw CustomException(ErrorCode.INVALID_STATUS_TRANSITION, status, newStatus)
+        }
+        status = newStatus
+    }
+
+    fun requestReview() {
+        if (status != TaskStatus.TODO && status != TaskStatus.IN_PROGRESS) {
+            throw CustomException(ErrorCode.INVALID_STATUS_TRANSITION, status, TaskApprovalAction.REVIEW_REQUEST)
+        }
+        status = TaskStatus.IN_REVIEW
+        progress = 100
+    }
+
+    fun approve() {
+        if (status != TaskStatus.IN_REVIEW) {
+            throw CustomException(ErrorCode.INVALID_STATUS_TRANSITION, status, TaskApprovalAction.APPROVE)
+        }
+        status = TaskStatus.DONE
+    }
+
+    fun reject() {
+        if (status != TaskStatus.IN_REVIEW) {
+            throw CustomException(ErrorCode.INVALID_STATUS_TRANSITION, status, TaskApprovalAction.REJECT)
+        }
+        status = TaskStatus.IN_PROGRESS
+    }
+
     fun update(
         epic: Epic? = null,
         name: String? = null,
         description: String? = null,
-        status: TaskStatus? = null,
         progress: Int? = null,
         startDate: LocalDate? = null,
         dueDate: LocalDate? = null,
@@ -51,7 +84,6 @@ class Task(
         epic?.let { this.epic = it }
         name?.let { this.name = it }
         description?.let { this.description = it }
-        status?.let { this.status = it }
         progress?.let { this.progress = it }
         startDate?.let { this.startDate = it }
         dueDate?.let { this.dueDate = it }

--- a/src/main/kotlin/com/pluxity/weekly/task/service/TaskService.kt
+++ b/src/main/kotlin/com/pluxity/weekly/task/service/TaskService.kt
@@ -92,19 +92,11 @@ class TaskService(
         val user = authorizationService.currentUser()
         val task = getTaskById(id)
         authorizationService.requireTaskOwner(user, task)
-        if (task.status == TaskStatus.DONE) {
-            throw CustomException(ErrorCode.INVALID_STATUS_TRANSITION, task.status, "update")
-        }
-        request.status?.let { newStatus ->
-            if (task.status == TaskStatus.IN_REVIEW || newStatus == TaskStatus.IN_REVIEW || newStatus == TaskStatus.DONE) {
-                throw CustomException(ErrorCode.INVALID_STATUS_TRANSITION, task.status, newStatus)
-            }
-        }
+        request.status?.let { task.changeStatus(it) }
         task.update(
             epic = request.epicId?.let { getEpicById(it) },
             name = request.name,
             description = request.description,
-            status = request.status,
             progress = request.progress,
             startDate = request.startDate,
             dueDate = request.dueDate,
@@ -117,10 +109,7 @@ class TaskService(
         val user = authorizationService.currentUser()
         val task = getTaskById(id)
         authorizationService.requireTaskOwner(user, task)
-        if (task.status != TaskStatus.TODO && task.status != TaskStatus.IN_PROGRESS) {
-            throw CustomException(ErrorCode.INVALID_STATUS_TRANSITION, task.status, TaskApprovalAction.REVIEW_REQUEST)
-        }
-        task.update(status = TaskStatus.IN_REVIEW, progress = 100)
+        task.requestReview()
         writeLog(task, user, TaskApprovalAction.REVIEW_REQUEST)
         task.epic.project.pmId?.let { pmId ->
             val card =
@@ -146,10 +135,7 @@ class TaskService(
         val user = authorizationService.currentUser()
         val task = getTaskById(id)
         authorizationService.requireTaskReviewer(user, task)
-        if (task.status != TaskStatus.IN_REVIEW) {
-            throw CustomException(ErrorCode.INVALID_STATUS_TRANSITION, task.status, TaskApprovalAction.APPROVE)
-        }
-        task.update(status = TaskStatus.DONE)
+        task.approve()
         writeLog(task, user, TaskApprovalAction.APPROVE)
         task.assignee?.requiredId?.let { assigneeId ->
             eventPublisher.publishEvent(
@@ -169,11 +155,8 @@ class TaskService(
         val user = authorizationService.currentUser()
         val task = getTaskById(id)
         authorizationService.requireTaskReviewer(user, task)
-        if (task.status != TaskStatus.IN_REVIEW) {
-            throw CustomException(ErrorCode.INVALID_STATUS_TRANSITION, task.status, TaskApprovalAction.REJECT)
-        }
+        task.reject()
         val normalizedReason = reason?.takeIf { it.isNotBlank() }
-        task.update(status = TaskStatus.IN_PROGRESS)
         writeLog(task, user, TaskApprovalAction.REJECT, normalizedReason)
         task.assignee?.requiredId?.let { assigneeId ->
             val suffix = normalizedReason?.let { " 사유: $it" } ?: ""

--- a/src/test/kotlin/com/pluxity/weekly/project/service/ProjectServiceTest.kt
+++ b/src/test/kotlin/com/pluxity/weekly/project/service/ProjectServiceTest.kt
@@ -222,7 +222,7 @@ class ProjectServiceTest :
                         .dummyEpic(id = 2L, status = com.pluxity.weekly.epic.entity.EpicStatus.IN_PROGRESS)
 
                 every { projectRepository.findByIdOrNull(71L) } returns entity
-                every { epicRepository.findByProjectId(71L) } returns listOf(epic1, epic2)
+                every { epicRepository.findByProjectIdIn(listOf(71L)) } returns listOf(epic1, epic2)
 
                 val exception =
                     shouldThrow<CustomException> {
@@ -237,7 +237,7 @@ class ProjectServiceTest :
             When("하위 에픽이 0개인 프로젝트를 status=DONE 으로 변경하려 하면") {
                 val entity = dummyProject(id = 72L, status = ProjectStatus.IN_PROGRESS)
                 every { projectRepository.findByIdOrNull(72L) } returns entity
-                every { epicRepository.findByProjectId(72L) } returns emptyList()
+                every { epicRepository.findByProjectIdIn(listOf(72L)) } returns emptyList()
 
                 val exception =
                     shouldThrow<CustomException> {

--- a/src/test/kotlin/com/pluxity/weekly/project/service/ProjectServiceTest.kt
+++ b/src/test/kotlin/com/pluxity/weekly/project/service/ProjectServiceTest.kt
@@ -82,7 +82,7 @@ class ProjectServiceTest :
                     )
 
                 every { projectRepository.findByIdOrNull(1L) } returns entity
-                every { projectRepository.findMembersByProjectId(1L) } returns emptyList()
+                every { projectRepository.findMembersByProjectIds(listOf(1L)) } returns emptyList()
                 every { userRepository.findByIdOrNull(10L) } returns dummyUser(id = 10L, name = "PM유저")
 
                 val result = service.findById(1L)
@@ -171,7 +171,6 @@ class ProjectServiceTest :
             When("존재하는 프로젝트를 삭제하면") {
                 val entity = dummyProject(id = 1L, name = "삭제대상 프로젝트")
 
-                every { epicRepository.existsByProjectId(1L) } returns false
                 every { projectRepository.findByIdOrNull(1L) } returns entity
                 every { projectRepository.delete(any<Project>()) } just runs
 
@@ -184,7 +183,6 @@ class ProjectServiceTest :
 
             When("존재하지 않는 프로젝트를 삭제하면") {
 
-                every { epicRepository.existsByProjectId(999L) } returns false
                 every { projectRepository.findByIdOrNull(999L) } returns null
 
                 val exception =


### PR DESCRIPTION
## Summary

- Project/Epic/Task entity에 상태 전이 메서드 추가 (`changeStatus`, `requestReview`, `approve`, `reject`)
- Service의 상태 검증 로직을 entity 메서드 호출로 교체
- DONE 상태 entity의 모든 필드 수정 차단 (기존 동작 보존)
- DONE 전이 시에만 하위 항목 조회 쿼리 실행 (불필요 쿼리 제거)
- Repository 중복 메서드 제거: `findMembersByProjectId`, `existsByProjectId`, `findByProjectId`

closes #32
closes #34

## 변경 파일

| 파일 | 변경 |
|---|---|
| `Project.kt` | `changeStatus()` 추가, `update()`에서 status 제거 + DONE 가드 |
| `Epic.kt` | `changeStatus()` 추가, `update()`에서 status 제거 + DONE 가드 |
| `Task.kt` | `changeStatus()`, `requestReview()`, `approve()`, `reject()` 추가, `update()`에서 status 제거 + DONE 가드 |
| `ProjectService.kt` | entity 메서드 호출, `findByProjectIdIn(listOf())` 전환 |
| `EpicService.kt` | entity 메서드 호출 |
| `TaskService.kt` | `requestReview/approve/reject` → entity 메서드 호출 |
| `ProjectRepository.kt` | `findMembersByProjectId` 제거 |
| `EpicRepository.kt` | `existsByProjectId`, `findByProjectId` 제거 |
| `DashboardService.kt` | `findByProjectIdIn(listOf())` 전환 |
| `ProjectServiceTest.kt` | 모킹 수정 |

## Test plan

- [ ] Project status: TODO → IN_PROGRESS → DONE (모든 epic DONE 시만 성공)
- [ ] Epic status: TODO → IN_PROGRESS → DONE (모든 task DONE 시만 성공)
- [ ] Task: changeStatus로 IN_REVIEW/DONE 진입 차단 확인
- [ ] Task: requestReview → approve/reject 흐름 정상 동작
- [ ] DONE 상태 entity에 이름/설명만 수정 시도 → 400 차단
- [ ] 기존 findAll/findById/search 회귀 없음