### PR TITLE
fix: Project/Epic/Task 유효성 체크 보강

### DIFF
--- a/src/main/kotlin/com/pluxity/weekly/core/constant/ErrorCode.kt
+++ b/src/main/kotlin/com/pluxity/weekly/core/constant/ErrorCode.kt
@@ -34,6 +34,7 @@ enum class ErrorCode(
     NOT_FOUND_TASK(HttpStatus.NOT_FOUND, "ID가 %s인 태스크를 찾을 수 없습니다."),
     DUPLICATE_TASK(HttpStatus.BAD_REQUEST, "에픽 '%s'에 이미 '%s' 태스크가 존재합니다."),
     INVALID_STATUS_TRANSITION(HttpStatus.BAD_REQUEST, "상태 %s에서는 %s 동작을 수행할 수 없습니다."),
+    INVALID_DATE_RANGE(HttpStatus.BAD_REQUEST, "시작일(%s)이 마감일(%s)보다 늦을 수 없습니다."),
     EPIC_NOT_ALL_DONE(HttpStatus.BAD_REQUEST, "프로젝트를 완료하려면 모든 하위 에픽을 먼저 완료해야 합니다."),
     TASK_NOT_ALL_DONE(HttpStatus.BAD_REQUEST, "에픽을 완료하려면 모든 하위 태스크를 먼저 완료해야 합니다."),
 

--- a/src/main/kotlin/com/pluxity/weekly/core/constant/ErrorCode.kt
+++ b/src/main/kotlin/com/pluxity/weekly/core/constant/ErrorCode.kt
@@ -34,6 +34,7 @@ enum class ErrorCode(
     NOT_FOUND_TASK(HttpStatus.NOT_FOUND, "ID가 %s인 태스크를 찾을 수 없습니다."),
     DUPLICATE_TASK(HttpStatus.BAD_REQUEST, "에픽 '%s'에 이미 '%s' 태스크가 존재합니다."),
     INVALID_STATUS_TRANSITION(HttpStatus.BAD_REQUEST, "상태 %s에서는 %s 동작을 수행할 수 없습니다."),
+    INVALID_INITIAL_STATUS(HttpStatus.BAD_REQUEST, "%s 상태로는 생성할 수 없습니다."),
     INVALID_DATE_RANGE(HttpStatus.BAD_REQUEST, "시작일(%s)이 마감일(%s)보다 늦을 수 없습니다."),
     EPIC_NOT_ALL_DONE(HttpStatus.BAD_REQUEST, "프로젝트를 완료하려면 모든 하위 에픽을 먼저 완료해야 합니다."),
     TASK_NOT_ALL_DONE(HttpStatus.BAD_REQUEST, "에픽을 완료하려면 모든 하위 태스크를 먼저 완료해야 합니다."),

--- a/src/main/kotlin/com/pluxity/weekly/core/validation/DateRangeValidator.kt
+++ b/src/main/kotlin/com/pluxity/weekly/core/validation/DateRangeValidator.kt
@@ -1,0 +1,14 @@
+package com.pluxity.weekly.core.validation
+
+import com.pluxity.weekly.core.constant.ErrorCode
+import com.pluxity.weekly.core.exception.CustomException
+import java.time.LocalDate
+
+fun validateDateRange(
+    startDate: LocalDate?,
+    dueDate: LocalDate?,
+) {
+    if (startDate != null && dueDate != null && startDate.isAfter(dueDate)) {
+        throw CustomException(ErrorCode.INVALID_DATE_RANGE, startDate, dueDate)
+    }
+}

--- a/src/main/kotlin/com/pluxity/weekly/epic/entity/Epic.kt
+++ b/src/main/kotlin/com/pluxity/weekly/epic/entity/Epic.kt
@@ -84,10 +84,13 @@ class Epic(
         startDate: LocalDate? = null,
         dueDate: LocalDate? = null,
     ) {
+        val nextStartDate = startDate ?: this.startDate
+        val nextDueDate = dueDate ?: this.dueDate
+        validateDateRange(nextStartDate, nextDueDate)
+
         name?.let { this.name = it }
         description?.let { this.description = it }
-        startDate?.let { this.startDate = it }
-        dueDate?.let { this.dueDate = it }
-        validateDateRange(this.startDate, this.dueDate)
+        this.startDate = nextStartDate
+        this.dueDate = nextDueDate
     }
 }

--- a/src/main/kotlin/com/pluxity/weekly/epic/entity/Epic.kt
+++ b/src/main/kotlin/com/pluxity/weekly/epic/entity/Epic.kt
@@ -49,9 +49,9 @@ class Epic(
         validateDateRange(startDate, dueDate)
     }
 
-    fun ensureMutable() {
+    fun ensureMutable(action: String = "update") {
         if (status == EpicStatus.DONE) {
-            throw CustomException(ErrorCode.INVALID_STATUS_TRANSITION, status, "update")
+            throw CustomException(ErrorCode.INVALID_STATUS_TRANSITION, status, action)
         }
     }
 

--- a/src/main/kotlin/com/pluxity/weekly/epic/entity/Epic.kt
+++ b/src/main/kotlin/com/pluxity/weekly/epic/entity/Epic.kt
@@ -4,6 +4,7 @@ import com.pluxity.weekly.auth.user.entity.User
 import com.pluxity.weekly.core.constant.ErrorCode
 import com.pluxity.weekly.core.entity.IdentityIdEntity
 import com.pluxity.weekly.core.exception.CustomException
+import com.pluxity.weekly.core.validation.validateDateRange
 import com.pluxity.weekly.project.entity.Project
 import com.pluxity.weekly.task.entity.Task
 import jakarta.persistence.CascadeType
@@ -44,6 +45,10 @@ class Epic(
     @OneToMany(mappedBy = "epic", cascade = [CascadeType.REMOVE])
     val tasks: MutableList<Task> = mutableListOf()
 
+    init {
+        validateDateRange(startDate, dueDate)
+    }
+
     fun assign(user: User) {
         if (assignments.none { it.user == user }) {
             assignments.add(EpicAssignment(epic = this, user = user))
@@ -80,5 +85,6 @@ class Epic(
         description?.let { this.description = it }
         startDate?.let { this.startDate = it }
         dueDate?.let { this.dueDate = it }
+        validateDateRange(this.startDate, this.dueDate)
     }
 }

--- a/src/main/kotlin/com/pluxity/weekly/epic/entity/Epic.kt
+++ b/src/main/kotlin/com/pluxity/weekly/epic/entity/Epic.kt
@@ -49,6 +49,12 @@ class Epic(
         validateDateRange(startDate, dueDate)
     }
 
+    fun ensureMutable() {
+        if (status == EpicStatus.DONE) {
+            throw CustomException(ErrorCode.INVALID_STATUS_TRANSITION, status, "update")
+        }
+    }
+
     fun assign(user: User) {
         if (assignments.none { it.user == user }) {
             assignments.add(EpicAssignment(epic = this, user = user))

--- a/src/main/kotlin/com/pluxity/weekly/epic/entity/Epic.kt
+++ b/src/main/kotlin/com/pluxity/weekly/epic/entity/Epic.kt
@@ -78,9 +78,6 @@ class Epic(
         startDate: LocalDate? = null,
         dueDate: LocalDate? = null,
     ) {
-        if (status == EpicStatus.DONE) {
-            throw CustomException(ErrorCode.INVALID_STATUS_TRANSITION, status, "update")
-        }
         name?.let { this.name = it }
         description?.let { this.description = it }
         startDate?.let { this.startDate = it }

--- a/src/main/kotlin/com/pluxity/weekly/epic/service/EpicService.kt
+++ b/src/main/kotlin/com/pluxity/weekly/epic/service/EpicService.kt
@@ -66,8 +66,7 @@ class EpicService(
                 ),
             )
         request.userIds?.forEach { userId ->
-            val assignee = getUserById(userId)
-            epic.assign(assignee)
+            assignAndNotify(epic, getUserById(userId))
         }
         return epic.requiredId
     }
@@ -104,23 +103,12 @@ class EpicService(
 
             epic.assignments
                 .filter { it.user !in requestedUsers }
-                .forEach { assignment ->
-                    val removedUserId = assignment.user.requiredId
-                    epic.unassign(assignment.user)
-                    taskRepository.deleteByEpicIdAndAssigneeId(epic.requiredId, removedUserId)
-                    eventPublisher.publishEvent(
-                        TeamsNotificationEvent(removedUserId, "${epic.name} 에픽에서 해제되었습니다"),
-                    )
-                }
+                .map { it.user }
+                .forEach { unassignAndNotify(epic, it) }
 
             requestedUsers
                 .filter { user -> epic.assignments.none { it.user == user } }
-                .forEach { newUser ->
-                    epic.assign(newUser)
-                    eventPublisher.publishEvent(
-                        TeamsNotificationEvent(newUser.requiredId, "${epic.name} 에픽에 배정되었습니다"),
-                    )
-                }
+                .forEach { assignAndNotify(epic, it) }
         }
     }
 
@@ -148,10 +136,7 @@ class EpicService(
         if (epic.assignments.any { it.user == assignee }) {
             throw CustomException(ErrorCode.DUPLICATE_EPIC_ASSIGNMENT, userId, epicId)
         }
-        epic.assign(assignee)
-        eventPublisher.publishEvent(
-            TeamsNotificationEvent(userId, "${epic.name} 에픽에 배정되었습니다"),
-        )
+        assignAndNotify(epic, assignee)
     }
 
     @Transactional
@@ -166,10 +151,27 @@ class EpicService(
         if (epic.assignments.none { it.user == assignee }) {
             throw CustomException(ErrorCode.NOT_FOUND_EPIC_ASSIGNMENT, epicId, userId)
         }
-        epic.unassign(assignee)
-        taskRepository.deleteByEpicIdAndAssigneeId(epicId, userId)
+        unassignAndNotify(epic, assignee)
+    }
+
+    private fun assignAndNotify(
+        epic: Epic,
+        assignee: User,
+    ) {
+        epic.assign(assignee)
         eventPublisher.publishEvent(
-            TeamsNotificationEvent(userId, "${epic.name} 에픽에서 해제되었습니다"),
+            TeamsNotificationEvent(assignee.requiredId, "${epic.name} 에픽에 배정되었습니다"),
+        )
+    }
+
+    private fun unassignAndNotify(
+        epic: Epic,
+        assignee: User,
+    ) {
+        epic.unassign(assignee)
+        taskRepository.deleteByEpicIdAndAssigneeId(epic.requiredId, assignee.requiredId)
+        eventPublisher.publishEvent(
+            TeamsNotificationEvent(assignee.requiredId, "${epic.name} 에픽에서 해제되었습니다"),
         )
     }
 

--- a/src/main/kotlin/com/pluxity/weekly/epic/service/EpicService.kt
+++ b/src/main/kotlin/com/pluxity/weekly/epic/service/EpicService.kt
@@ -133,6 +133,7 @@ class EpicService(
         val user = authorizationService.currentUser()
         authorizationService.requireEpicAssign(user, epicId)
         val epic = getEpicById(epicId)
+        epic.ensureMutable("assign")
         val assignee = getUserById(userId)
         if (epic.assignments.any { it.user == assignee }) {
             throw CustomException(ErrorCode.DUPLICATE_EPIC_ASSIGNMENT, userId, epicId)
@@ -148,6 +149,7 @@ class EpicService(
         val user = authorizationService.currentUser()
         authorizationService.requireEpicAssign(user, epicId)
         val epic = getEpicById(epicId)
+        epic.ensureMutable("unassign")
         val assignee = getUserById(userId)
         if (epic.assignments.none { it.user == assignee }) {
             throw CustomException(ErrorCode.NOT_FOUND_EPIC_ASSIGNMENT, epicId, userId)

--- a/src/main/kotlin/com/pluxity/weekly/epic/service/EpicService.kt
+++ b/src/main/kotlin/com/pluxity/weekly/epic/service/EpicService.kt
@@ -79,6 +79,9 @@ class EpicService(
         val user = authorizationService.currentUser()
         val epic = getEpicById(id)
         authorizationService.requireEpicManage(user, epic.project.requiredId)
+        if (epic.status == EpicStatus.DONE) {
+            throw CustomException(ErrorCode.INVALID_STATUS_TRANSITION, epic.status, "update")
+        }
 
         request.status?.let { newStatus ->
             val allTasksDone =

--- a/src/main/kotlin/com/pluxity/weekly/epic/service/EpicService.kt
+++ b/src/main/kotlin/com/pluxity/weekly/epic/service/EpicService.kt
@@ -50,6 +50,9 @@ class EpicService(
     fun create(request: EpicRequest): Long {
         val user = authorizationService.currentUser()
         authorizationService.requireEpicManage(user, request.projectId)
+        if (request.status == EpicStatus.DONE) {
+            throw CustomException(ErrorCode.INVALID_INITIAL_STATUS, request.status)
+        }
         val project = getProjectById(request.projectId)
         if (project.status == ProjectStatus.DONE) {
             throw CustomException(ErrorCode.INVALID_STATUS_TRANSITION, project.status, "create epic")

--- a/src/main/kotlin/com/pluxity/weekly/epic/service/EpicService.kt
+++ b/src/main/kotlin/com/pluxity/weekly/epic/service/EpicService.kt
@@ -79,9 +79,7 @@ class EpicService(
         val user = authorizationService.currentUser()
         val epic = getEpicById(id)
         authorizationService.requireEpicManage(user, epic.project.requiredId)
-        if (epic.status == EpicStatus.DONE) {
-            throw CustomException(ErrorCode.INVALID_STATUS_TRANSITION, epic.status, "update")
-        }
+        epic.ensureMutable()
 
         request.status?.let { newStatus ->
             val allTasksDone =

--- a/src/main/kotlin/com/pluxity/weekly/project/entity/Project.kt
+++ b/src/main/kotlin/com/pluxity/weekly/project/entity/Project.kt
@@ -60,9 +60,6 @@ class Project(
         dueDate: LocalDate? = null,
         pmId: Long? = null,
     ) {
-        if (status == ProjectStatus.DONE) {
-            throw CustomException(ErrorCode.INVALID_STATUS_TRANSITION, status, "update")
-        }
         name?.let { this.name = it }
         description?.let { this.description = it }
         startDate?.let { this.startDate = it }

--- a/src/main/kotlin/com/pluxity/weekly/project/entity/Project.kt
+++ b/src/main/kotlin/com/pluxity/weekly/project/entity/Project.kt
@@ -66,11 +66,14 @@ class Project(
         dueDate: LocalDate? = null,
         pmId: Long? = null,
     ) {
+        val nextStartDate = startDate ?: this.startDate
+        val nextDueDate = dueDate ?: this.dueDate
+        validateDateRange(nextStartDate, nextDueDate)
+
         name?.let { this.name = it }
         description?.let { this.description = it }
-        startDate?.let { this.startDate = it }
-        dueDate?.let { this.dueDate = it }
+        this.startDate = nextStartDate
+        this.dueDate = nextDueDate
         pmId?.let { this.pmId = it }
-        validateDateRange(this.startDate, this.dueDate)
     }
 }

--- a/src/main/kotlin/com/pluxity/weekly/project/entity/Project.kt
+++ b/src/main/kotlin/com/pluxity/weekly/project/entity/Project.kt
@@ -3,6 +3,7 @@ package com.pluxity.weekly.project.entity
 import com.pluxity.weekly.core.constant.ErrorCode
 import com.pluxity.weekly.core.entity.IdentityIdEntity
 import com.pluxity.weekly.core.exception.CustomException
+import com.pluxity.weekly.core.validation.validateDateRange
 import com.pluxity.weekly.epic.entity.Epic
 import jakarta.persistence.CascadeType
 import jakarta.persistence.Column
@@ -35,6 +36,10 @@ class Project(
     @OneToMany(mappedBy = "project", cascade = [CascadeType.REMOVE])
     val epics: MutableList<Epic> = mutableListOf()
 
+    init {
+        validateDateRange(startDate, dueDate)
+    }
+
     fun changeStatus(
         newStatus: ProjectStatus,
         allEpicsDone: Boolean,
@@ -63,5 +68,6 @@ class Project(
         startDate?.let { this.startDate = it }
         dueDate?.let { this.dueDate = it }
         pmId?.let { this.pmId = it }
+        validateDateRange(this.startDate, this.dueDate)
     }
 }

--- a/src/main/kotlin/com/pluxity/weekly/project/entity/Project.kt
+++ b/src/main/kotlin/com/pluxity/weekly/project/entity/Project.kt
@@ -40,6 +40,12 @@ class Project(
         validateDateRange(startDate, dueDate)
     }
 
+    fun ensureMutable() {
+        if (status == ProjectStatus.DONE) {
+            throw CustomException(ErrorCode.INVALID_STATUS_TRANSITION, status, "update")
+        }
+    }
+
     fun changeStatus(
         newStatus: ProjectStatus,
         allEpicsDone: Boolean,

--- a/src/main/kotlin/com/pluxity/weekly/project/service/ProjectService.kt
+++ b/src/main/kotlin/com/pluxity/weekly/project/service/ProjectService.kt
@@ -54,6 +54,9 @@ class ProjectService(
     fun create(request: ProjectRequest): Long {
         val user = authorizationService.currentUser()
         authorizationService.requireAdmin(user)
+        if (request.status == ProjectStatus.DONE) {
+            throw CustomException(ErrorCode.INVALID_INITIAL_STATUS, request.status)
+        }
         request.pmId?.let { ensurePmExists(it) }
         return projectRepository
             .save(

--- a/src/main/kotlin/com/pluxity/weekly/project/service/ProjectService.kt
+++ b/src/main/kotlin/com/pluxity/weekly/project/service/ProjectService.kt
@@ -54,6 +54,7 @@ class ProjectService(
     fun create(request: ProjectRequest): Long {
         val user = authorizationService.currentUser()
         authorizationService.requireAdmin(user)
+        request.pmId?.let { ensurePmExists(it) }
         return projectRepository
             .save(
                 Project(
@@ -75,6 +76,7 @@ class ProjectService(
         val user = authorizationService.currentUser()
         authorizationService.requireProjectManager(user, id)
         val project = getById(id)
+        request.pmId?.let { ensurePmExists(it) }
 
         request.status?.let { newStatus ->
             val allEpicsDone =
@@ -107,6 +109,12 @@ class ProjectService(
     private fun getById(id: Long): Project =
         projectRepository.findByIdOrNull(id)
             ?: throw CustomException(ErrorCode.NOT_FOUND_PROJECT, id)
+
+    private fun ensurePmExists(pmId: Long) {
+        if (!userRepository.existsById(pmId)) {
+            throw CustomException(ErrorCode.NOT_FOUND_USER, pmId)
+        }
+    }
 
     private fun resolvePmNames(pmIds: List<Long>): Map<Long, String> =
         if (pmIds.isEmpty()) {

--- a/src/main/kotlin/com/pluxity/weekly/project/service/ProjectService.kt
+++ b/src/main/kotlin/com/pluxity/weekly/project/service/ProjectService.kt
@@ -76,6 +76,9 @@ class ProjectService(
         val user = authorizationService.currentUser()
         authorizationService.requireProjectManager(user, id)
         val project = getById(id)
+        if (project.status == ProjectStatus.DONE) {
+            throw CustomException(ErrorCode.INVALID_STATUS_TRANSITION, project.status, "update")
+        }
         request.pmId?.let { ensurePmExists(it) }
 
         request.status?.let { newStatus ->

--- a/src/main/kotlin/com/pluxity/weekly/project/service/ProjectService.kt
+++ b/src/main/kotlin/com/pluxity/weekly/project/service/ProjectService.kt
@@ -76,9 +76,7 @@ class ProjectService(
         val user = authorizationService.currentUser()
         authorizationService.requireProjectManager(user, id)
         val project = getById(id)
-        if (project.status == ProjectStatus.DONE) {
-            throw CustomException(ErrorCode.INVALID_STATUS_TRANSITION, project.status, "update")
-        }
+        project.ensureMutable()
         request.pmId?.let { ensurePmExists(it) }
 
         request.status?.let { newStatus ->

--- a/src/main/kotlin/com/pluxity/weekly/task/entity/Task.kt
+++ b/src/main/kotlin/com/pluxity/weekly/task/entity/Task.kt
@@ -91,12 +91,15 @@ class Task(
         dueDate: LocalDate? = null,
         assignee: User? = null,
     ) {
+        val nextStartDate = startDate ?: this.startDate
+        val nextDueDate = dueDate ?: this.dueDate
+        validateDateRange(nextStartDate, nextDueDate)
+
         name?.let { this.name = it }
         description?.let { this.description = it }
         progress?.let { this.progress = it }
-        startDate?.let { this.startDate = it }
-        dueDate?.let { this.dueDate = it }
+        this.startDate = nextStartDate
+        this.dueDate = nextDueDate
         assignee?.let { this.assignee = it }
-        validateDateRange(this.startDate, this.dueDate)
     }
 }

--- a/src/main/kotlin/com/pluxity/weekly/task/entity/Task.kt
+++ b/src/main/kotlin/com/pluxity/weekly/task/entity/Task.kt
@@ -85,9 +85,6 @@ class Task(
         dueDate: LocalDate? = null,
         assignee: User? = null,
     ) {
-        if (status == TaskStatus.DONE) {
-            throw CustomException(ErrorCode.INVALID_STATUS_TRANSITION, status, "update")
-        }
         name?.let { this.name = it }
         description?.let { this.description = it }
         progress?.let { this.progress = it }

--- a/src/main/kotlin/com/pluxity/weekly/task/entity/Task.kt
+++ b/src/main/kotlin/com/pluxity/weekly/task/entity/Task.kt
@@ -45,6 +45,12 @@ class Task(
         validateDateRange(startDate, dueDate)
     }
 
+    fun ensureMutable() {
+        if (status == TaskStatus.DONE) {
+            throw CustomException(ErrorCode.INVALID_STATUS_TRANSITION, status, "update")
+        }
+    }
+
     fun changeStatus(newStatus: TaskStatus) {
         if (status == TaskStatus.DONE) {
             throw CustomException(ErrorCode.INVALID_STATUS_TRANSITION, status, "update")

--- a/src/main/kotlin/com/pluxity/weekly/task/entity/Task.kt
+++ b/src/main/kotlin/com/pluxity/weekly/task/entity/Task.kt
@@ -4,6 +4,7 @@ import com.pluxity.weekly.auth.user.entity.User
 import com.pluxity.weekly.core.constant.ErrorCode
 import com.pluxity.weekly.core.entity.IdentityIdEntity
 import com.pluxity.weekly.core.exception.CustomException
+import com.pluxity.weekly.core.validation.validateDateRange
 import com.pluxity.weekly.epic.entity.Epic
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
@@ -40,6 +41,10 @@ class Task(
     @JoinColumn(name = "assignee_id")
     var assignee: User? = null,
 ) : IdentityIdEntity() {
+    init {
+        validateDateRange(startDate, dueDate)
+    }
+
     fun changeStatus(newStatus: TaskStatus) {
         if (status == TaskStatus.DONE) {
             throw CustomException(ErrorCode.INVALID_STATUS_TRANSITION, status, "update")
@@ -89,5 +94,6 @@ class Task(
         startDate?.let { this.startDate = it }
         dueDate?.let { this.dueDate = it }
         assignee?.let { this.assignee = it }
+        validateDateRange(this.startDate, this.dueDate)
     }
 }

--- a/src/main/kotlin/com/pluxity/weekly/task/service/TaskService.kt
+++ b/src/main/kotlin/com/pluxity/weekly/task/service/TaskService.kt
@@ -94,6 +94,9 @@ class TaskService(
         val user = authorizationService.currentUser()
         val task = getTaskById(id)
         authorizationService.requireTaskOwner(user, task)
+        if (task.status == TaskStatus.DONE) {
+            throw CustomException(ErrorCode.INVALID_STATUS_TRANSITION, task.status, "update")
+        }
         request.status?.let { task.changeStatus(it) }
         request.name?.takeIf { it != task.name }?.let { newName ->
             if (taskRepository.existsByEpicIdAndName(task.epic.requiredId, newName)) {

--- a/src/main/kotlin/com/pluxity/weekly/task/service/TaskService.kt
+++ b/src/main/kotlin/com/pluxity/weekly/task/service/TaskService.kt
@@ -66,7 +66,7 @@ class TaskService(
         epic.ensureMutable("create task")
         ensureUniqueTaskName(request.epicId, request.name)
         val newAssigneeId = request.assigneeId?.takeIf { it != user.requiredId }
-        ensureAssigneeInEpic(user, newAssigneeId, epic)
+        autoAssignIfMissing(user, newAssigneeId, epic)
         return taskRepository
             .save(
                 Task(
@@ -96,7 +96,7 @@ class TaskService(
             ensureUniqueTaskName(task.epic.requiredId, newName)
         }
         val newAssigneeId = request.assigneeId?.takeIf { it != task.assignee?.requiredId }
-        ensureAssigneeInEpic(user, newAssigneeId, task.epic)
+        autoAssignIfMissing(user, newAssigneeId, task.epic)
         task.update(
             name = request.name,
             description = request.description,
@@ -254,7 +254,7 @@ class TaskService(
         }
     }
 
-    private fun ensureAssigneeInEpic(
+    private fun autoAssignIfMissing(
         actor: User,
         assigneeId: Long?,
         epic: Epic,

--- a/src/main/kotlin/com/pluxity/weekly/task/service/TaskService.kt
+++ b/src/main/kotlin/com/pluxity/weekly/task/service/TaskService.kt
@@ -63,12 +63,8 @@ class TaskService(
         val user = authorizationService.currentUser()
         authorizationService.requireEpicAccess(user, request.epicId)
         val epic = getEpicById(request.epicId)
-        if (epic.status == EpicStatus.DONE) {
-            throw CustomException(ErrorCode.INVALID_STATUS_TRANSITION, epic.status, "create task")
-        }
-        if (taskRepository.existsByEpicIdAndName(request.epicId, request.name)) {
-            throw CustomException(ErrorCode.DUPLICATE_TASK, request.epicId, request.name)
-        }
+        epic.ensureMutable("create task")
+        ensureUniqueTaskName(request.epicId, request.name)
         val newAssigneeId = request.assigneeId?.takeIf { it != user.requiredId }
         ensureAssigneeInEpic(user, newAssigneeId, epic)
         return taskRepository
@@ -97,9 +93,7 @@ class TaskService(
         task.ensureMutable()
         request.status?.let { task.changeStatus(it) }
         request.name?.takeIf { it != task.name }?.let { newName ->
-            if (taskRepository.existsByEpicIdAndName(task.epic.requiredId, newName)) {
-                throw CustomException(ErrorCode.DUPLICATE_TASK, task.epic.requiredId, newName)
-            }
+            ensureUniqueTaskName(task.epic.requiredId, newName)
         }
         val newAssigneeId = request.assigneeId?.takeIf { it != task.assignee?.requiredId }
         ensureAssigneeInEpic(user, newAssigneeId, task.epic)
@@ -249,6 +243,15 @@ class TaskService(
         val task = getTaskById(id)
         authorizationService.requireTaskOwner(user, task)
         taskRepository.delete(task)
+    }
+
+    private fun ensureUniqueTaskName(
+        epicId: Long,
+        name: String,
+    ) {
+        if (taskRepository.existsByEpicIdAndName(epicId, name)) {
+            throw CustomException(ErrorCode.DUPLICATE_TASK, epicId, name)
+        }
     }
 
     private fun ensureAssigneeInEpic(

--- a/src/main/kotlin/com/pluxity/weekly/task/service/TaskService.kt
+++ b/src/main/kotlin/com/pluxity/weekly/task/service/TaskService.kt
@@ -69,6 +69,12 @@ class TaskService(
         if (taskRepository.existsByEpicIdAndName(request.epicId, request.name)) {
             throw CustomException(ErrorCode.DUPLICATE_TASK, request.epicId, request.name)
         }
+        val newAssigneeId = request.assigneeId?.takeIf { it != user.requiredId }
+        if (newAssigneeId != null) {
+            authorizationService.requireAdminOrPm(user)
+            ensureAssigneeInEpic(newAssigneeId, epic)
+        }
+        val assignee = request.assigneeId?.let { getUserById(it) } ?: user
         return taskRepository
             .save(
                 Task(
@@ -79,7 +85,7 @@ class TaskService(
                     progress = request.progress,
                     startDate = request.startDate,
                     dueDate = request.dueDate,
-                    assignee = request.assigneeId?.let { getUserById(it) } ?: user,
+                    assignee = assignee,
                 ),
             ).requiredId
     }

--- a/src/main/kotlin/com/pluxity/weekly/task/service/TaskService.kt
+++ b/src/main/kotlin/com/pluxity/weekly/task/service/TaskService.kt
@@ -74,7 +74,7 @@ class TaskService(
             authorizationService.requireAdminOrPm(user)
             ensureAssigneeInEpic(newAssigneeId, epic)
         }
-        val assignee = request.assigneeId?.let { getUserById(it) } ?: user
+        val assignee = newAssigneeId?.let { getUserById(it) } ?: user
         return taskRepository
             .save(
                 Task(

--- a/src/main/kotlin/com/pluxity/weekly/task/service/TaskService.kt
+++ b/src/main/kotlin/com/pluxity/weekly/task/service/TaskService.kt
@@ -71,7 +71,6 @@ class TaskService(
         }
         val newAssigneeId = request.assigneeId?.takeIf { it != user.requiredId }
         ensureAssigneeInEpic(user, newAssigneeId, epic)
-        val assignee = newAssigneeId?.let { getUserById(it) } ?: user
         return taskRepository
             .save(
                 Task(
@@ -82,7 +81,7 @@ class TaskService(
                     progress = request.progress,
                     startDate = request.startDate,
                     dueDate = request.dueDate,
-                    assignee = assignee,
+                    assignee = newAssigneeId?.let { getUserById(it) } ?: user,
                 ),
             ).requiredId
     }
@@ -96,6 +95,11 @@ class TaskService(
         val task = getTaskById(id)
         authorizationService.requireTaskOwner(user, task)
         request.status?.let { task.changeStatus(it) }
+        request.name?.takeIf { it != task.name }?.let { newName ->
+            if (taskRepository.existsByEpicIdAndName(task.epic.requiredId, newName)) {
+                throw CustomException(ErrorCode.DUPLICATE_TASK, task.epic.requiredId, newName)
+            }
+        }
         val newAssigneeId = request.assigneeId?.takeIf { it != task.assignee?.requiredId }
         ensureAssigneeInEpic(user, newAssigneeId, task.epic)
         task.update(

--- a/src/main/kotlin/com/pluxity/weekly/task/service/TaskService.kt
+++ b/src/main/kotlin/com/pluxity/weekly/task/service/TaskService.kt
@@ -70,10 +70,7 @@ class TaskService(
             throw CustomException(ErrorCode.DUPLICATE_TASK, request.epicId, request.name)
         }
         val newAssigneeId = request.assigneeId?.takeIf { it != user.requiredId }
-        if (newAssigneeId != null) {
-            authorizationService.requireAdminOrPm(user)
-            ensureAssigneeInEpic(newAssigneeId, epic)
-        }
+        ensureAssigneeInEpic(user, newAssigneeId, epic)
         val assignee = newAssigneeId?.let { getUserById(it) } ?: user
         return taskRepository
             .save(
@@ -100,10 +97,7 @@ class TaskService(
         authorizationService.requireTaskOwner(user, task)
         request.status?.let { task.changeStatus(it) }
         val newAssigneeId = request.assigneeId?.takeIf { it != task.assignee?.requiredId }
-        if (newAssigneeId != null) {
-            authorizationService.requireAdminOrPm(user)
-            ensureAssigneeInEpic(newAssigneeId, task.epic)
-        }
+        ensureAssigneeInEpic(user, newAssigneeId, task.epic)
         task.update(
             name = request.name,
             description = request.description,
@@ -253,9 +247,12 @@ class TaskService(
     }
 
     private fun ensureAssigneeInEpic(
-        assigneeId: Long,
+        actor: User,
+        assigneeId: Long?,
         epic: Epic,
     ) {
+        if (assigneeId == null) return
+        authorizationService.requireAdminOrPm(actor)
         if (!epicRepository.existsByAssignmentsUserIdAndId(assigneeId, epic.requiredId)) {
             val assignee = getUserById(assigneeId)
             epic.assign(assignee)

--- a/src/main/kotlin/com/pluxity/weekly/task/service/TaskService.kt
+++ b/src/main/kotlin/com/pluxity/weekly/task/service/TaskService.kt
@@ -94,9 +94,7 @@ class TaskService(
         val user = authorizationService.currentUser()
         val task = getTaskById(id)
         authorizationService.requireTaskOwner(user, task)
-        if (task.status == TaskStatus.DONE) {
-            throw CustomException(ErrorCode.INVALID_STATUS_TRANSITION, task.status, "update")
-        }
+        task.ensureMutable()
         request.status?.let { task.changeStatus(it) }
         request.name?.takeIf { it != task.name }?.let { newName ->
             if (taskRepository.existsByEpicIdAndName(task.epic.requiredId, newName)) {

--- a/src/main/kotlin/com/pluxity/weekly/task/service/TaskService.kt
+++ b/src/main/kotlin/com/pluxity/weekly/task/service/TaskService.kt
@@ -62,6 +62,9 @@ class TaskService(
     fun create(request: TaskRequest): Long {
         val user = authorizationService.currentUser()
         authorizationService.requireEpicAccess(user, request.epicId)
+        if (request.status != TaskStatus.TODO) {
+            throw CustomException(ErrorCode.INVALID_INITIAL_STATUS, request.status)
+        }
         val epic = getEpicById(request.epicId)
         epic.ensureMutable("create task")
         ensureUniqueTaskName(request.epicId, request.name)

--- a/src/test/kotlin/com/pluxity/weekly/epic/dto/DummyDTOs.kt
+++ b/src/test/kotlin/com/pluxity/weekly/epic/dto/DummyDTOs.kt
@@ -10,6 +10,7 @@ fun dummyEpicRequest(
     status: EpicStatus = EpicStatus.TODO,
     startDate: LocalDate? = null,
     dueDate: LocalDate? = null,
+    userIds: List<Long>? = null,
 ) = EpicRequest(
     projectId = projectId,
     name = name,
@@ -17,6 +18,7 @@ fun dummyEpicRequest(
     status = status,
     startDate = startDate,
     dueDate = dueDate,
+    userIds = userIds,
 )
 
 fun dummyEpicUpdateRequest(

--- a/src/test/kotlin/com/pluxity/weekly/epic/service/EpicServiceTest.kt
+++ b/src/test/kotlin/com/pluxity/weekly/epic/service/EpicServiceTest.kt
@@ -139,6 +139,33 @@ class EpicServiceTest :
                 }
             }
 
+            When("userIds와 함께 생성하면 각 사용자에게 배정 알림이 발행된다") {
+                val project = dummyProject(id = 1L)
+                val request =
+                    dummyEpicRequest(
+                        projectId = 1L,
+                        name = "알림 에픽",
+                        userIds = listOf(11L, 22L),
+                    )
+                val savedEpic = dummyEpic(id = 7L, project = project, name = "알림 에픽")
+                val u1 = dummyUser(id = 11L, name = "유저1")
+                val u2 = dummyUser(id = 22L, name = "유저2")
+
+                every { projectRepository.findByIdOrNull(1L) } returns project
+                every { epicRepository.save(any<Epic>()) } returns savedEpic
+                every { userRepository.findByIdOrNull(11L) } returns u1
+                every { userRepository.findByIdOrNull(22L) } returns u2
+                every { eventPublisher.publishEvent(any<TeamsNotificationEvent>()) } just runs
+
+                service.create(request)
+
+                Then("두 사용자 모두 epic에 배정되고 알림이 발행된다") {
+                    savedEpic.assignments.map { it.user } shouldBe listOf(u1, u2)
+                    verify { eventPublisher.publishEvent(match<TeamsNotificationEvent> { it.userId == 11L && it.message.contains("배정") }) }
+                    verify { eventPublisher.publishEvent(match<TeamsNotificationEvent> { it.userId == 22L && it.message.contains("배정") }) }
+                }
+            }
+
             When("startDate가 dueDate보다 늦게 생성하면") {
                 val project = dummyProject(id = 1L)
                 val request =

--- a/src/test/kotlin/com/pluxity/weekly/epic/service/EpicServiceTest.kt
+++ b/src/test/kotlin/com/pluxity/weekly/epic/service/EpicServiceTest.kt
@@ -138,6 +138,28 @@ class EpicServiceTest :
                     result shouldBe 1L
                 }
             }
+
+            When("startDate가 dueDate보다 늦게 생성하면") {
+                val project = dummyProject(id = 1L)
+                val request =
+                    dummyEpicRequest(
+                        projectId = 1L,
+                        name = "날짜 역전",
+                        startDate = LocalDate.of(2026, 6, 1),
+                        dueDate = LocalDate.of(2026, 5, 1),
+                    )
+
+                every { projectRepository.findByIdOrNull(1L) } returns project
+
+                val exception =
+                    shouldThrow<CustomException> {
+                        service.create(request)
+                    }
+
+                Then("INVALID_DATE_RANGE 예외가 발생한다") {
+                    exception.code shouldBe ErrorCode.INVALID_DATE_RANGE
+                }
+            }
         }
 
         Given("에픽 수정") {
@@ -170,6 +192,31 @@ class EpicServiceTest :
 
                 Then("NOT_FOUND 예외가 발생한다") {
                     exception.code shouldBe ErrorCode.NOT_FOUND_EPIC
+                }
+            }
+
+            When("기존 dueDate보다 늦은 startDate로 수정하면") {
+                val project = dummyProject(id = 1L)
+                val entity =
+                    dummyEpic(
+                        id = 80L,
+                        project = project,
+                        startDate = LocalDate.of(2026, 1, 1),
+                        dueDate = LocalDate.of(2026, 3, 1),
+                    )
+
+                every { epicRepository.findByIdOrNull(80L) } returns entity
+
+                val exception =
+                    shouldThrow<CustomException> {
+                        service.update(
+                            80L,
+                            dummyEpicUpdateRequest(startDate = LocalDate.of(2026, 4, 1)),
+                        )
+                    }
+
+                Then("INVALID_DATE_RANGE 예외가 발생한다") {
+                    exception.code shouldBe ErrorCode.INVALID_DATE_RANGE
                 }
             }
         }

--- a/src/test/kotlin/com/pluxity/weekly/project/service/ProjectServiceTest.kt
+++ b/src/test/kotlin/com/pluxity/weekly/project/service/ProjectServiceTest.kt
@@ -122,12 +122,46 @@ class ProjectServiceTest :
                     )
                 val saved = dummyProject(id = 1L, name = "신규 프로젝트", pmId = 5L)
 
+                every { userRepository.existsById(5L) } returns true
                 every { projectRepository.save(any<Project>()) } returns saved
 
                 val result = service.create(request)
 
                 Then("생성된 프로젝트의 ID가 반환된다") {
                     result shouldBe 1L
+                }
+            }
+
+            When("존재하지 않는 pmId로 생성하면") {
+                val request = dummyProjectRequest(name = "pm없음", pmId = 999L)
+
+                every { userRepository.existsById(999L) } returns false
+
+                val exception =
+                    shouldThrow<CustomException> {
+                        service.create(request)
+                    }
+
+                Then("NOT_FOUND_USER 예외가 발생한다") {
+                    exception.code shouldBe ErrorCode.NOT_FOUND_USER
+                }
+            }
+
+            When("startDate가 dueDate보다 늦게 생성하면") {
+                val request =
+                    dummyProjectRequest(
+                        name = "날짜 역전",
+                        startDate = LocalDate.of(2026, 6, 1),
+                        dueDate = LocalDate.of(2026, 5, 1),
+                    )
+
+                val exception =
+                    shouldThrow<CustomException> {
+                        service.create(request)
+                    }
+
+                Then("INVALID_DATE_RANGE 예외가 발생한다") {
+                    exception.code shouldBe ErrorCode.INVALID_DATE_RANGE
                 }
             }
         }
@@ -143,6 +177,7 @@ class ProjectServiceTest :
                     )
 
                 every { projectRepository.findByIdOrNull(1L) } returns entity
+                every { userRepository.existsById(10L) } returns true
 
                 service.update(1L, request)
 
@@ -163,6 +198,45 @@ class ProjectServiceTest :
 
                 Then("NOT_FOUND 예외가 발생한다") {
                     exception.code shouldBe ErrorCode.NOT_FOUND_PROJECT
+                }
+            }
+
+            When("존재하지 않는 pmId로 수정하면") {
+                val entity = dummyProject(id = 1L, name = "기존")
+                every { projectRepository.findByIdOrNull(1L) } returns entity
+                every { userRepository.existsById(888L) } returns false
+
+                val exception =
+                    shouldThrow<CustomException> {
+                        service.update(1L, dummyProjectUpdateRequest(pmId = 888L))
+                    }
+
+                Then("NOT_FOUND_USER 예외가 발생한다") {
+                    exception.code shouldBe ErrorCode.NOT_FOUND_USER
+                }
+            }
+
+            When("기존 dueDate보다 늦은 startDate로 수정하면") {
+                val entity =
+                    dummyProject(
+                        id = 80L,
+                        name = "기존",
+                        startDate = LocalDate.of(2026, 1, 1),
+                        dueDate = LocalDate.of(2026, 3, 1),
+                    )
+
+                every { projectRepository.findByIdOrNull(80L) } returns entity
+
+                val exception =
+                    shouldThrow<CustomException> {
+                        service.update(
+                            80L,
+                            dummyProjectUpdateRequest(startDate = LocalDate.of(2026, 4, 1)),
+                        )
+                    }
+
+                Then("INVALID_DATE_RANGE 예외가 발생한다") {
+                    exception.code shouldBe ErrorCode.INVALID_DATE_RANGE
                 }
             }
         }

--- a/src/test/kotlin/com/pluxity/weekly/task/dto/DummyDTOs.kt
+++ b/src/test/kotlin/com/pluxity/weekly/task/dto/DummyDTOs.kt
@@ -11,6 +11,7 @@ fun dummyTaskRequest(
     progress: Int = 0,
     startDate: LocalDate? = null,
     dueDate: LocalDate? = null,
+    assigneeId: Long? = null,
 ) = TaskRequest(
     epicId = epicId,
     name = name,
@@ -19,6 +20,7 @@ fun dummyTaskRequest(
     progress = progress,
     startDate = startDate,
     dueDate = dueDate,
+    assigneeId = assigneeId,
 )
 
 fun dummyTaskUpdateRequest(

--- a/src/test/kotlin/com/pluxity/weekly/task/service/TaskServiceTest.kt
+++ b/src/test/kotlin/com/pluxity/weekly/task/service/TaskServiceTest.kt
@@ -163,6 +163,123 @@ class TaskServiceTest :
             }
         }
 
+        Given("태스크 생성 시 assignee epic 배정 검증") {
+            When("ADMIN/PM이 다른 사용자를 assignee로 지정하면 epic에 자동 배정된다") {
+                val epic = dummyEpic(id = 5L)
+                val newAssignee = dummyUser(id = 30L, name = "신규 담당자")
+                val request = dummyTaskRequest(epicId = 5L, name = "자동배정 create", assigneeId = 30L)
+                val saved =
+                    dummyTask(id = 100L, epic = epic, name = "자동배정 create").apply {
+                        this.assignee = newAssignee
+                    }
+
+                every { epicRepository.findByIdOrNull(5L) } returns epic
+                every { taskRepository.existsByEpicIdAndName(5L, request.name) } returns false
+                every { authorizationService.requireAdminOrPm(any()) } just runs
+                every { epicRepository.existsByAssignmentsUserIdAndId(30L, 5L) } returns false
+                every { userRepository.findByIdOrNull(30L) } returns newAssignee
+                every { taskRepository.save(any<Task>()) } returns saved
+
+                service.create(request)
+
+                Then("epic에 자동 배정되고 알림이 발행된다") {
+                    epic.assignments.any { it.user == newAssignee } shouldBe true
+                    verify { eventPublisher.publishEvent(match<TeamsNotificationEvent> { it.userId == 30L }) }
+                }
+            }
+
+            When("일반 사용자가 다른 사용자를 assignee로 지정하면 권한 거부") {
+                val epic = dummyEpic(id = 9L)
+                val request = dummyTaskRequest(epicId = 9L, name = "권한없음 create", assigneeId = 50L)
+
+                every { epicRepository.findByIdOrNull(9L) } returns epic
+                every { taskRepository.existsByEpicIdAndName(9L, request.name) } returns false
+                every { authorizationService.requireAdminOrPm(any()) } throws CustomException(ErrorCode.PERMISSION_DENIED)
+
+                val exception =
+                    shouldThrow<CustomException> {
+                        service.create(request)
+                    }
+
+                Then("PERMISSION_DENIED 예외가 발생한다") {
+                    exception.code shouldBe ErrorCode.PERMISSION_DENIED
+                }
+            }
+
+            When("assigneeId가 현재 로그인 사용자와 같으면 권한 체크/자동배정을 건너뛴다") {
+                val epic = dummyEpic(id = 6L)
+                val request = dummyTaskRequest(epicId = 6L, name = "본인 지정", assigneeId = 1L)
+                val saved =
+                    dummyTask(id = 101L, epic = epic, name = "본인 지정").apply {
+                        this.assignee = adminUser
+                    }
+
+                every { epicRepository.findByIdOrNull(6L) } returns epic
+                every { taskRepository.existsByEpicIdAndName(6L, request.name) } returns false
+                every { userRepository.findByIdOrNull(1L) } returns adminUser
+                every { taskRepository.save(any<Task>()) } returns saved
+
+                service.create(request)
+
+                Then("requireAdminOrPm 호출되지 않고 epic에 자동 배정도 되지 않는다") {
+                    verify(exactly = 0) { authorizationService.requireAdminOrPm(any()) }
+                    verify(exactly = 0) { epicRepository.existsByAssignmentsUserIdAndId(1L, 6L) }
+                }
+            }
+        }
+
+        Given("태스크 생성 시 날짜 검증") {
+            When("startDate가 dueDate보다 늦게 생성하면") {
+                val epic = dummyEpic(id = 7L)
+                val request =
+                    dummyTaskRequest(
+                        epicId = 7L,
+                        name = "날짜 역전",
+                        startDate = LocalDate.of(2026, 6, 1),
+                        dueDate = LocalDate.of(2026, 5, 1),
+                    )
+
+                every { epicRepository.findByIdOrNull(7L) } returns epic
+                every { taskRepository.existsByEpicIdAndName(7L, request.name) } returns false
+
+                val exception =
+                    shouldThrow<CustomException> {
+                        service.create(request)
+                    }
+
+                Then("INVALID_DATE_RANGE 예외가 발생한다") {
+                    exception.code shouldBe ErrorCode.INVALID_DATE_RANGE
+                }
+            }
+        }
+
+        Given("태스크 수정 시 날짜 검증") {
+            When("기존 dueDate보다 늦은 startDate로 수정하면") {
+                val epic = dummyEpic(id = 8L)
+                val entity =
+                    dummyTask(
+                        id = 80L,
+                        epic = epic,
+                        startDate = LocalDate.of(2026, 1, 1),
+                        dueDate = LocalDate.of(2026, 3, 1),
+                    )
+
+                every { taskRepository.findWithEpicAndProjectById(80L) } returns entity
+
+                val exception =
+                    shouldThrow<CustomException> {
+                        service.update(
+                            80L,
+                            dummyTaskUpdateRequest(startDate = LocalDate.of(2026, 4, 1)),
+                        )
+                    }
+
+                Then("INVALID_DATE_RANGE 예외가 발생한다") {
+                    exception.code shouldBe ErrorCode.INVALID_DATE_RANGE
+                }
+            }
+        }
+
         Given("DONE 에픽에 태스크 생성 차단") {
             When("DONE 상태 에픽에 태스크를 생성하려 하면") {
                 val doneEpic = dummyEpic(id = 99L, status = com.pluxity.weekly.epic.entity.EpicStatus.DONE)

--- a/src/test/kotlin/com/pluxity/weekly/task/service/TaskServiceTest.kt
+++ b/src/test/kotlin/com/pluxity/weekly/task/service/TaskServiceTest.kt
@@ -309,6 +309,7 @@ class TaskServiceTest :
                     )
 
                 every { taskRepository.findWithEpicAndProjectById(1L) } returns entity
+                every { taskRepository.existsByEpicIdAndName(1L, "수정된 태스크") } returns false
 
                 service.update(1L, request)
 
@@ -329,6 +330,38 @@ class TaskServiceTest :
 
                 Then("NOT_FOUND 예외가 발생한다") {
                     exception.code shouldBe ErrorCode.NOT_FOUND_TASK
+                }
+            }
+
+            When("같은 epic의 다른 태스크 이름으로 수정하면") {
+                val epic = dummyEpic(id = 1L)
+                val entity = dummyTask(id = 50L, epic = epic, name = "원본")
+
+                every { taskRepository.findWithEpicAndProjectById(50L) } returns entity
+                every { taskRepository.existsByEpicIdAndName(1L, "중복") } returns true
+
+                val exception =
+                    shouldThrow<CustomException> {
+                        service.update(50L, dummyTaskUpdateRequest(name = "중복"))
+                    }
+
+                Then("DUPLICATE_TASK 예외가 발생한다") {
+                    exception.code shouldBe ErrorCode.DUPLICATE_TASK
+                }
+            }
+
+            When("본인 이름과 동일한 이름으로 수정하면") {
+                val epic = dummyEpic(id = 1L)
+                val entity = dummyTask(id = 51L, epic = epic, name = "변경없음")
+
+                every { taskRepository.findWithEpicAndProjectById(51L) } returns entity
+
+                service.update(51L, dummyTaskUpdateRequest(name = "변경없음"))
+
+                Then("중복 체크 쿼리가 호출되지 않는다") {
+                    verify(exactly = 0) {
+                        taskRepository.existsByEpicIdAndName(any(), any())
+                    }
                 }
             }
         }
@@ -689,6 +722,7 @@ class TaskServiceTest :
             When("현재 상태가 DONE 인 태스크를 update 로 수정하려 하면") {
                 val entity = dummyTask(id = 42L, status = TaskStatus.DONE, name = "완료된 태스크")
                 every { taskRepository.findWithEpicAndProjectById(42L) } returns entity
+                every { taskRepository.existsByEpicIdAndName(any(), any()) } returns false
 
                 val exception =
                     shouldThrow<CustomException> {

--- a/src/test/kotlin/com/pluxity/weekly/task/service/TaskServiceTest.kt
+++ b/src/test/kotlin/com/pluxity/weekly/task/service/TaskServiceTest.kt
@@ -209,21 +209,20 @@ class TaskServiceTest :
             When("assigneeId가 현재 로그인 사용자와 같으면 권한 체크/자동배정을 건너뛴다") {
                 val epic = dummyEpic(id = 6L)
                 val request = dummyTaskRequest(epicId = 6L, name = "본인 지정", assigneeId = 1L)
-                val saved =
-                    dummyTask(id = 101L, epic = epic, name = "본인 지정").apply {
-                        this.assignee = adminUser
-                    }
+                val savedSlot = slot<Task>()
+                val saved = dummyTask(id = 101L, epic = epic, name = "본인 지정")
 
                 every { epicRepository.findByIdOrNull(6L) } returns epic
                 every { taskRepository.existsByEpicIdAndName(6L, request.name) } returns false
-                every { userRepository.findByIdOrNull(1L) } returns adminUser
-                every { taskRepository.save(any<Task>()) } returns saved
+                every { taskRepository.save(capture(savedSlot)) } returns saved
 
                 service.create(request)
 
-                Then("requireAdminOrPm 호출되지 않고 epic에 자동 배정도 되지 않는다") {
+                Then("권한 체크/자동배정 없이 currentUser가 assignee로 설정된다") {
                     verify(exactly = 0) { authorizationService.requireAdminOrPm(any()) }
                     verify(exactly = 0) { epicRepository.existsByAssignmentsUserIdAndId(1L, 6L) }
+                    verify(exactly = 0) { userRepository.findByIdOrNull(1L) }
+                    savedSlot.captured.assignee shouldBe adminUser
                 }
             }
         }


### PR DESCRIPTION
## Summary
이슈 #33 작업.

- **Project pmId 존재 검증**: `ProjectService.create`/`update`에서 `pmId` 전달 시 `userRepository.existsById` 체크 후 `NOT_FOUND_USER` throw
- **공통 날짜 범위 검증**: Project/Epic/Task entity에 `validateDateRange` 적용 (init + update). `startDate > dueDate`이면 `INVALID_DATE_RANGE` throw
  - 신규 ErrorCode `INVALID_DATE_RANGE` 추가
  - `core/validation/DateRangeValidator.kt` 공통 유틸 도입
- **Task create assignee epic 배정 검증**: update와 동일 패턴 적용
  - `assigneeId`가 현재 로그인 사용자와 다를 때만 `requireAdminOrPm` + `ensureAssigneeInEpic` 호출
  - epic 미배정 사용자면 자동 배정 + Teams 알림

Closes #33

## Test plan
- [x] `ProjectServiceTest`
  - pmId 존재 검증 (create/update 각각)
  - 날짜 역전 차단 (create/update 각각)
- [x] `EpicServiceTest`
  - 날짜 역전 차단 (create/update 각각)
- [x] `TaskServiceTest`
  - 날짜 역전 차단 (create/update 각각)
  - assignee 자동 배정 (ADMIN/PM)
  - 권한 없는 사용자가 다른 사용자 지정 시 PERMISSION_DENIED
  - 본인 지정 시 권한 체크/배정 검증 건너뜀
- [x] 전체 테스트 통과
- [x] spotless 검증 통과