### PR TITLE
feat: clarify 세션 기반 /resolve 엔드포인트 추가

### DIFF
--- a/promptfoo/promptfooconfig.yaml
+++ b/promptfoo/promptfooconfig.yaml
@@ -138,7 +138,7 @@ tests:
   ## assign / unassign
   - description: "[intent] 에픽 배정"
     vars:
-      userMessage: "OO 에픽에 OO 할당해줘"
+      userMessage: "대시보드 에픽에 홍길동 할당해줘"
     prompts: [intent]
     assert:
       - type: is-json
@@ -147,7 +147,7 @@ tests:
 
   - description: "[intent] 에픽 배정 해제"
     vars:
-      userMessage: "OO 에픽에서 OO 빼줘"
+      userMessage: "대시보드 에픽에서 홍길동 빼줘"
     prompts: [intent]
     assert:
       - type: is-json
@@ -260,19 +260,6 @@ tests:
         value: |
           const o = JSON.parse(output);
           return o.actions.includes('create') && o.target === 'task';
-
-  ## clarify 후속 응답 - 이전 clarify에서 target/actions 이어받기
-  - description: "[intent-history] clarify 후 프로젝트명 보충 → assign 이어받기"
-    vars:
-      userMessage: "SAFERS 프로젝트"
-      history: "--- 히스토리 #1 | 질문: 대시보드 에픽에 OO 할당해줘 | target: epic | actions: [assign] | 결과: clarify: '대시보드' 에픽이 여러 프로젝트에 있습니다 ---"
-    prompts: [intent]
-    assert:
-      - type: is-json
-      - type: javascript
-        value: |
-          const o = JSON.parse(output);
-          return o.actions.includes('assign') && o.target === 'epic' && o.project === 'SAFERS';
 
   # ──────────────────────────────────────
   # system-prompt tests (fixture: 스마트팩토리/모바일POS/사내포털)
@@ -516,4 +503,21 @@ tests:
           const arr = JSON.parse(output);
           const o = arr[0];
           return o.action === 'clarify' && !!o.message;
+
+  ## assign - 동명 에픽 + user 미지정 (복수 미확정 → missing_fields는 id 1개만)
+  - description: "[system] 복수 미확정 → missing_fields는 id 1개만"
+    vars:
+      userMessage: "대시보드 에픽에 할당해줘"
+      intent: '{"actions":["assign"],"target":"epic"}'
+    prompts: [system]
+    assert:
+      - type: is-json
+      - type: javascript
+        value: |
+          const arr = JSON.parse(output);
+          const o = arr[0];
+          return o.action === 'assign' && o.target === 'epic' &&
+            o.missing_fields && o.missing_fields.length === 1 &&
+            o.missing_fields[0] === 'id' &&
+            o.candidates && o.candidates.length >= 2;
 

--- a/src/main/kotlin/com/pluxity/weekly/auth/authorization/AuthorizationService.kt
+++ b/src/main/kotlin/com/pluxity/weekly/auth/authorization/AuthorizationService.kt
@@ -2,6 +2,8 @@ package com.pluxity.weekly.auth.authorization
 
 import com.pluxity.weekly.auth.user.entity.User
 import com.pluxity.weekly.auth.user.service.UserService
+import com.pluxity.weekly.chat.dto.ChatActionType
+import com.pluxity.weekly.chat.dto.ChatTarget
 import com.pluxity.weekly.core.constant.ErrorCode
 import com.pluxity.weekly.core.exception.CustomException
 import com.pluxity.weekly.epic.repository.EpicRepository
@@ -112,15 +114,16 @@ class AuthorizationService(
     /** target + action 조합의 사전 권한 체크 — Chat context 빌드 전 호출 */
     fun checkChatPermission(
         user: User,
-        target: String,
-        actions: List<String>,
+        target: ChatTarget,
+        actions: List<ChatActionType>,
     ) {
-        val hasMutation = actions.any { it in listOf("create", "update", "delete", "assign", "unassign") }
+        val hasMutation = actions.any { it.isMutating }
         if (!hasMutation) return
 
         when (target) {
-            "project" -> if ("create" in actions) requireAdmin(user) else requireAdminOrPm(user)
-            "epic" -> requireAdminOrPm(user)
+            ChatTarget.PROJECT -> if (ChatActionType.CREATE in actions) requireAdmin(user) else requireAdminOrPm(user)
+            ChatTarget.EPIC -> requireAdminOrPm(user)
+            else -> Unit
         }
     }
 

--- a/src/main/kotlin/com/pluxity/weekly/chat/context/ContextBuilder.kt
+++ b/src/main/kotlin/com/pluxity/weekly/chat/context/ContextBuilder.kt
@@ -3,6 +3,8 @@ package com.pluxity.weekly.chat.context
 import com.pluxity.weekly.auth.authorization.AuthorizationService
 import com.pluxity.weekly.auth.user.entity.User
 import com.pluxity.weekly.auth.user.repository.UserRepository
+import com.pluxity.weekly.chat.dto.ChatActionType
+import com.pluxity.weekly.chat.dto.ChatTarget
 import com.pluxity.weekly.chat.dto.EpicSearchFilter
 import com.pluxity.weekly.chat.dto.ProjectSearchFilter
 import com.pluxity.weekly.chat.dto.TaskSearchFilter
@@ -44,8 +46,8 @@ class ContextBuilder(
     private val objectMapper: ObjectMapper,
 ) {
     fun build(
-        target: String,
-        actions: List<String>,
+        target: ChatTarget,
+        actions: List<ChatActionType>,
     ): String {
         val user = authorizationService.currentUser()
 
@@ -55,15 +57,15 @@ class ContextBuilder(
         val todayDayOfWeek = LocalDate.now().dayOfWeek.getDisplayName(TextStyle.FULL, Locale.KOREAN)
         val userRef = UserRef(id = user.requiredId, name = user.name)
 
-        val hasCreateOnly = "create" in actions && "update" !in actions
-        val excludeDone = "update" in actions || "delete" in actions
+        val hasCreateOnly = ChatActionType.CREATE in actions && ChatActionType.UPDATE !in actions
+        val excludeDone = ChatActionType.UPDATE in actions || ChatActionType.DELETE in actions
 
         val context: ChatContext =
             when (target) {
-                "project" -> buildProjectContext(today, todayDayOfWeek, userRef, excludeDone)
-                "epic" -> buildEpicContext(today, todayDayOfWeek, userRef, excludeDone)
-                "team" -> buildTeamContext(today, todayDayOfWeek, userRef)
-                else -> buildTaskContext(today, todayDayOfWeek, userRef, hasCreateOnly, excludeDone)
+                ChatTarget.PROJECT -> buildProjectContext(today, todayDayOfWeek, userRef, excludeDone)
+                ChatTarget.EPIC -> buildEpicContext(today, todayDayOfWeek, userRef, excludeDone)
+                ChatTarget.TEAM -> buildTeamContext(today, todayDayOfWeek, userRef)
+                ChatTarget.TASK, ChatTarget.REVIEW -> buildTaskContext(today, todayDayOfWeek, userRef, hasCreateOnly, excludeDone)
             }
 
         return objectMapper.writeValueAsString(context)

--- a/src/main/kotlin/com/pluxity/weekly/chat/controller/ChatController.kt
+++ b/src/main/kotlin/com/pluxity/weekly/chat/controller/ChatController.kt
@@ -2,6 +2,8 @@ package com.pluxity.weekly.chat.controller
 
 import com.pluxity.weekly.chat.dto.ChatActionResponse
 import com.pluxity.weekly.chat.dto.ChatRequest
+import com.pluxity.weekly.chat.dto.ChatResolveRequest
+import com.pluxity.weekly.chat.service.ChatResolveService
 import com.pluxity.weekly.chat.service.ChatService
 import com.pluxity.weekly.core.response.DataResponseBody
 import com.pluxity.weekly.core.response.ErrorResponseBody
@@ -23,6 +25,7 @@ import org.springframework.web.bind.annotation.RestController
 @Tag(name = "Chat Controller", description = "자연어 채팅 CRUD API")
 class ChatController(
     private val chatService: ChatService,
+    private val chatResolveService: ChatResolveService,
 ) {
     @Operation(summary = "채팅 메시지 전송", description = "자연어 메시지를 분석하여 폼 조립용 JSON을 반환합니다")
     @ApiResponses(
@@ -40,6 +43,28 @@ class ChatController(
         @RequestBody @Valid request: ChatRequest,
     ): ResponseEntity<DataResponseBody<List<ChatActionResponse>>> {
         val response = chatService.chat(request.message)
+        return ResponseEntity.ok(DataResponseBody(response))
+    }
+
+    @Operation(
+        summary = "clarify 세션 해결",
+        description = "CHAT_SELECT_REQUIRED 응답의 clarifyId에 대해 누락 필드 값을 제공하여 액션을 완성합니다.",
+    )
+    @ApiResponses(
+        value = [
+            ApiResponse(responseCode = "200", description = "처리 성공"),
+            ApiResponse(
+                responseCode = "400",
+                description = "세션 만료/누락 또는 추가 clarify 필요",
+                content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponseBody::class))],
+            ),
+        ],
+    )
+    @PostMapping("/resolve")
+    fun resolve(
+        @RequestBody @Valid request: ChatResolveRequest,
+    ): ResponseEntity<DataResponseBody<ChatActionResponse>> {
+        val response = chatResolveService.resolve(request)
         return ResponseEntity.ok(DataResponseBody(response))
     }
 }

--- a/src/main/kotlin/com/pluxity/weekly/chat/dto/ChatActionType.kt
+++ b/src/main/kotlin/com/pluxity/weekly/chat/dto/ChatActionType.kt
@@ -1,0 +1,26 @@
+package com.pluxity.weekly.chat.dto
+
+import com.pluxity.weekly.chat.exception.ChatClarifyException
+
+enum class ChatActionType(
+    val key: String,
+    val requiredFields: List<String> = emptyList(),
+    val validatesMissingFields: Boolean = true,
+    val isMutating: Boolean = false,
+) {
+    READ("read", validatesMissingFields = false),
+    CLARIFY("clarify"),
+    CREATE("create", validatesMissingFields = false, isMutating = true),
+    UPDATE("update", requiredFields = listOf("id"), isMutating = true),
+    DELETE("delete", requiredFields = listOf("id"), isMutating = true),
+    REVIEW_REQUEST("review_request", requiredFields = listOf("id"), isMutating = true),
+    ASSIGN("assign", requiredFields = listOf("id", "user_ids"), isMutating = true),
+    UNASSIGN("unassign", requiredFields = listOf("id", "remove_user_ids"), isMutating = true),
+    ;
+
+    companion object {
+        fun from(key: String?): ChatActionType =
+            entries.firstOrNull { it.key == key }
+                ?: throw ChatClarifyException(message = "지원하지 않는 요청입니다.")
+    }
+}

--- a/src/main/kotlin/com/pluxity/weekly/chat/dto/ChatActionType.kt
+++ b/src/main/kotlin/com/pluxity/weekly/chat/dto/ChatActionType.kt
@@ -19,8 +19,9 @@ enum class ChatActionType(
     ;
 
     companion object {
+        fun fromOrNull(key: String?): ChatActionType? = entries.firstOrNull { it.key == key }
+
         fun from(key: String?): ChatActionType =
-            entries.firstOrNull { it.key == key }
-                ?: throw ChatClarifyException(message = "지원하지 않는 요청입니다.")
+            fromOrNull(key) ?: throw ChatClarifyException(message = "지원하지 않는 요청입니다.")
     }
 }

--- a/src/main/kotlin/com/pluxity/weekly/chat/dto/ChatResolveRequest.kt
+++ b/src/main/kotlin/com/pluxity/weekly/chat/dto/ChatResolveRequest.kt
@@ -1,0 +1,16 @@
+package com.pluxity.weekly.chat.dto
+
+import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.constraints.NotBlank
+
+@Schema(description = "clarify 세션 해결 요청")
+data class ChatResolveRequest(
+    @field:Schema(description = "clarify 응답에서 발급된 clarifyId", example = "abc-123")
+    @field:NotBlank
+    val clarifyId: String,
+    @field:Schema(description = "채울 필드명", example = "id")
+    @field:NotBlank
+    val field: String,
+    @field:Schema(description = "Long 리스트 값", example = "[1,2]")
+    val values: List<Long>? = null,
+)

--- a/src/main/kotlin/com/pluxity/weekly/chat/dto/ChatTarget.kt
+++ b/src/main/kotlin/com/pluxity/weekly/chat/dto/ChatTarget.kt
@@ -1,0 +1,19 @@
+package com.pluxity.weekly.chat.dto
+
+import com.pluxity.weekly.chat.exception.ChatClarifyException
+
+enum class ChatTarget(val key: String) {
+    TASK("task"),
+    EPIC("epic"),
+    PROJECT("project"),
+    TEAM("team"),
+    REVIEW("review"),
+    ;
+
+    companion object {
+        fun fromOrNull(key: String?): ChatTarget? = entries.firstOrNull { it.key == key }
+
+        fun from(key: String?): ChatTarget =
+            fromOrNull(key) ?: throw ChatClarifyException(message = "지원하지 않는 대상입니다.")
+    }
+}

--- a/src/main/kotlin/com/pluxity/weekly/chat/dto/LlmAction.kt
+++ b/src/main/kotlin/com/pluxity/weekly/chat/dto/LlmAction.kt
@@ -38,3 +38,13 @@ data class LlmAction(
     val missingFields: List<String>? = null,
     val candidates: List<Long>? = null,
 )
+
+fun LlmAction.hasValueFor(field: String): Boolean =
+    when (field) {
+        "id" -> id != null
+        "project_id" -> projectId != null
+        "epic_id" -> epicId != null
+        "user_ids" -> !userIds.isNullOrEmpty()
+        "remove_user_ids" -> !removeUserIds.isNullOrEmpty()
+        else -> false
+    }

--- a/src/main/kotlin/com/pluxity/weekly/chat/exception/ChatResolveInvalidException.kt
+++ b/src/main/kotlin/com/pluxity/weekly/chat/exception/ChatResolveInvalidException.kt
@@ -1,0 +1,8 @@
+package com.pluxity.weekly.chat.exception
+
+import com.pluxity.weekly.core.constant.ErrorCode
+import com.pluxity.weekly.core.exception.CustomException
+
+class ChatResolveInvalidException(
+    message: String,
+) : CustomException(ErrorCode.CHAT_RESOLVE_INVALID, message)

--- a/src/main/kotlin/com/pluxity/weekly/chat/exception/ChatSelectRequiredException.kt
+++ b/src/main/kotlin/com/pluxity/weekly/chat/exception/ChatSelectRequiredException.kt
@@ -1,0 +1,12 @@
+package com.pluxity.weekly.chat.exception
+
+import com.pluxity.weekly.chat.dto.Candidate
+import com.pluxity.weekly.core.constant.ErrorCode
+import com.pluxity.weekly.core.exception.CustomException
+
+class ChatSelectRequiredException(
+    message: String,
+    val clarifyId: String,
+    val field: String,
+    val candidates: List<Candidate>,
+) : CustomException(ErrorCode.CHAT_SELECT_REQUIRED, message)

--- a/src/main/kotlin/com/pluxity/weekly/chat/exception/ChatSessionExpiredException.kt
+++ b/src/main/kotlin/com/pluxity/weekly/chat/exception/ChatSessionExpiredException.kt
@@ -3,6 +3,4 @@ package com.pluxity.weekly.chat.exception
 import com.pluxity.weekly.core.constant.ErrorCode
 import com.pluxity.weekly.core.exception.CustomException
 
-class ChatClarifyException(
-    message: String,
-) : CustomException(ErrorCode.CHAT_CLARIFY, message)
+class ChatSessionExpiredException : CustomException(ErrorCode.CHAT_SESSION_EXPIRED)

--- a/src/main/kotlin/com/pluxity/weekly/chat/service/ChatActionRouter.kt
+++ b/src/main/kotlin/com/pluxity/weekly/chat/service/ChatActionRouter.kt
@@ -2,8 +2,10 @@ package com.pluxity.weekly.chat.service
 
 import com.pluxity.weekly.auth.authorization.AuthorizationService
 import com.pluxity.weekly.chat.dto.ChatActionResponse
+import com.pluxity.weekly.chat.dto.ChatActionType
 import com.pluxity.weekly.chat.dto.ChatDto
 import com.pluxity.weekly.chat.dto.LlmAction
+import com.pluxity.weekly.chat.dto.hasValueFor
 import com.pluxity.weekly.chat.exception.ChatClarifyException
 import com.pluxity.weekly.chat.exception.ChatSelectRequiredException
 import com.pluxity.weekly.epic.service.EpicService
@@ -27,97 +29,100 @@ class ChatActionRouter(
     private val projectService: ProjectService,
 ) {
     fun route(action: LlmAction): ChatActionResponse {
+        val type = ChatActionType.from(action.action)
         val target = action.target ?: "task"
-        return when {
-            action.action == "read" ->
+        validate(action, type, target)
+
+        return when (type) {
+            ChatActionType.READ ->
                 ChatActionResponse(
-                    action = action.action,
+                    action = type.key,
                     target = target,
                     readResult = chatReadHandler.handle(action),
                 )
-            action.action == "clarify" -> throw ChatClarifyException(
-                message = action.message ?: "좀 더 구체적으로 말씀해주세요.",
-            )
-            target == "team" && action.action != "read" -> throw ChatClarifyException(
-                message = "팀 관리는 웹페이지에서 이용해주세요.",
-            )
-            action.action == "create" -> {
-                val selectFields = selectFieldResolver.resolve(action)
-                val dto = chatDtoMapper.toDto(action)
+            ChatActionType.CREATE, ChatActionType.UPDATE ->
+                buildDtoResponse(action, type, target)
+            ChatActionType.DELETE,
+            ChatActionType.REVIEW_REQUEST,
+            ChatActionType.ASSIGN,
+            ChatActionType.UNASSIGN,
+            ->
                 ChatActionResponse(
-                    action = action.action,
+                    action = type.key,
                     target = target,
-                    dto = dto,
-                    selectFields = selectFields.ifEmpty { null },
+                    id = chatExecutor.execute(action),
                 )
-            }
-            action.id == null ||
-                (
-                    action.action in listOf("delete", "review_request", "assign", "unassign") &&
-                        !action.missingFields.isNullOrEmpty()
-                ) ||
-                (action.action == "assign" && action.userIds.isNullOrEmpty()) ||
-                (action.action == "unassign" && action.removeUserIds.isNullOrEmpty()) ->
-                throwSelectOrClarify(action)
-            action.action == "update" -> {
-                val selectFields = selectFieldResolver.resolve(action)
-                val existing = loadExistingDto(target, action.id)
-                val changes = chatDtoMapper.toDto(action)
-                val dto = if (existing != null && changes != null) chatDtoMapper.merge(existing, changes) else changes
-                ChatActionResponse(
-                    action = action.action,
-                    target = target,
-                    id = action.id,
-                    dto = dto,
-                    selectFields = selectFields.ifEmpty { null },
-                )
-            }
-            else -> {
-                val resultId = chatExecutor.execute(action)
-                ChatActionResponse(
-                    action = action.action,
-                    target = target,
-                    id = resultId,
-                )
-            }
+            ChatActionType.CLARIFY -> error("CLARIFY는 validate에서 이미 처리됨")
         }
     }
 
-    private fun throwSelectOrClarify(action: LlmAction): Nothing {
+    private fun validate(
+        action: LlmAction,
+        type: ChatActionType,
+        target: String,
+    ) {
+        if (type == ChatActionType.CLARIFY) {
+            throw ChatClarifyException(action.message ?: "좀 더 구체적으로 말씀해주세요.")
+        }
+        if (target == "team" && type != ChatActionType.READ) {
+            throw ChatClarifyException("팀 관리는 웹페이지에서 이용해주세요.")
+        }
+        if (type.validatesMissingFields && !action.missingFields.isNullOrEmpty()) {
+            if (action.missingFields.size > 1) {
+                log.warn { "LLM이 복수 missingFields 반환: ${action.missingFields} — [0]만 사용" }
+            }
+            throwSelectOrClarify(action, action.missingFields.first())
+        }
+        type.requiredFields.firstOrNull { !action.hasValueFor(it) }?.let { missing ->
+            throwSelectOrClarify(action, missing)
+        }
+    }
+
+    private fun throwSelectOrClarify(
+        action: LlmAction,
+        field: String,
+    ): Nothing {
         val message = action.message ?: "대상을 특정할 수 없습니다."
-        val missingFields = action.missingFields
-        if ((missingFields?.size ?: 0) > 1) {
-            log.warn { "LLM이 복수 missingFields 반환: $missingFields — [0]만 사용" }
-        }
+        val resolved = selectFieldResolver.resolveCandidates(field, action)
+        if (resolved.isEmpty()) throw ChatClarifyException(message)
 
-        val field = missingFields?.firstOrNull() ?: nextMissingField(action)
-        if (field != null) {
-            val resolved = selectFieldResolver.resolveCandidates(field, action)
-            if (resolved.isNotEmpty()) {
-                val userId = authorizationService.currentUser().requiredId
-                val normalized =
-                    action.copy(
-                        missingFields = listOf(field),
-                        candidates = resolved.mapNotNull { it.id.toLongOrNull() },
-                    )
-                val clarifyId = clarifyStore.save(userId, normalized)
-                throw ChatSelectRequiredException(
-                    message = message,
-                    clarifyId = clarifyId,
-                    field = field,
-                    candidates = resolved,
-                )
-            }
-        }
-        throw ChatClarifyException(message)
+        val userId = authorizationService.currentUser().requiredId
+        val normalized =
+            action.copy(
+                missingFields = listOf(field),
+                candidates = resolved.mapNotNull { it.id.toLongOrNull() },
+            )
+        val clarifyId = clarifyStore.save(userId, normalized)
+        throw ChatSelectRequiredException(
+            message = message,
+            clarifyId = clarifyId,
+            field = field,
+            candidates = resolved,
+        )
     }
 
-    private fun nextMissingField(action: LlmAction): String? =
-        when (action.action) {
-            "assign" if action.userIds.isNullOrEmpty() -> "user_ids"
-            "unassign" if action.removeUserIds.isNullOrEmpty() -> "remove_user_ids"
-            else -> null
-        }
+    private fun buildDtoResponse(
+        action: LlmAction,
+        type: ChatActionType,
+        target: String,
+    ): ChatActionResponse {
+        val selectFields = selectFieldResolver.resolve(action)
+        val changes = chatDtoMapper.toDto(action)
+        val dto =
+            if (type == ChatActionType.UPDATE && action.id != null) {
+                val existing = loadExistingDto(target, action.id)
+                if (existing != null && changes != null) chatDtoMapper.merge(existing, changes) else changes
+            } else {
+                changes
+            }
+        return ChatActionResponse(
+            action = type.key,
+            target = target,
+            id = if (type == ChatActionType.UPDATE) action.id else null,
+            dto = dto,
+            selectFields = selectFields.ifEmpty { null },
+        )
+    }
 
     private fun loadExistingDto(
         target: String,

--- a/src/main/kotlin/com/pluxity/weekly/chat/service/ChatActionRouter.kt
+++ b/src/main/kotlin/com/pluxity/weekly/chat/service/ChatActionRouter.kt
@@ -93,7 +93,7 @@ class ChatActionRouter(
                 log.warn { "LLM이 복수 missingFields 반환: $missingFields — [0]만 사용" }
             }
             val field = missingFields[0]
-            val resolved = selectFieldResolver.resolveCandidates(field, action.target, candidates)
+            val resolved = selectFieldResolver.resolveCandidates(field, action)
             if (resolved.isNotEmpty()) {
                 val userId = authorizationService.currentUser().requiredId
                 val normalized = action.copy(missingFields = listOf(field))

--- a/src/main/kotlin/com/pluxity/weekly/chat/service/ChatActionRouter.kt
+++ b/src/main/kotlin/com/pluxity/weekly/chat/service/ChatActionRouter.kt
@@ -9,7 +9,10 @@ import com.pluxity.weekly.chat.exception.ChatSelectRequiredException
 import com.pluxity.weekly.epic.service.EpicService
 import com.pluxity.weekly.project.service.ProjectService
 import com.pluxity.weekly.task.service.TaskService
+import io.github.oshai.kotlinlogging.KotlinLogging
 import org.springframework.stereotype.Component
+
+private val log = KotlinLogging.logger {}
 
 @Component
 class ChatActionRouter(
@@ -85,12 +88,16 @@ class ChatActionRouter(
         val missingFields = action.missingFields
         val candidates = action.candidates
 
-        if (!candidates.isNullOrEmpty() && missingFields?.size == 1) {
+        if (!candidates.isNullOrEmpty() && !missingFields.isNullOrEmpty()) {
+            if (missingFields.size > 1) {
+                log.warn { "LLM이 복수 missingFields 반환: $missingFields — [0]만 사용" }
+            }
             val field = missingFields[0]
             val resolved = selectFieldResolver.resolveCandidates(field, action.target, candidates)
             if (resolved.isNotEmpty()) {
                 val userId = authorizationService.currentUser().requiredId
-                val clarifyId = clarifyStore.save(userId, action)
+                val normalized = action.copy(missingFields = listOf(field))
+                val clarifyId = clarifyStore.save(userId, normalized)
                 throw ChatSelectRequiredException(
                     message = message,
                     clarifyId = clarifyId,

--- a/src/main/kotlin/com/pluxity/weekly/chat/service/ChatActionRouter.kt
+++ b/src/main/kotlin/com/pluxity/weekly/chat/service/ChatActionRouter.kt
@@ -86,17 +86,20 @@ class ChatActionRouter(
     private fun throwSelectOrClarify(action: LlmAction): Nothing {
         val message = action.message ?: "대상을 특정할 수 없습니다."
         val missingFields = action.missingFields
-        val candidates = action.candidates
+        if ((missingFields?.size ?: 0) > 1) {
+            log.warn { "LLM이 복수 missingFields 반환: $missingFields — [0]만 사용" }
+        }
 
-        if (!candidates.isNullOrEmpty() && !missingFields.isNullOrEmpty()) {
-            if (missingFields.size > 1) {
-                log.warn { "LLM이 복수 missingFields 반환: $missingFields — [0]만 사용" }
-            }
-            val field = missingFields[0]
+        val field = missingFields?.firstOrNull() ?: nextMissingField(action)
+        if (field != null) {
             val resolved = selectFieldResolver.resolveCandidates(field, action)
             if (resolved.isNotEmpty()) {
                 val userId = authorizationService.currentUser().requiredId
-                val normalized = action.copy(missingFields = listOf(field))
+                val normalized =
+                    action.copy(
+                        missingFields = listOf(field),
+                        candidates = resolved.mapNotNull { it.id.toLongOrNull() },
+                    )
                 val clarifyId = clarifyStore.save(userId, normalized)
                 throw ChatSelectRequiredException(
                     message = message,
@@ -108,6 +111,13 @@ class ChatActionRouter(
         }
         throw ChatClarifyException(message)
     }
+
+    private fun nextMissingField(action: LlmAction): String? =
+        when (action.action) {
+            "assign" if action.userIds.isNullOrEmpty() -> "user_ids"
+            "unassign" if action.removeUserIds.isNullOrEmpty() -> "remove_user_ids"
+            else -> null
+        }
 
     private fun loadExistingDto(
         target: String,

--- a/src/main/kotlin/com/pluxity/weekly/chat/service/ChatActionRouter.kt
+++ b/src/main/kotlin/com/pluxity/weekly/chat/service/ChatActionRouter.kt
@@ -4,6 +4,7 @@ import com.pluxity.weekly.auth.authorization.AuthorizationService
 import com.pluxity.weekly.chat.dto.ChatActionResponse
 import com.pluxity.weekly.chat.dto.ChatActionType
 import com.pluxity.weekly.chat.dto.ChatDto
+import com.pluxity.weekly.chat.dto.ChatTarget
 import com.pluxity.weekly.chat.dto.LlmAction
 import com.pluxity.weekly.chat.dto.hasValueFor
 import com.pluxity.weekly.chat.exception.ChatClarifyException
@@ -30,14 +31,14 @@ class ChatActionRouter(
 ) {
     fun route(action: LlmAction): ChatActionResponse {
         val type = ChatActionType.from(action.action)
-        val target = action.target ?: "task"
+        val target = ChatTarget.fromOrNull(action.target) ?: ChatTarget.TASK
         validate(action, type, target)
 
         return when (type) {
             ChatActionType.READ ->
                 ChatActionResponse(
                     action = type.key,
-                    target = target,
+                    target = target.key,
                     readResult = chatReadHandler.handle(action),
                 )
             ChatActionType.CREATE, ChatActionType.UPDATE ->
@@ -49,7 +50,7 @@ class ChatActionRouter(
             ->
                 ChatActionResponse(
                     action = type.key,
-                    target = target,
+                    target = target.key,
                     id = chatExecutor.execute(action),
                 )
             ChatActionType.CLARIFY -> error("CLARIFY는 validate에서 이미 처리됨")
@@ -59,12 +60,12 @@ class ChatActionRouter(
     private fun validate(
         action: LlmAction,
         type: ChatActionType,
-        target: String,
+        target: ChatTarget,
     ) {
         if (type == ChatActionType.CLARIFY) {
             throw ChatClarifyException(action.message ?: "좀 더 구체적으로 말씀해주세요.")
         }
-        if (target == "team" && type != ChatActionType.READ) {
+        if (target == ChatTarget.TEAM && type != ChatActionType.READ) {
             throw ChatClarifyException("팀 관리는 웹페이지에서 이용해주세요.")
         }
         if (type.validatesMissingFields && !action.missingFields.isNullOrEmpty()) {
@@ -104,7 +105,7 @@ class ChatActionRouter(
     private fun buildDtoResponse(
         action: LlmAction,
         type: ChatActionType,
-        target: String,
+        target: ChatTarget,
     ): ChatActionResponse {
         val selectFields = selectFieldResolver.resolve(action)
         val changes = chatDtoMapper.toDto(action)
@@ -117,7 +118,7 @@ class ChatActionRouter(
             }
         return ChatActionResponse(
             action = type.key,
-            target = target,
+            target = target.key,
             id = if (type == ChatActionType.UPDATE) action.id else null,
             dto = dto,
             selectFields = selectFields.ifEmpty { null },
@@ -125,13 +126,13 @@ class ChatActionRouter(
     }
 
     private fun loadExistingDto(
-        target: String,
+        target: ChatTarget,
         id: Long,
     ): ChatDto? =
         when (target) {
-            "task" -> chatDtoMapper.fromTaskResponse(taskService.findById(id))
-            "epic" -> chatDtoMapper.fromEpicResponse(epicService.findById(id))
-            "project" -> chatDtoMapper.fromProjectResponse(projectService.findById(id))
-            else -> null
+            ChatTarget.TASK -> chatDtoMapper.fromTaskResponse(taskService.findById(id))
+            ChatTarget.EPIC -> chatDtoMapper.fromEpicResponse(epicService.findById(id))
+            ChatTarget.PROJECT -> chatDtoMapper.fromProjectResponse(projectService.findById(id))
+            ChatTarget.TEAM, ChatTarget.REVIEW -> null
         }
 }

--- a/src/main/kotlin/com/pluxity/weekly/chat/service/ChatActionRouter.kt
+++ b/src/main/kotlin/com/pluxity/weekly/chat/service/ChatActionRouter.kt
@@ -1,9 +1,11 @@
 package com.pluxity.weekly.chat.service
 
+import com.pluxity.weekly.auth.authorization.AuthorizationService
 import com.pluxity.weekly.chat.dto.ChatActionResponse
 import com.pluxity.weekly.chat.dto.ChatDto
 import com.pluxity.weekly.chat.dto.LlmAction
 import com.pluxity.weekly.chat.exception.ChatClarifyException
+import com.pluxity.weekly.chat.exception.ChatSelectRequiredException
 import com.pluxity.weekly.epic.service.EpicService
 import com.pluxity.weekly.project.service.ProjectService
 import com.pluxity.weekly.task.service.TaskService
@@ -15,6 +17,8 @@ class ChatActionRouter(
     private val chatExecutor: ChatExecutor,
     private val chatDtoMapper: ChatDtoMapper,
     private val selectFieldResolver: SelectFieldResolver,
+    private val clarifyStore: ClarifyStore,
+    private val authorizationService: AuthorizationService,
     private val taskService: TaskService,
     private val epicService: EpicService,
     private val projectService: ProjectService,
@@ -51,7 +55,7 @@ class ChatActionRouter(
                 ) ||
                 (action.action == "assign" && action.userIds.isNullOrEmpty()) ||
                 (action.action == "unassign" && action.removeUserIds.isNullOrEmpty()) ->
-                throw buildClarifyException(action)
+                throwSelectOrClarify(action)
             action.action == "update" -> {
                 val selectFields = selectFieldResolver.resolve(action)
                 val existing = loadExistingDto(target, action.id)
@@ -76,27 +80,26 @@ class ChatActionRouter(
         }
     }
 
-    private fun buildClarifyException(action: LlmAction): ChatClarifyException {
-        val base = action.message ?: "대상을 특정할 수 없습니다."
-        val candidates = action.candidates
+    private fun throwSelectOrClarify(action: LlmAction): Nothing {
+        val message = action.message ?: "대상을 특정할 수 없습니다."
         val missingFields = action.missingFields
+        val candidates = action.candidates
 
-        if (candidates.isNullOrEmpty() || missingFields.isNullOrEmpty()) {
-            return ChatClarifyException(message = base)
+        if (!candidates.isNullOrEmpty() && missingFields?.size == 1) {
+            val field = missingFields[0]
+            val resolved = selectFieldResolver.resolveCandidates(field, action.target, candidates)
+            if (resolved.isNotEmpty()) {
+                val userId = authorizationService.currentUser().requiredId
+                val clarifyId = clarifyStore.save(userId, action)
+                throw ChatSelectRequiredException(
+                    message = message,
+                    clarifyId = clarifyId,
+                    field = field,
+                    candidates = resolved,
+                )
+            }
         }
-
-        val names =
-            missingFields
-                .firstNotNullOfOrNull { field ->
-                    selectFieldResolver
-                        .resolveCandidateNames(field, action.target, candidates)
-                        .takeIf { it.isNotEmpty() }
-                }.orEmpty()
-
-        return ChatClarifyException(
-            message = base,
-            candidates = names.ifEmpty { null },
-        )
+        throw ChatClarifyException(message)
     }
 
     private fun loadExistingDto(

--- a/src/main/kotlin/com/pluxity/weekly/chat/service/ChatDtoMapper.kt
+++ b/src/main/kotlin/com/pluxity/weekly/chat/service/ChatDtoMapper.kt
@@ -1,6 +1,8 @@
 package com.pluxity.weekly.chat.service
 
+import com.pluxity.weekly.chat.dto.ChatActionType
 import com.pluxity.weekly.chat.dto.ChatDto
+import com.pluxity.weekly.chat.dto.ChatTarget
 import com.pluxity.weekly.chat.dto.EpicChatDto
 import com.pluxity.weekly.chat.dto.LlmAction
 import com.pluxity.weekly.chat.dto.ProjectChatDto
@@ -13,13 +15,14 @@ import org.springframework.stereotype.Component
 @Component
 class ChatDtoMapper {
     fun toDto(action: LlmAction): ChatDto? {
-        if (action.action == "clarify" || action.action == "read") return null
+        val type = ChatActionType.fromOrNull(action.action)
+        if (type == null || type == ChatActionType.CLARIFY || type == ChatActionType.READ) return null
 
-        return when (action.target) {
-            "project" -> toProjectDto(action)
-            "epic" -> toEpicDto(action)
-            "task" -> toTaskDto(action)
-            else -> null
+        return when (ChatTarget.fromOrNull(action.target)) {
+            ChatTarget.PROJECT -> toProjectDto(action)
+            ChatTarget.EPIC -> toEpicDto(action)
+            ChatTarget.TASK -> toTaskDto(action)
+            ChatTarget.TEAM, ChatTarget.REVIEW, null -> null
         }
     }
 

--- a/src/main/kotlin/com/pluxity/weekly/chat/service/ChatExecutor.kt
+++ b/src/main/kotlin/com/pluxity/weekly/chat/service/ChatExecutor.kt
@@ -1,5 +1,7 @@
 package com.pluxity.weekly.chat.service
 
+import com.pluxity.weekly.chat.dto.ChatActionType
+import com.pluxity.weekly.chat.dto.ChatTarget
 import com.pluxity.weekly.chat.dto.LlmAction
 import com.pluxity.weekly.epic.service.EpicService
 import com.pluxity.weekly.project.service.ProjectService
@@ -17,23 +19,23 @@ class ChatExecutor(
     private val taskService: TaskService,
 ) {
     fun execute(action: LlmAction): Long? =
-        when (action.action) {
-            "delete" -> executeDelete(action)
-            "review_request" -> executeReviewRequest(action)
-            "assign" -> executeAssign(action)
-            "unassign" -> executeUnassign(action)
+        when (ChatActionType.fromOrNull(action.action)) {
+            ChatActionType.DELETE -> executeDelete(action)
+            ChatActionType.REVIEW_REQUEST -> executeReviewRequest(action)
+            ChatActionType.ASSIGN -> executeAssign(action)
+            ChatActionType.UNASSIGN -> executeUnassign(action)
             else -> null
         }
 
     private fun executeReviewRequest(action: LlmAction): Long? {
-        if (action.target != "task") return null
+        if (ChatTarget.fromOrNull(action.target) != ChatTarget.TASK) return null
         val id = action.id ?: return null
         taskService.requestReview(id)
         return id
     }
 
     private fun executeAssign(action: LlmAction): Long? {
-        if (action.target != "epic") return null
+        if (ChatTarget.fromOrNull(action.target) != ChatTarget.EPIC) return null
         val id = action.id ?: return null
         action.userIds?.forEach { userId ->
             epicService.assign(id, userId)
@@ -42,7 +44,7 @@ class ChatExecutor(
     }
 
     private fun executeUnassign(action: LlmAction): Long? {
-        if (action.target != "epic") return null
+        if (ChatTarget.fromOrNull(action.target) != ChatTarget.EPIC) return null
         val id = action.id ?: return null
         action.removeUserIds?.forEach { userId ->
             epicService.unassign(id, userId)
@@ -52,10 +54,11 @@ class ChatExecutor(
 
     private fun executeDelete(action: LlmAction): Long? {
         val id = action.id ?: return null
-        when (action.target) {
-            "project" -> projectService.delete(id)
-            "epic" -> epicService.delete(id)
-            "task" -> taskService.delete(id)
+        when (ChatTarget.fromOrNull(action.target)) {
+            ChatTarget.PROJECT -> projectService.delete(id)
+            ChatTarget.EPIC -> epicService.delete(id)
+            ChatTarget.TASK -> taskService.delete(id)
+            ChatTarget.TEAM, ChatTarget.REVIEW, null -> Unit
         }
         return id
     }

--- a/src/main/kotlin/com/pluxity/weekly/chat/service/ChatHistoryStore.kt
+++ b/src/main/kotlin/com/pluxity/weekly/chat/service/ChatHistoryStore.kt
@@ -1,5 +1,6 @@
 package com.pluxity.weekly.chat.service
 
+import com.pluxity.weekly.chat.dto.ChatActionResponse
 import com.pluxity.weekly.chat.llm.dto.Message
 import io.github.oshai.kotlinlogging.KotlinLogging
 import org.springframework.data.redis.core.StringRedisTemplate
@@ -51,6 +52,60 @@ class ChatHistoryStore(
             emptyList()
         }
     }
+
+    fun recordChatTurn(
+        userId: String,
+        message: String,
+        target: String,
+        actions: List<String>,
+        responses: List<ChatActionResponse>,
+    ) {
+        val summary = buildActionSummary(responses)
+        val turnNumber = incrementTurn(userId)
+        save(
+            userId,
+            "system",
+            "--- 히스토리 #$turnNumber | 질문: $message | target: $target | actions: $actions | 결과: $summary ---",
+        )
+    }
+
+    fun recordResolvedTurn(
+        userId: String,
+        target: String?,
+        action: String,
+        response: ChatActionResponse,
+    ) {
+        val summary = buildResolveSummary(response)
+        val turnNumber = incrementTurn(userId)
+        save(
+            userId,
+            "system",
+            "--- 히스토리 #$turnNumber | resolved | target: ${target ?: "-"} | actions: [$action] | 결과: $summary ---",
+        )
+    }
+
+    private fun buildResolveSummary(response: ChatActionResponse): String =
+        "${response.action} ${response.target} id=${response.id ?: "pending"}"
+
+    private fun buildActionSummary(responses: List<ChatActionResponse>): String =
+        responses.joinToString(", ") { r ->
+            when (r.action) {
+                "read" -> {
+                    val count =
+                        r.readResult?.let {
+                            it.tasks?.size
+                                ?: it.projects?.size
+                                ?: it.epics?.size
+                                ?: it.teams?.size
+                                ?: it.pendingReviews?.size
+                                ?: 0
+                        } ?: 0
+                    "read ${r.target} ${count}건"
+                }
+                "create", "update", "delete", "review_request", "assign", "unassign" -> "${r.action} ${r.target} id=${r.id ?: "pending"}"
+                else -> "${r.action} ${r.target}"
+            }
+        }
 
     private fun parseMessage(json: String): Message? =
         try {

--- a/src/main/kotlin/com/pluxity/weekly/chat/service/ChatHistoryStore.kt
+++ b/src/main/kotlin/com/pluxity/weekly/chat/service/ChatHistoryStore.kt
@@ -1,6 +1,7 @@
 package com.pluxity.weekly.chat.service
 
 import com.pluxity.weekly.chat.dto.ChatActionResponse
+import com.pluxity.weekly.chat.dto.ChatActionType
 import com.pluxity.weekly.chat.llm.dto.Message
 import io.github.oshai.kotlinlogging.KotlinLogging
 import org.springframework.data.redis.core.StringRedisTemplate
@@ -89,8 +90,9 @@ class ChatHistoryStore(
 
     private fun buildActionSummary(responses: List<ChatActionResponse>): String =
         responses.joinToString(", ") { r ->
-            when (r.action) {
-                "read" -> {
+            val type = ChatActionType.fromOrNull(r.action)
+            when {
+                type == ChatActionType.READ -> {
                     val count =
                         r.readResult?.let {
                             it.tasks?.size
@@ -102,7 +104,7 @@ class ChatHistoryStore(
                         } ?: 0
                     "read ${r.target} ${count}건"
                 }
-                "create", "update", "delete", "review_request", "assign", "unassign" -> "${r.action} ${r.target} id=${r.id ?: "pending"}"
+                type?.isMutating == true -> "${r.action} ${r.target} id=${r.id ?: "pending"}"
                 else -> "${r.action} ${r.target}"
             }
         }

--- a/src/main/kotlin/com/pluxity/weekly/chat/service/ChatPromptBuilder.kt
+++ b/src/main/kotlin/com/pluxity/weekly/chat/service/ChatPromptBuilder.kt
@@ -33,34 +33,13 @@ class ChatPromptBuilder(
         message: String,
         intent: IntentResult,
         context: String,
-        history: List<Message> = emptyList(),
     ): List<Message> {
         val intentJson = objectMapper.writeValueAsString(intent)
-        val clarifyContext = buildClarifyContext(history)
-        val userMessage = "$clarifyContext[INTENT]\n$intentJson\n[/INTENT]\n\n[CONTEXT]\n$context\n[/CONTEXT]\n\n$message"
+        val userMessage = "[INTENT]\n$intentJson\n[/INTENT]\n\n[CONTEXT]\n$context\n[/CONTEXT]\n\n$message"
         return listOf(
             Message(role = "system", content = systemPrompt),
             Message(role = "user", content = userMessage),
         )
-    }
-
-    /**
-     * 직전 대화가 clarify로 끝났을 때만, 원래 질문을 2차 LLM에 전달
-     */
-    private fun buildClarifyContext(history: List<Message>): String {
-        if (history.isEmpty()) return ""
-
-        val lastEntry = history.last().content
-        if (!lastEntry.contains("결과: clarify:")) return ""
-
-        return buildString {
-            appendLine("[CLARIFY_CONTEXT]")
-            appendLine("현재 메시지는 이전 clarify에 대한 보충 답변이다.")
-            appendLine("원래 질문: $lastEntry")
-            appendLine("이전 질문의 의도를 유지하되, 현재 메시지의 정보로 대상을 특정하라.")
-            appendLine("[/CLARIFY_CONTEXT]")
-            appendLine()
-        }
     }
 
     private fun appendHistory(
@@ -69,19 +48,12 @@ class ChatPromptBuilder(
     ): String {
         if (history.isEmpty()) return basePrompt
 
-        val lastEntry = history.last().content
-        val isClarifyPending = lastEntry.contains("결과: clarify:")
-
         return buildString {
             append(basePrompt)
             appendLine()
             appendLine()
             appendLine("## 대화 히스토리 (참조용, 이 형식으로 응답하지 마세요)")
             history.forEach { appendLine(it.content) }
-            if (isClarifyPending) {
-                appendLine()
-                appendLine("## 중요: 직전 대화가 clarify(미확정)로 끝났다. 현재 메시지는 이전 질문에 대한 보충 답변일 가능성이 높다. 이전 질문의 target과 actions를 이어받아라.")
-            }
         }
     }
 }

--- a/src/main/kotlin/com/pluxity/weekly/chat/service/ChatReadHandler.kt
+++ b/src/main/kotlin/com/pluxity/weekly/chat/service/ChatReadHandler.kt
@@ -1,6 +1,7 @@
 package com.pluxity.weekly.chat.service
 
 import com.pluxity.weekly.chat.dto.ChatReadResponse
+import com.pluxity.weekly.chat.dto.ChatTarget
 import com.pluxity.weekly.chat.dto.EpicSearchFilter
 import com.pluxity.weekly.chat.dto.LlmAction
 import com.pluxity.weekly.chat.dto.LlmActionFilters
@@ -24,32 +25,28 @@ class ChatReadHandler(
     private val teamService: TeamService,
 ) {
     fun handle(action: LlmAction): ChatReadResponse {
-        val target = action.target ?: "task"
+        val target = ChatTarget.fromOrNull(action.target) ?: ChatTarget.TASK
         val filters = action.filters
         return when (target) {
-            "task" ->
+            ChatTarget.TASK ->
                 ChatReadResponse(
                     tasks = taskService.search(buildTaskFilter(filters, action.id)),
                 )
-            "project" ->
+            ChatTarget.PROJECT ->
                 ChatReadResponse(
                     projects = projectService.search(buildProjectFilter(filters, action.id)),
                 )
-            "epic" ->
+            ChatTarget.EPIC ->
                 ChatReadResponse(
                     epics = epicService.search(buildEpicFilter(filters, action.id)),
                 )
-            "team" ->
+            ChatTarget.TEAM ->
                 ChatReadResponse(
                     teams = teamService.search(buildTeamFilter(filters)),
                 )
-            "review" ->
+            ChatTarget.REVIEW ->
                 ChatReadResponse(
                     pendingReviews = taskService.findPendingReviews(),
-                )
-            else ->
-                ChatReadResponse(
-                    tasks = taskService.search(buildTaskFilter(filters, action.id)),
                 )
         }
     }

--- a/src/main/kotlin/com/pluxity/weekly/chat/service/ChatResolveService.kt
+++ b/src/main/kotlin/com/pluxity/weekly/chat/service/ChatResolveService.kt
@@ -79,8 +79,7 @@ class ChatResolveService(
         map.remove("missing_fields")
         map.remove("candidates")
         map.remove("message")
-        val mergedJson = objectMapper.writeValueAsString(map)
-        return objectMapper.readValue(mergedJson, LlmAction::class.java)
+        return objectMapper.convertValue(map)
     }
 
     private fun resolveFieldValue(request: ChatResolveRequest): Any? {

--- a/src/main/kotlin/com/pluxity/weekly/chat/service/ChatResolveService.kt
+++ b/src/main/kotlin/com/pluxity/weekly/chat/service/ChatResolveService.kt
@@ -25,7 +25,12 @@ class ChatResolveService(
         val stored = clarifyStore.consume(userId, request.clarifyId)
         val mergedAction = mergeField(stored, request)
         val response = chatActionRouter.route(mergedAction)
-        saveSuccessHistory(userId.toString(), mergedAction, response)
+        chatHistoryStore.recordResolvedTurn(
+            userId = userId.toString(),
+            target = mergedAction.target,
+            action = mergedAction.action,
+            response = response,
+        )
         return response
     }
 
@@ -35,8 +40,9 @@ class ChatResolveService(
     ): LlmAction {
         val map: MutableMap<String, Any?> = objectMapper.convertValue(stored)
         map[request.field] = resolveFieldValue(request)
-        map[LlmAction::missingFields.name] = null
-        map[LlmAction::candidates.name] = null
+        map.remove("missing_fields")
+        map.remove("candidates")
+        map.remove("message")
         val mergedJson = objectMapper.writeValueAsString(map)
         return objectMapper.readValue(mergedJson, LlmAction::class.java)
     }
@@ -44,19 +50,5 @@ class ChatResolveService(
     private fun resolveFieldValue(request: ChatResolveRequest): Any? {
         val values = request.values ?: return null
         return if (request.field in LIST_FIELDS) values else values.singleOrNull()
-    }
-
-    private fun saveSuccessHistory(
-        userId: String,
-        action: LlmAction,
-        response: ChatActionResponse,
-    ) {
-        val turnNumber = chatHistoryStore.incrementTurn(userId)
-        val summary = "${response.action} ${response.target} id=${response.id ?: "pending"}"
-        chatHistoryStore.save(
-            userId,
-            "system",
-            "--- 히스토리 #$turnNumber | resolved | target: ${action.target ?: "-"} | actions: [${action.action}] | 결과: $summary ---",
-        )
     }
 }

--- a/src/main/kotlin/com/pluxity/weekly/chat/service/ChatResolveService.kt
+++ b/src/main/kotlin/com/pluxity/weekly/chat/service/ChatResolveService.kt
@@ -1,0 +1,62 @@
+package com.pluxity.weekly.chat.service
+
+import com.pluxity.weekly.auth.authorization.AuthorizationService
+import com.pluxity.weekly.chat.dto.ChatActionResponse
+import com.pluxity.weekly.chat.dto.ChatResolveRequest
+import com.pluxity.weekly.chat.dto.LlmAction
+import org.springframework.stereotype.Service
+import tools.jackson.databind.ObjectMapper
+import tools.jackson.module.kotlin.convertValue
+
+@Service
+class ChatResolveService(
+    private val clarifyStore: ClarifyStore,
+    private val chatActionRouter: ChatActionRouter,
+    private val chatHistoryStore: ChatHistoryStore,
+    private val authorizationService: AuthorizationService,
+    private val objectMapper: ObjectMapper,
+) {
+    companion object {
+        private val LIST_FIELDS = setOf("user_ids", "remove_user_ids")
+    }
+
+    fun resolve(request: ChatResolveRequest): ChatActionResponse {
+        val userId = authorizationService.currentUser().requiredId
+        val stored = clarifyStore.consume(userId, request.clarifyId)
+        val mergedAction = mergeField(stored, request)
+        val response = chatActionRouter.route(mergedAction)
+        saveSuccessHistory(userId.toString(), mergedAction, response)
+        return response
+    }
+
+    private fun mergeField(
+        stored: LlmAction,
+        request: ChatResolveRequest,
+    ): LlmAction {
+        val map: MutableMap<String, Any?> = objectMapper.convertValue(stored)
+        map[request.field] = resolveFieldValue(request)
+        map[LlmAction::missingFields.name] = null
+        map[LlmAction::candidates.name] = null
+        val mergedJson = objectMapper.writeValueAsString(map)
+        return objectMapper.readValue(mergedJson, LlmAction::class.java)
+    }
+
+    private fun resolveFieldValue(request: ChatResolveRequest): Any? {
+        val values = request.values ?: return null
+        return if (request.field in LIST_FIELDS) values else values.singleOrNull()
+    }
+
+    private fun saveSuccessHistory(
+        userId: String,
+        action: LlmAction,
+        response: ChatActionResponse,
+    ) {
+        val turnNumber = chatHistoryStore.incrementTurn(userId)
+        val summary = "${response.action} ${response.target} id=${response.id ?: "pending"}"
+        chatHistoryStore.save(
+            userId,
+            "system",
+            "--- 히스토리 #$turnNumber | resolved | target: ${action.target ?: "-"} | actions: [${action.action}] | 결과: $summary ---",
+        )
+    }
+}

--- a/src/main/kotlin/com/pluxity/weekly/chat/service/ChatResolveService.kt
+++ b/src/main/kotlin/com/pluxity/weekly/chat/service/ChatResolveService.kt
@@ -4,6 +4,8 @@ import com.pluxity.weekly.auth.authorization.AuthorizationService
 import com.pluxity.weekly.chat.dto.ChatActionResponse
 import com.pluxity.weekly.chat.dto.ChatResolveRequest
 import com.pluxity.weekly.chat.dto.LlmAction
+import com.pluxity.weekly.chat.exception.ChatResolveInvalidException
+import com.pluxity.weekly.chat.exception.ChatSessionExpiredException
 import org.springframework.stereotype.Service
 import tools.jackson.databind.ObjectMapper
 import tools.jackson.module.kotlin.convertValue
@@ -22,9 +24,11 @@ class ChatResolveService(
 
     fun resolve(request: ChatResolveRequest): ChatActionResponse {
         val userId = authorizationService.currentUser().requiredId
-        val stored = clarifyStore.consume(userId, request.clarifyId)
+        val stored = clarifyStore.peek(userId, request.clarifyId)
+        validate(stored, request)
         val mergedAction = mergeField(stored, request)
         val response = chatActionRouter.route(mergedAction)
+        clarifyStore.delete(userId, request.clarifyId)
         chatHistoryStore.recordResolvedTurn(
             userId = userId.toString(),
             target = mergedAction.target,
@@ -32,6 +36,38 @@ class ChatResolveService(
             response = response,
         )
         return response
+    }
+
+    private fun validate(
+        stored: LlmAction,
+        request: ChatResolveRequest,
+    ) {
+        val missingField =
+            stored.missingFields?.singleOrNull()
+                ?: throw ChatSessionExpiredException()
+
+        if (request.field != missingField) {
+            throw ChatResolveInvalidException(
+                "요청한 필드 '${request.field}'는 이번 clarify의 대상이 아닙니다 (기대: $missingField)",
+            )
+        }
+
+        val values = request.values
+        if (values.isNullOrEmpty()) {
+            throw ChatResolveInvalidException("values는 비어있을 수 없습니다")
+        }
+
+        if (request.field !in LIST_FIELDS && values.size != 1) {
+            throw ChatResolveInvalidException("'${request.field}' 필드는 단일 값만 허용합니다")
+        }
+
+        val candidates = stored.candidates
+        if (!candidates.isNullOrEmpty()) {
+            val invalid = values - candidates.toSet()
+            if (invalid.isNotEmpty()) {
+                throw ChatResolveInvalidException("후보에 없는 값: $invalid (허용: $candidates)")
+            }
+        }
     }
 
     private fun mergeField(

--- a/src/main/kotlin/com/pluxity/weekly/chat/service/ChatService.kt
+++ b/src/main/kotlin/com/pluxity/weekly/chat/service/ChatService.kt
@@ -80,42 +80,7 @@ class ChatService(
         // LlmAction → ChatActionResponse 변환
         val responses = actions.map { chatActionRouter.route(it) }
 
-        saveHistory(userId, message, intent.target, intent.actions, buildActionSummary(responses))
+        chatHistoryStore.recordChatTurn(userId, message, intent.target, intent.actions, responses)
         return responses
     }
-
-    private fun saveHistory(
-        userId: String,
-        message: String,
-        target: String,
-        actions: List<String>,
-        summary: String,
-    ) {
-        val turnNumber = chatHistoryStore.incrementTurn(userId)
-        chatHistoryStore.save(
-            userId,
-            "system",
-            "--- 히스토리 #$turnNumber | 질문: $message | target: $target | actions: $actions | 결과: $summary ---",
-        )
-    }
-
-    private fun buildActionSummary(responses: List<ChatActionResponse>): String =
-        responses.joinToString(", ") { r ->
-            when (r.action) {
-                "read" -> {
-                    val count =
-                        r.readResult?.let {
-                            it.tasks?.size
-                                ?: it.projects?.size
-                                ?: it.epics?.size
-                                ?: it.teams?.size
-                                ?: it.pendingReviews?.size
-                                ?: 0
-                        } ?: 0
-                    "read ${r.target} ${count}건"
-                }
-                "create", "update", "delete", "review_request", "assign", "unassign" -> "${r.action} ${r.target} id=${r.id ?: "pending"}"
-                else -> "${r.action} ${r.target}"
-            }
-        }
 }

--- a/src/main/kotlin/com/pluxity/weekly/chat/service/ChatService.kt
+++ b/src/main/kotlin/com/pluxity/weekly/chat/service/ChatService.kt
@@ -3,6 +3,8 @@ package com.pluxity.weekly.chat.service
 import com.pluxity.weekly.auth.authorization.AuthorizationService
 import com.pluxity.weekly.chat.context.ContextBuilder
 import com.pluxity.weekly.chat.dto.ChatActionResponse
+import com.pluxity.weekly.chat.dto.ChatActionType
+import com.pluxity.weekly.chat.dto.ChatTarget
 import com.pluxity.weekly.chat.llm.LlmService
 import com.pluxity.weekly.core.constant.ErrorCode
 import com.pluxity.weekly.core.exception.CustomException
@@ -69,7 +71,9 @@ class ChatService(
         log.info { "1차 의도 추출 - action: ${intent.actions}, target: ${intent.target}, id: ${intent.id}, response: $intent" }
 
         // target별+action별+권한별 context 조회
-        val context = contextBuilder.build(intent.target, intent.actions)
+        val targetType = ChatTarget.fromOrNull(intent.target) ?: ChatTarget.TASK
+        val actionTypes = intent.actions.mapNotNull { ChatActionType.fromOrNull(it) }
+        val context = contextBuilder.build(targetType, actionTypes)
         log.info { "context:\n${objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(objectMapper.readTree(context))}" }
 
         // 2차: LlmAction 생성

--- a/src/main/kotlin/com/pluxity/weekly/chat/service/ChatService.kt
+++ b/src/main/kotlin/com/pluxity/weekly/chat/service/ChatService.kt
@@ -73,22 +73,15 @@ class ChatService(
         log.info { "context:\n${objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(objectMapper.readTree(context))}" }
 
         // 2차: LlmAction 생성
-        val actionMessages = promptBuilder.buildActionMessages(message, intent, context, history)
+        val actionMessages = promptBuilder.buildActionMessages(message, intent, context)
         val actions = llmService.generate(actionMessages).take(1)
         log.info { "LLM 응답 액션:\n${objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(actions)}" }
 
         // LlmAction → ChatActionResponse 변환
-        try {
-            val responses = actions.map { chatActionRouter.route(it) }
+        val responses = actions.map { chatActionRouter.route(it) }
 
-            saveHistory(userId, message, intent.target, intent.actions, buildActionSummary(responses))
-            return responses
-        } catch (e: CustomException) {
-            if (e.code == ErrorCode.LLM_AMBIGUOUS_REQUEST) {
-                saveHistory(userId, message, intent.target, intent.actions, "clarify: ${e.message}")
-            }
-            throw e
-        }
+        saveHistory(userId, message, intent.target, intent.actions, buildActionSummary(responses))
+        return responses
     }
 
     private fun saveHistory(

--- a/src/main/kotlin/com/pluxity/weekly/chat/service/ClarifyStore.kt
+++ b/src/main/kotlin/com/pluxity/weekly/chat/service/ClarifyStore.kt
@@ -1,0 +1,44 @@
+package com.pluxity.weekly.chat.service
+
+import com.pluxity.weekly.chat.dto.LlmAction
+import com.pluxity.weekly.chat.exception.ChatSessionExpiredException
+import org.springframework.data.redis.core.StringRedisTemplate
+import org.springframework.stereotype.Component
+import tools.jackson.databind.ObjectMapper
+import java.time.Duration
+import java.util.UUID
+
+@Component
+class ClarifyStore(
+    private val redisTemplate: StringRedisTemplate,
+    private val objectMapper: ObjectMapper,
+) {
+    companion object {
+        private val TTL = Duration.ofMinutes(10)
+    }
+
+    fun save(
+        userId: Long,
+        action: LlmAction,
+    ): String {
+        val clarifyId = UUID.randomUUID().toString()
+        val key = keyOf(userId, clarifyId)
+        val json = objectMapper.writeValueAsString(action)
+        redisTemplate.opsForValue().set(key, json, TTL)
+        return clarifyId
+    }
+
+    fun consume(
+        userId: Long,
+        clarifyId: String,
+    ): LlmAction {
+        val key = keyOf(userId, clarifyId)
+        val raw = redisTemplate.opsForValue().getAndDelete(key) ?: throw ChatSessionExpiredException()
+        return objectMapper.readValue(raw, LlmAction::class.java)
+    }
+
+    private fun keyOf(
+        userId: Long,
+        clarifyId: String,
+    ): String = "chat:clarify:$userId:$clarifyId"
+}

--- a/src/main/kotlin/com/pluxity/weekly/chat/service/ClarifyStore.kt
+++ b/src/main/kotlin/com/pluxity/weekly/chat/service/ClarifyStore.kt
@@ -28,13 +28,20 @@ class ClarifyStore(
         return clarifyId
     }
 
-    fun consume(
+    fun peek(
         userId: Long,
         clarifyId: String,
     ): LlmAction {
         val key = keyOf(userId, clarifyId)
-        val raw = redisTemplate.opsForValue().getAndDelete(key) ?: throw ChatSessionExpiredException()
+        val raw = redisTemplate.opsForValue().get(key) ?: throw ChatSessionExpiredException()
         return objectMapper.readValue(raw, LlmAction::class.java)
+    }
+
+    fun delete(
+        userId: Long,
+        clarifyId: String,
+    ) {
+        redisTemplate.delete(keyOf(userId, clarifyId))
     }
 
     private fun keyOf(

--- a/src/main/kotlin/com/pluxity/weekly/chat/service/SelectFieldResolver.kt
+++ b/src/main/kotlin/com/pluxity/weekly/chat/service/SelectFieldResolver.kt
@@ -34,11 +34,11 @@ class SelectFieldResolver(
         return result
     }
 
-    fun resolveCandidateNames(
+    fun resolveCandidates(
         field: String,
         target: String?,
         candidateIds: List<Long>,
-    ): List<String> = dispatch(field, target, candidateIds)?.candidates?.map { it.name } ?: emptyList()
+    ): List<Candidate> = dispatch(field, target, candidateIds)?.candidates ?: emptyList()
 
     private fun dispatch(
         field: String,

--- a/src/main/kotlin/com/pluxity/weekly/chat/service/SelectFieldResolver.kt
+++ b/src/main/kotlin/com/pluxity/weekly/chat/service/SelectFieldResolver.kt
@@ -49,6 +49,8 @@ class SelectFieldResolver(
             "id" -> resolveIdCandidates(target, candidateIds)
             "project_id" -> resolveProjectCandidates(candidateIds)
             "epic_id" -> resolveEpicCandidates(candidateIds)
+            "user_ids" -> resolveUserCandidates("userIds")
+            "remove_user_ids" -> resolveUserCandidates("removeUserIds")
             // user_ids / remove_user_ids: 프롬프트는 candidates(전체 사용자 ID)를 담아 보내지만
             // 후보가 많아 드롭다운 UX 가 부적합해 의도적으로 선택지를 만들지 않는다.
             // (unassign 의 경우 "해당 에픽 배정자"로 좁히면 적합하므로 추후 분기 추가 여지)

--- a/src/main/kotlin/com/pluxity/weekly/chat/service/SelectFieldResolver.kt
+++ b/src/main/kotlin/com/pluxity/weekly/chat/service/SelectFieldResolver.kt
@@ -3,6 +3,8 @@ package com.pluxity.weekly.chat.service
 import com.pluxity.weekly.auth.authorization.UserType
 import com.pluxity.weekly.auth.user.repository.UserRepository
 import com.pluxity.weekly.chat.dto.Candidate
+import com.pluxity.weekly.chat.dto.ChatActionType
+import com.pluxity.weekly.chat.dto.ChatTarget
 import com.pluxity.weekly.chat.dto.LlmAction
 import com.pluxity.weekly.chat.dto.SelectField
 import com.pluxity.weekly.epic.repository.EpicRepository
@@ -43,7 +45,7 @@ class SelectFieldResolver(
         field: String,
         action: LlmAction,
     ): SelectField? {
-        val target = action.target
+        val target = ChatTarget.fromOrNull(action.target)
         val candidateIds = action.candidates ?: emptyList()
         return when (field) {
             "id" -> resolveIdCandidates(target, candidateIds)
@@ -56,23 +58,23 @@ class SelectFieldResolver(
     }
 
     private fun resolveIdCandidates(
-        target: String?,
+        target: ChatTarget?,
         candidateIds: List<Long>,
     ): SelectField? {
         if (candidateIds.isEmpty()) return null
         val candidates =
             when (target) {
-                "task" ->
+                ChatTarget.TASK ->
                     taskRepository.findAllWithEpicAndProjectByIdIn(candidateIds).map { task ->
                         Candidate(task.requiredId.toString(), "${task.name} (${task.epic.project.name}/${task.epic.name})")
                     }
-                "epic" ->
+                ChatTarget.EPIC ->
                     epicRepository.findAllWithProjectByIdIn(candidateIds).map { epic ->
                         Candidate(epic.requiredId.toString(), "${epic.name} (${epic.project.name})")
                     }
-                "project" ->
+                ChatTarget.PROJECT ->
                     projectRepository.findAllById(candidateIds).map { Candidate(it.requiredId.toString(), it.name) }
-                else -> return null
+                ChatTarget.TEAM, ChatTarget.REVIEW, null -> return null
             }
         return SelectField(field = "id", candidates = candidates)
     }
@@ -102,7 +104,7 @@ class SelectFieldResolver(
     }
 
     private fun resolveRemoveUserCandidates(action: LlmAction): SelectField? {
-        if (action.target != "epic" || action.id == null) return null
+        if (ChatTarget.fromOrNull(action.target) != ChatTarget.EPIC || action.id == null) return null
         val assigneeIds = epicService.findAssignments(action.id).map { it.userId }
         if (assigneeIds.isEmpty()) return null
         val candidates =
@@ -144,12 +146,13 @@ class SelectFieldResolver(
         action: LlmAction,
         result: MutableList<SelectField>,
     ) {
-        if (action.action !in listOf("create", "update")) return
+        val type = ChatActionType.fromOrNull(action.action)
+        if (type != ChatActionType.CREATE && type != ChatActionType.UPDATE) return
 
         val existingFields = result.map { it.field }.toSet()
 
-        when (action.target) {
-            "project" -> {
+        when (ChatTarget.fromOrNull(action.target)) {
+            ChatTarget.PROJECT -> {
                 if ("pmId" !in existingFields) {
                     result.add(resolveUserCandidates("pmId", listOf("PM", "PO")))
                 }
@@ -157,7 +160,7 @@ class SelectFieldResolver(
                     result.add(resolveStatusCandidates())
                 }
             }
-            "epic" -> {
+            ChatTarget.EPIC -> {
                 if ("projectId" !in existingFields) {
                     result.add(resolveProjectCandidates(emptyList()) ?: return)
                 }
@@ -168,11 +171,12 @@ class SelectFieldResolver(
                     result.add(resolveStatusCandidates())
                 }
             }
-            "task" -> {
+            ChatTarget.TASK -> {
                 if ("epicId" !in existingFields) {
                     result.add(resolveEpicCandidates(emptyList()) ?: return)
                 }
             }
+            ChatTarget.TEAM, ChatTarget.REVIEW, null -> Unit
         }
     }
 }

--- a/src/main/kotlin/com/pluxity/weekly/chat/service/SelectFieldResolver.kt
+++ b/src/main/kotlin/com/pluxity/weekly/chat/service/SelectFieldResolver.kt
@@ -1,5 +1,6 @@
 package com.pluxity.weekly.chat.service
 
+import com.pluxity.weekly.auth.authorization.UserType
 import com.pluxity.weekly.auth.user.repository.UserRepository
 import com.pluxity.weekly.chat.dto.Candidate
 import com.pluxity.weekly.chat.dto.LlmAction
@@ -23,10 +24,9 @@ class SelectFieldResolver(
 ) {
     fun resolve(action: LlmAction): List<SelectField> {
         val missingFields = action.missingFields ?: emptyList()
-        val candidateIds = action.candidates ?: emptyList()
         val result =
             missingFields
-                .mapNotNull { dispatch(it, action.target, candidateIds) }
+                .mapNotNull { dispatch(it, action) }
                 .toMutableList()
 
         addSelectFields(action, result)
@@ -36,26 +36,24 @@ class SelectFieldResolver(
 
     fun resolveCandidates(
         field: String,
-        target: String?,
-        candidateIds: List<Long>,
-    ): List<Candidate> = dispatch(field, target, candidateIds)?.candidates ?: emptyList()
+        action: LlmAction,
+    ): List<Candidate> = dispatch(field, action)?.candidates ?: emptyList()
 
     private fun dispatch(
         field: String,
-        target: String?,
-        candidateIds: List<Long>,
-    ): SelectField? =
-        when (field) {
+        action: LlmAction,
+    ): SelectField? {
+        val target = action.target
+        val candidateIds = action.candidates ?: emptyList()
+        return when (field) {
             "id" -> resolveIdCandidates(target, candidateIds)
             "project_id" -> resolveProjectCandidates(candidateIds)
             "epic_id" -> resolveEpicCandidates(candidateIds)
             "user_ids" -> resolveUserCandidates("userIds")
-            "remove_user_ids" -> resolveUserCandidates("removeUserIds")
-            // user_ids / remove_user_ids: 프롬프트는 candidates(전체 사용자 ID)를 담아 보내지만
-            // 후보가 많아 드롭다운 UX 가 부적합해 의도적으로 선택지를 만들지 않는다.
-            // (unassign 의 경우 "해당 에픽 배정자"로 좁히면 적합하므로 추후 분기 추가 여지)
+            "remove_user_ids" -> resolveRemoveUserCandidates(action)
             else -> null
         }
+    }
 
     private fun resolveIdCandidates(
         target: String?,
@@ -103,6 +101,19 @@ class SelectFieldResolver(
         return SelectField(field = "epicId", candidates = candidates)
     }
 
+    private fun resolveRemoveUserCandidates(action: LlmAction): SelectField? {
+        if (action.target != "epic" || action.id == null) return null
+        val assigneeIds = epicService.findAssignments(action.id).map { it.userId }
+        if (assigneeIds.isEmpty()) return null
+        val candidates =
+            userRepository
+                .findAllById(assigneeIds)
+                .distinctBy { it.requiredId }
+                .map { Candidate(it.requiredId.toString(), it.name) }
+        if (candidates.isEmpty()) return null
+        return SelectField(field = "removeUserIds", candidates = candidates)
+    }
+
     private fun resolveUserCandidates(
         field: String,
         roleNames: List<String>? = null,
@@ -112,7 +123,7 @@ class SelectFieldResolver(
             if (roleNames != null) {
                 users.filter { user -> user.userRoles.any { it.role.name.uppercase() in roleNames } }
             } else {
-                users
+                users.filterNot { user -> user.userRoles.any { it.role.name.equals(UserType.ADMIN.name, ignoreCase = true) } }
             }
         val candidates =
             filtered

--- a/src/main/kotlin/com/pluxity/weekly/core/constant/ErrorCode.kt
+++ b/src/main/kotlin/com/pluxity/weekly/core/constant/ErrorCode.kt
@@ -40,7 +40,9 @@ enum class ErrorCode(
     // ── Chat / LLM ──
     LLM_SERVICE_UNAVAILABLE(HttpStatus.SERVICE_UNAVAILABLE, "LLM 서비스에 연결할 수 없습니다."),
     LLM_INVALID_RESPONSE(HttpStatus.INTERNAL_SERVER_ERROR, "LLM 응답을 파싱할 수 없습니다."),
-    LLM_AMBIGUOUS_REQUEST(HttpStatus.BAD_REQUEST, "%s"),
+    CHAT_SELECT_REQUIRED(HttpStatus.BAD_REQUEST, "%s"),
+    CHAT_CLARIFY(HttpStatus.BAD_REQUEST, "%s"),
+    CHAT_SESSION_EXPIRED(HttpStatus.BAD_REQUEST, "clarify 세션이 만료되었거나 존재하지 않습니다."),
     CHAT_ALREADY_PROCESSING(HttpStatus.TOO_MANY_REQUESTS, "이전 요청을 처리 중입니다. 잠시 후 다시 시도해주세요."),
 
     // ── Common (DB / Request) ──

--- a/src/main/kotlin/com/pluxity/weekly/core/constant/ErrorCode.kt
+++ b/src/main/kotlin/com/pluxity/weekly/core/constant/ErrorCode.kt
@@ -43,6 +43,7 @@ enum class ErrorCode(
     CHAT_SELECT_REQUIRED(HttpStatus.BAD_REQUEST, "%s"),
     CHAT_CLARIFY(HttpStatus.BAD_REQUEST, "%s"),
     CHAT_SESSION_EXPIRED(HttpStatus.BAD_REQUEST, "clarify 세션이 만료되었거나 존재하지 않습니다."),
+    CHAT_RESOLVE_INVALID(HttpStatus.BAD_REQUEST, "%s"),
     CHAT_ALREADY_PROCESSING(HttpStatus.TOO_MANY_REQUESTS, "이전 요청을 처리 중입니다. 잠시 후 다시 시도해주세요."),
 
     // ── Common (DB / Request) ──

--- a/src/main/kotlin/com/pluxity/weekly/core/exception/CustomExceptionHandler.kt
+++ b/src/main/kotlin/com/pluxity/weekly/core/exception/CustomExceptionHandler.kt
@@ -1,6 +1,6 @@
 package com.pluxity.weekly.core.exception
 
-import com.pluxity.weekly.chat.exception.ChatClarifyException
+import com.pluxity.weekly.chat.exception.ChatSelectRequiredException
 import com.pluxity.weekly.core.constant.ErrorCode
 import com.pluxity.weekly.core.response.ClarifyErrorResponseBody
 import com.pluxity.weekly.core.response.ErrorResponseBody
@@ -40,8 +40,8 @@ class CustomExceptionHandler {
                 ),
             ).also { log.error(e) { "Unhandled Exception" } }
 
-    @ExceptionHandler(ChatClarifyException::class)
-    fun handleChatClarifyException(e: ChatClarifyException): ResponseEntity<ClarifyErrorResponseBody> =
+    @ExceptionHandler(ChatSelectRequiredException::class)
+    fun handleChatSelectRequiredException(e: ChatSelectRequiredException): ResponseEntity<ClarifyErrorResponseBody> =
         ResponseEntity
             .status(e.code.getHttpStatus())
             .body(
@@ -54,9 +54,13 @@ class CustomExceptionHandler {
                             .value()
                             .toString(),
                     error = e.code.getCodeName(),
+                    clarifyId = e.clarifyId,
+                    field = e.field,
                     candidates = e.candidates,
                 ),
-            ).also { log.info { "ChatClarifyException: ${e.message}, candidates=${e.candidates}" } }
+            ).also {
+                log.info { "ChatSelectRequiredException: clarifyId=${e.clarifyId}, field=${e.field}, candidates=${e.candidates.size}건" }
+            }
 
     @ExceptionHandler(CustomException::class)
     fun handleCustomException(e: CustomException): ResponseEntity<ErrorResponseBody> =

--- a/src/main/kotlin/com/pluxity/weekly/core/response/ClarifyErrorResponseBody.kt
+++ b/src/main/kotlin/com/pluxity/weekly/core/response/ClarifyErrorResponseBody.kt
@@ -1,5 +1,6 @@
 package com.pluxity.weekly.core.response
 
+import com.pluxity.weekly.chat.dto.Candidate
 import org.springframework.http.HttpStatus
 
 class ClarifyErrorResponseBody(
@@ -7,5 +8,7 @@ class ClarifyErrorResponseBody(
     message: String?,
     code: String,
     error: String,
-    val candidates: List<String>?,
+    val clarifyId: String,
+    val field: String,
+    val candidates: List<Candidate>,
 ) : ErrorResponseBody(status, message, code, error)

--- a/src/main/kotlin/com/pluxity/weekly/teams/converter/AdaptiveCardConverter.kt
+++ b/src/main/kotlin/com/pluxity/weekly/teams/converter/AdaptiveCardConverter.kt
@@ -1,8 +1,10 @@
 package com.pluxity.weekly.teams.converter
 
 import com.pluxity.weekly.chat.dto.ChatActionResponse
+import com.pluxity.weekly.chat.dto.ChatActionType
 import com.pluxity.weekly.chat.dto.ChatDto
 import com.pluxity.weekly.chat.dto.ChatReadResponse
+import com.pluxity.weekly.chat.dto.ChatTarget
 import com.pluxity.weekly.chat.dto.EpicChatDto
 import com.pluxity.weekly.chat.dto.ProjectChatDto
 import com.pluxity.weekly.chat.dto.SelectField
@@ -58,10 +60,10 @@ class AdaptiveCardConverter {
 
     private fun formatExecutionResult(response: ChatActionResponse): String {
         val actionLabel =
-            when (response.action) {
-                "create" -> "생성"
-                "update" -> "수정"
-                "delete" -> "삭제"
+            when (ChatActionType.fromOrNull(response.action)) {
+                ChatActionType.CREATE -> "생성"
+                ChatActionType.UPDATE -> "수정"
+                ChatActionType.DELETE -> "삭제"
                 else -> response.action
             }
         val targetLabel = targetLabel(response.target)
@@ -192,7 +194,7 @@ class AdaptiveCardConverter {
     private fun buildFormCard(response: ChatActionResponse): Map<String, Any> {
         val dto = response.dto!!
         val inputs = buildInputs(dto, response.selectFields.orEmpty())
-        val actionLabel = if (response.action == "create") "생성" else "수정"
+        val actionLabel = if (ChatActionType.fromOrNull(response.action) == ChatActionType.CREATE) "생성" else "수정"
 
         return mapOf(
             "type" to "AdaptiveCard",
@@ -317,12 +319,13 @@ class AdaptiveCardConverter {
         )
 
     private fun targetLabel(target: String): String =
-        when (target) {
-            "project" -> "프로젝트"
-            "epic" -> "에픽"
-            "task" -> "태스크"
-            "team" -> "팀"
-            else -> target
+        when (ChatTarget.fromOrNull(target)) {
+            ChatTarget.PROJECT -> "프로젝트"
+            ChatTarget.EPIC -> "에픽"
+            ChatTarget.TASK -> "태스크"
+            ChatTarget.TEAM -> "팀"
+            ChatTarget.REVIEW -> "리뷰"
+            null -> target
         }
 
     private fun TaskResponse.toFact(): Map<String, String> = mapOf("title" to name, "value" to "$status ($progress%)")

--- a/src/main/resources/llm/intent-prompt.txt
+++ b/src/main/resources/llm/intent-prompt.txt
@@ -22,16 +22,16 @@ JSON 1개만 출력. 설명, 마크다운 절대 금지.
 | delete | 삭제, 지워줘 |
 | read | 조회, 목록, 보여줘 |
 | review_request | 검수 요청, 리뷰 요청, 검수 올려줘, 리뷰 올려줘, 완료, 끝냈어, 다 했어, 마쳤어, 100%, 리뷰로, 검수로, IN_REVIEW로 (task 전용) |
-| assign | 할당, 배정 + 사람 이름 (epic 전용) |
-| unassign | 해제, 빼줘, 제거, 제외 + 사람 이름 (epic 전용) |
-| clarify | action 키워드가 없고 대상도 불명확할 때만 |
+| assign | 할당, 배정 (epic 전용) |
+| unassign | 해제, 빼줘, 제거, 제외 (epic 전용) |
+| clarify | **마지막 수단**. action 키워드·target 키워드 모두 전무하고 히스토리 참조도 불가능할 때만. |
 
 ## 판단 규칙
 
 1. review_request vs update: "완료/끝냈어/100%/리뷰로/검수로" → 반드시 review_request. update 아님.
 2. team: CUD 요청이 와도 read로 처리.
-3. clarify: target + action 키워드가 있으면 clarify 금지. ("태스크 생성" → create)
-4. action 키워드가 있으면 대상 이름이 없어도 해당 action으로 분류. 이름 미특정은 2차에서 처리.
+3. clarify: target + action 키워드가 있으면 clarify 금지. ("태스크 생성" → create, "태스크 수정" -> update, "에픽 할당" -> assign 등)
+4. action 키워드가 있으면 대상 이름이 없어도 해당 action으로 분류.
 5. 복합 지시 미지원. actions에는 1개만.
 
 ## 힌트 규칙
@@ -50,10 +50,6 @@ actions에 "create"가 포함되거나, 직전 히스토리가 clarify로 끝난
 3. 새 action 키워드가 있으면 actions는 새로 판단.
 4. 참조 대상이 불명확하면 clarify.
 
-clarify 후속 응답:
-- 히스토리 최근 결과가 clarify이면, 이전 질문의 target/actions를 이어받는다.
-- 구체적 정보가 있으면 힌트(project, epic, name)에 포함.
-
 ## 예시
 
 "프로젝트 만들어줘" → {"actions":["create"],"target":"project"}
@@ -65,17 +61,17 @@ clarify 후속 응답:
 "DB 설계 완료" → {"actions":["review_request"],"target":"task"}
 "크롤러 개발 리뷰 올려줘" → {"actions":["review_request"],"target":"task"}
 "알파 프로젝트 삭제해줘" → {"actions":["delete"],"target":"project"}
-"OO 에픽에 OO 할당해줘" → {"actions":["assign"],"target":"epic"}
-"OO 에픽에서 OO 빼줘" → {"actions":["unassign"],"target":"epic"}
+"알파 대시보드 에픽에 홍길동 할당해줘" → {"actions":["assign"],"target":"epic","project":"알파","epic":"대시보드"}
+"데이터 파이프라인 에픽에 인원 할당" → {"actions":["assign"],"target":"epic","epic":"데이터 파이프라인"}
+"에픽에 할당해줘" → {"actions":["assign"],"target":"epic"}
+"대시보드 에픽에서 홍길동 빼줘" → {"actions":["unassign"],"target":"epic","epic":"대시보드"}
+"에픽에서 인원 빼줘" → {"actions":["unassign"],"target":"epic"}
 "진행중" → {"actions":["clarify"],"target":"task"}
 
 히스토리 예시:
 히스토리: "--- #1 | 질문: 로그인 태스크 만들어줘 | 결과: create task id=13 ---"
 "아까 만든거 마감일을 금요일로" → {"actions":["update"],"target":"task","id":13}
 "그거 삭제해줘" → {"actions":["delete"],"target":"task","id":13}
-
-히스토리: "--- #1 | 질문: 대시보드 에픽에 OO 할당해줘 | 결과: clarify ---"
-"SAFERS 프로젝트" → {"actions":["assign"],"target":"epic","project":"SAFERS"}
 
 출력: {"actions":[".."],"target":".."}
 id는 히스토리 참조 시에만 포함.

--- a/src/main/resources/llm/system-prompt.txt
+++ b/src/main/resources/llm/system-prompt.txt
@@ -82,9 +82,19 @@ read filters:
 update/delete/review_request/assign/unassign에만 적용:
 - 후보 1개 → 자동 채움.
 - 후보 2개 이상 → missing_fields + candidates.
-- assign: user_ids 미지정 → missing_fields:["user_ids"] + candidates.
-- unassign: remove_user_ids 미지정 → missing_fields:["remove_user_ids"] + candidates.
+- assign: user_ids 미지정 → missing_fields:["user_ids"] + candidates:**[CONTEXT.users 의 모든 id]**.
+- unassign: remove_user_ids 미지정 → missing_fields:["remove_user_ids"] + candidates:**[CONTEXT.users 의 모든 id]**.
 - message: missing_fields 또는 clarify일 때만 포함. 확정된 액션에는 불포함.
+
+### missing_fields 규칙
+- 허용 값 (아래 3개 외 금지):
+  - `id` — update/delete/review_request/assign/unassign 의 대상 식별자 미확정
+  - `user_ids` — assign 시 배정 유저 미지정
+  - `remove_user_ids` — unassign 시 해제 유저 미지정
+- 항상 **최대 1개만** 담는다. `id` 와 `user_ids`/`remove_user_ids` 가 동시에 미확정이면 **`id` 우선** (대상이 정해져야 후보 정확도가 나옴).
+- candidates는 그 1개 필드의 후보만 담는다 (id면 엔티티 ID, user_ids면 유저 ID). 타입 혼합 금지.
+- id 등 이름 매칭으로 정하는 값은 **## 매칭 규칙을 엄격히 따른다** — 2개 이상 매칭 시 반드시 missing_fields:["id"] + candidates 로 빠질 것. "이름이 같으니 아마 이거겠지" 식의 추측 확정 금지.
+- 생략 대상은 **"확정되지 않아 아직 못 정한 값"** 뿐이다. 그 중 하나를 missing_fields에 담고, 나머지 미확정 값만 이번 턴에 언급하지 않는다.
 
 ## JSON 형식
 
@@ -170,6 +180,18 @@ Output: [{"action":"assign","target":"epic","id":100,"user_ids":[1]}]
 
 [INPUT]백엔드 구축 에픽에서 홍길동 빼줘[/INPUT]
 Output: [{"action":"unassign","target":"epic","id":100,"remove_user_ids":[1]}]
+
+[INPUT]백엔드 구축 에픽에 할당해줘[/INPUT]
+Output: [{"action":"assign","target":"epic","message":"'백엔드 구축' 에픽이 여러 곳에 있습니다.","missing_fields":["id"],"candidates":[100,103]}]
+
+[INPUT]백엔드 구축 에픽에 홍길동 할당해줘[/INPUT]
+Output: [{"action":"assign","target":"epic","user_ids":[1],"message":"'백엔드 구축' 에픽이 여러 곳에 있습니다.","missing_fields":["id"],"candidates":[100,103]}]
+
+[INPUT]데이터 수집 에픽에 할당해줘[/INPUT]
+Output: [{"action":"assign","target":"epic","id":102,"message":"누구를 할당할까요?","missing_fields":["user_ids"],"candidates":[1]}]
+
+[INPUT]데이터 수집 에픽에서 인원 빼줘[/INPUT]
+Output: [{"action":"unassign","target":"epic","id":102,"message":"누구를 제외할까요?","missing_fields":["remove_user_ids"],"candidates":[1]}]
 
 --- partial match / not found ---
 [INPUT]크롤 50%[/INPUT]

--- a/src/test/kotlin/com/pluxity/weekly/chat/service/ChatActionRouterTest.kt
+++ b/src/test/kotlin/com/pluxity/weekly/chat/service/ChatActionRouterTest.kt
@@ -181,6 +181,7 @@ class ChatActionRouterTest :
                         message = "어느 태스크를 수정할까요?",
                         missingFields = listOf("id"),
                     )
+                every { selectFieldResolver.resolveCandidates("id", action) } returns emptyList()
 
                 Then("ChatClarifyException 이 발생한다") {
                     val ex = shouldThrow<ChatClarifyException> { router.route(action) }
@@ -222,6 +223,7 @@ class ChatActionRouterTest :
                         missingFields = listOf("id"),
                         message = "대상을 확인해주세요.",
                     )
+                every { selectFieldResolver.resolveCandidates("id", action) } returns emptyList()
 
                 Then("회귀 방지 clarify 가 발생한다") {
                     shouldThrow<ChatClarifyException> { router.route(action) }
@@ -243,7 +245,7 @@ class ChatActionRouterTest :
                 }
             }
 
-            When("missingFields 가 남아있어 userIds 가 누락된 상태이면") {
+            When("missingFields 로 user_ids 가 지정돼 있으면") {
                 val action =
                     LlmAction(
                         action = "assign",
@@ -252,27 +254,61 @@ class ChatActionRouterTest :
                         missingFields = listOf("user_ids"),
                         message = "누구를 배정할까요?",
                     )
+                val resolvedCandidates = listOf(Candidate("10", "홍길동"), Candidate("20", "김영희"))
+                val normalized = action.copy(missingFields = listOf("user_ids"), candidates = listOf(10L, 20L))
+                val user = mockk<User> { every { requiredId } returns 42L }
+                every { selectFieldResolver.resolveCandidates("user_ids", action) } returns resolvedCandidates
+                every { authorizationService.currentUser() } returns user
+                every { clarifyStore.save(42L, normalized) } returns "turn-id-xyz"
 
-                Then("silent no-op 을 방지하는 clarify 가 발생한다") {
-                    shouldThrow<ChatClarifyException> { router.route(action) }
+                Then("user_ids 후보가 담긴 ChatSelectRequiredException 이 발생한다") {
+                    val ex = shouldThrow<ChatSelectRequiredException> { router.route(action) }
+                    ex.field shouldBe "user_ids"
+                    ex.candidates shouldBe resolvedCandidates
+                    ex.clarifyId shouldBe "turn-id-xyz"
                     verify(exactly = 0) { chatExecutor.execute(any()) }
                 }
             }
 
             When("missingFields 없이 userIds 만 누락된 상태이면") {
                 val action = LlmAction(action = "assign", target = "epic", id = 3L)
+                val resolvedCandidates = listOf(Candidate("10", "홍길동"))
+                val normalized = action.copy(missingFields = listOf("user_ids"), candidates = listOf(10L))
+                val user = mockk<User> { every { requiredId } returns 42L }
+                every { selectFieldResolver.resolveCandidates("user_ids", action) } returns resolvedCandidates
+                every { authorizationService.currentUser() } returns user
+                every { clarifyStore.save(42L, normalized) } returns "turn-id-xyz"
 
-                Then("defense-in-depth clarify 가 발생한다") {
-                    shouldThrow<ChatClarifyException> { router.route(action) }
+                Then("nextMissingField 가 user_ids 를 감지해 clarify 로 이어진다") {
+                    val ex = shouldThrow<ChatSelectRequiredException> { router.route(action) }
+                    ex.field shouldBe "user_ids"
                     verify(exactly = 0) { chatExecutor.execute(any()) }
                 }
             }
 
             When("missingFields 없이 userIds 가 빈 리스트이면") {
                 val action = LlmAction(action = "assign", target = "epic", id = 3L, userIds = emptyList())
+                val resolvedCandidates = listOf(Candidate("10", "홍길동"))
+                val normalized = action.copy(missingFields = listOf("user_ids"), candidates = listOf(10L))
+                val user = mockk<User> { every { requiredId } returns 42L }
+                every { selectFieldResolver.resolveCandidates("user_ids", action) } returns resolvedCandidates
+                every { authorizationService.currentUser() } returns user
+                every { clarifyStore.save(42L, normalized) } returns "turn-id-xyz"
 
-                Then("clarify 가 발생한다") {
-                    shouldThrow<ChatClarifyException> { router.route(action) }
+                Then("빈 리스트도 누락으로 간주해 clarify 가 발생한다") {
+                    val ex = shouldThrow<ChatSelectRequiredException> { router.route(action) }
+                    ex.field shouldBe "user_ids"
+                    verify(exactly = 0) { chatExecutor.execute(any()) }
+                }
+            }
+
+            When("userIds 누락인데 후보도 없으면") {
+                val action = LlmAction(action = "assign", target = "epic", id = 3L, message = "배정할 유저를 찾을 수 없습니다.")
+                every { selectFieldResolver.resolveCandidates("user_ids", action) } returns emptyList()
+
+                Then("ChatClarifyException 으로 폴백한다") {
+                    val ex = shouldThrow<ChatClarifyException> { router.route(action) }
+                    ex.message shouldBe "배정할 유저를 찾을 수 없습니다."
                     verify(exactly = 0) { chatExecutor.execute(any()) }
                 }
             }
@@ -294,9 +330,17 @@ class ChatActionRouterTest :
 
             When("missingFields 없이 removeUserIds 만 누락된 상태이면") {
                 val action = LlmAction(action = "unassign", target = "epic", id = 3L)
+                val resolvedCandidates = listOf(Candidate("10", "홍길동"))
+                val normalized = action.copy(missingFields = listOf("remove_user_ids"), candidates = listOf(10L))
+                val user = mockk<User> { every { requiredId } returns 42L }
+                every { selectFieldResolver.resolveCandidates("remove_user_ids", action) } returns resolvedCandidates
+                every { authorizationService.currentUser() } returns user
+                every { clarifyStore.save(42L, normalized) } returns "turn-id-xyz"
 
-                Then("defense-in-depth clarify 가 발생한다") {
-                    shouldThrow<ChatClarifyException> { router.route(action) }
+                Then("nextMissingField 가 remove_user_ids 를 감지해 clarify 로 이어진다") {
+                    val ex = shouldThrow<ChatSelectRequiredException> { router.route(action) }
+                    ex.field shouldBe "remove_user_ids"
+                    ex.candidates shouldBe resolvedCandidates
                     verify(exactly = 0) { chatExecutor.execute(any()) }
                 }
             }

--- a/src/test/kotlin/com/pluxity/weekly/chat/service/ChatActionRouterTest.kt
+++ b/src/test/kotlin/com/pluxity/weekly/chat/service/ChatActionRouterTest.kt
@@ -86,6 +86,18 @@ class ChatActionRouterTest :
             }
         }
 
+        Given("지원하지 않는 action") {
+            When("enum 에 정의되지 않은 key 가 들어오면") {
+                val action = LlmAction(action = "foo", target = "task")
+
+                Then("ChatClarifyException 이 발생하고 executor 는 호출되지 않는다") {
+                    val ex = shouldThrow<ChatClarifyException> { router.route(action) }
+                    ex.message shouldBe "지원하지 않는 요청입니다."
+                    verify(exactly = 0) { chatExecutor.execute(any()) }
+                }
+            }
+        }
+
         Given("create 액션") {
             When("missingFields 없이 태스크 생성 요청이 들어오면") {
                 val action = LlmAction(action = "create", target = "task", name = "새 태스크")
@@ -208,6 +220,7 @@ class ChatActionRouterTest :
 
             When("id 가 없으면") {
                 val action = LlmAction(action = "delete", target = "task", id = null, message = "대상을 특정할 수 없습니다.")
+                every { selectFieldResolver.resolveCandidates("id", action) } returns emptyList()
 
                 Then("clarify 가 발생한다") {
                     shouldThrow<ChatClarifyException> { router.route(action) }

--- a/src/test/kotlin/com/pluxity/weekly/chat/service/ChatActionRouterTest.kt
+++ b/src/test/kotlin/com/pluxity/weekly/chat/service/ChatActionRouterTest.kt
@@ -1,11 +1,14 @@
 package com.pluxity.weekly.chat.service
 
+import com.pluxity.weekly.auth.authorization.AuthorizationService
+import com.pluxity.weekly.auth.user.entity.User
 import com.pluxity.weekly.chat.dto.Candidate
 import com.pluxity.weekly.chat.dto.ChatReadResponse
 import com.pluxity.weekly.chat.dto.LlmAction
 import com.pluxity.weekly.chat.dto.SelectField
 import com.pluxity.weekly.chat.dto.TaskChatDto
 import com.pluxity.weekly.chat.exception.ChatClarifyException
+import com.pluxity.weekly.chat.exception.ChatSelectRequiredException
 import com.pluxity.weekly.epic.service.EpicService
 import com.pluxity.weekly.project.service.ProjectService
 import com.pluxity.weekly.task.service.TaskService
@@ -24,6 +27,8 @@ class ChatActionRouterTest :
         val chatExecutor: ChatExecutor = mockk()
         val chatDtoMapper: ChatDtoMapper = mockk()
         val selectFieldResolver: SelectFieldResolver = mockk()
+        val clarifyStore: ClarifyStore = mockk()
+        val authorizationService: AuthorizationService = mockk()
         val taskService: TaskService = mockk()
         val epicService: EpicService = mockk()
         val projectService: ProjectService = mockk()
@@ -34,6 +39,8 @@ class ChatActionRouterTest :
                 chatExecutor,
                 chatDtoMapper,
                 selectFieldResolver,
+                clarifyStore,
+                authorizationService,
                 taskService,
                 epicService,
                 projectService,
@@ -138,7 +145,7 @@ class ChatActionRouterTest :
                 }
             }
 
-            When("id 가 없으면") {
+            When("id 가 없고 candidates 가 있으면") {
                 val action =
                     LlmAction(
                         action = "update",
@@ -148,14 +155,36 @@ class ChatActionRouterTest :
                         candidates = listOf(1L, 2L),
                         missingFields = listOf("id"),
                     )
-                every {
-                    selectFieldResolver.resolveCandidateNames("id", "task", listOf(1L, 2L))
-                } returns listOf("태스크A", "태스크B")
+                val resolvedCandidates =
+                    listOf(Candidate("1", "태스크A"), Candidate("2", "태스크B"))
+                val user = mockk<User> { every { requiredId } returns 42L }
+                every { selectFieldResolver.resolveCandidates("id", "task", listOf(1L, 2L)) } returns resolvedCandidates
+                every { authorizationService.currentUser() } returns user
+                every { clarifyStore.save(42L, action) } returns "turn-id-xyz"
 
-                Then("candidates 이름을 담은 clarify 가 발생한다") {
+                Then("ChatSelectRequiredException 이 clarifyId/field/candidates 와 함께 발생한다") {
+                    val ex = shouldThrow<ChatSelectRequiredException> { router.route(action) }
+                    ex.message shouldBe "어느 태스크를 수정할까요?"
+                    ex.clarifyId shouldBe "turn-id-xyz"
+                    ex.field shouldBe "id"
+                    ex.candidates shouldBe resolvedCandidates
+                    verify { clarifyStore.save(42L, action) }
+                }
+            }
+
+            When("id 가 없고 candidates 가 없으면") {
+                val action =
+                    LlmAction(
+                        action = "update",
+                        target = "task",
+                        id = null,
+                        message = "어느 태스크를 수정할까요?",
+                        missingFields = listOf("id"),
+                    )
+
+                Then("ChatClarifyException 이 발생한다") {
                     val ex = shouldThrow<ChatClarifyException> { router.route(action) }
                     ex.message shouldBe "어느 태스크를 수정할까요?"
-                    ex.candidates shouldBe listOf("태스크A", "태스크B")
                 }
             }
         }

--- a/src/test/kotlin/com/pluxity/weekly/chat/service/ChatActionRouterTest.kt
+++ b/src/test/kotlin/com/pluxity/weekly/chat/service/ChatActionRouterTest.kt
@@ -158,7 +158,7 @@ class ChatActionRouterTest :
                 val resolvedCandidates =
                     listOf(Candidate("1", "태스크A"), Candidate("2", "태스크B"))
                 val user = mockk<User> { every { requiredId } returns 42L }
-                every { selectFieldResolver.resolveCandidates("id", "task", listOf(1L, 2L)) } returns resolvedCandidates
+                every { selectFieldResolver.resolveCandidates("id", action) } returns resolvedCandidates
                 every { authorizationService.currentUser() } returns user
                 every { clarifyStore.save(42L, action) } returns "turn-id-xyz"
 

--- a/src/test/kotlin/com/pluxity/weekly/chat/service/ChatResolveServiceTest.kt
+++ b/src/test/kotlin/com/pluxity/weekly/chat/service/ChatResolveServiceTest.kt
@@ -1,0 +1,283 @@
+package com.pluxity.weekly.chat.service
+
+import com.pluxity.weekly.auth.authorization.AuthorizationService
+import com.pluxity.weekly.auth.user.entity.User
+import com.pluxity.weekly.chat.dto.ChatActionResponse
+import com.pluxity.weekly.chat.dto.ChatResolveRequest
+import com.pluxity.weekly.chat.dto.LlmAction
+import com.pluxity.weekly.chat.exception.ChatResolveInvalidException
+import com.pluxity.weekly.chat.exception.ChatSessionExpiredException
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import tools.jackson.databind.json.JsonMapper
+
+class ChatResolveServiceTest :
+    BehaviorSpec({
+
+        val clarifyStore: ClarifyStore = mockk()
+        val chatActionRouter: ChatActionRouter = mockk()
+        val chatHistoryStore: ChatHistoryStore = mockk(relaxed = true)
+        val authorizationService: AuthorizationService = mockk()
+        val objectMapper = JsonMapper()
+
+        val service =
+            ChatResolveService(
+                clarifyStore,
+                chatActionRouter,
+                chatHistoryStore,
+                authorizationService,
+                objectMapper,
+            )
+
+        val userId = 42L
+        val user = mockk<User> { every { requiredId } returns userId }
+        every { authorizationService.currentUser() } returns user
+
+        Given("정상 resolve - 단일 id 필드") {
+            val clarifyId = "clarify-xyz"
+            val stored =
+                LlmAction(
+                    action = "update",
+                    target = "task",
+                    status = "IN_PROGRESS",
+                    missingFields = listOf("id"),
+                    candidates = listOf(10L, 20L),
+                    message = "어떤 태스크?",
+                )
+            val request = ChatResolveRequest(clarifyId = clarifyId, field = "id", values = listOf(10L))
+            val routerResponse = ChatActionResponse(action = "update", target = "task", id = 10L)
+
+            every { clarifyStore.peek(userId, clarifyId) } returns stored
+            every { chatActionRouter.route(any()) } returns routerResponse
+            every { clarifyStore.delete(userId, clarifyId) } returns Unit
+
+            When("resolve 가 호출되면") {
+                val response = service.resolve(request)
+
+                Then("router 응답이 그대로 반환된다") {
+                    response shouldBe routerResponse
+                }
+
+                Then("merged action 에 id 가 주입되고 clarify 메타(missing_fields/candidates/message)가 제거된다") {
+                    verify {
+                        chatActionRouter.route(
+                            match {
+                                it.id == 10L &&
+                                    it.status == "IN_PROGRESS" &&
+                                    it.missingFields == null &&
+                                    it.candidates == null &&
+                                    it.message == null
+                            },
+                        )
+                    }
+                }
+
+                Then("세션이 삭제되고 히스토리가 기록된다") {
+                    verify { clarifyStore.delete(userId, clarifyId) }
+                    verify {
+                        chatHistoryStore.recordResolvedTurn(
+                            userId = userId.toString(),
+                            target = "task",
+                            action = "update",
+                            response = routerResponse,
+                        )
+                    }
+                }
+            }
+        }
+
+        Given("정상 resolve - 리스트 필드(user_ids)") {
+            val clarifyId = "clarify-abc"
+            val stored =
+                LlmAction(
+                    action = "assign",
+                    target = "epic",
+                    id = 3L,
+                    missingFields = listOf("user_ids"),
+                    candidates = listOf(1L, 2L, 3L),
+                )
+            val request =
+                ChatResolveRequest(clarifyId = clarifyId, field = "user_ids", values = listOf(1L, 2L))
+            val routerResponse = ChatActionResponse(action = "assign", target = "epic", id = 3L)
+
+            every { clarifyStore.peek(userId, clarifyId) } returns stored
+            every { chatActionRouter.route(any()) } returns routerResponse
+            every { clarifyStore.delete(userId, clarifyId) } returns Unit
+
+            When("복수 값으로 resolve 가 호출되면") {
+                service.resolve(request)
+
+                Then("merged action 의 userIds 에 리스트가 그대로 들어간다") {
+                    verify {
+                        chatActionRouter.route(
+                            match { it.userIds == listOf(1L, 2L) && it.missingFields == null },
+                        )
+                    }
+                }
+            }
+        }
+
+        Given("세션 invariant 파손 - missingFields 가 null") {
+            val clarifyId = "clarify-1"
+            val stored = LlmAction(action = "update", target = "task", missingFields = null)
+            val request = ChatResolveRequest(clarifyId = clarifyId, field = "id", values = listOf(10L))
+
+            every { clarifyStore.peek(userId, clarifyId) } returns stored
+
+            When("resolve 가 호출되면") {
+                Then("ChatSessionExpiredException 이 발생하고 세션은 삭제되지 않는다") {
+                    shouldThrow<ChatSessionExpiredException> { service.resolve(request) }
+                    verify(exactly = 0) { clarifyStore.delete(any(), any()) }
+                    verify(exactly = 0) { chatActionRouter.route(any()) }
+                }
+            }
+        }
+
+        Given("세션 invariant 파손 - missingFields 가 복수") {
+            val clarifyId = "clarify-2"
+            val stored =
+                LlmAction(
+                    action = "assign",
+                    target = "epic",
+                    missingFields = listOf("id", "user_ids"),
+                )
+            val request = ChatResolveRequest(clarifyId = clarifyId, field = "id", values = listOf(1L))
+
+            every { clarifyStore.peek(userId, clarifyId) } returns stored
+
+            When("resolve 가 호출되면") {
+                Then("ChatSessionExpiredException 이 발생한다") {
+                    shouldThrow<ChatSessionExpiredException> { service.resolve(request) }
+                    verify(exactly = 0) { clarifyStore.delete(any(), any()) }
+                }
+            }
+        }
+
+        Given("field 불일치") {
+            val clarifyId = "clarify-3"
+            val stored =
+                LlmAction(
+                    action = "update",
+                    target = "task",
+                    missingFields = listOf("id"),
+                    candidates = listOf(10L),
+                )
+            val request =
+                ChatResolveRequest(clarifyId = clarifyId, field = "user_ids", values = listOf(10L))
+
+            every { clarifyStore.peek(userId, clarifyId) } returns stored
+
+            When("clarify 대상이 아닌 필드로 resolve 하면") {
+                Then("IllegalArgumentException 이 발생하고 세션은 유지된다") {
+                    shouldThrow<ChatResolveInvalidException> { service.resolve(request) }
+                    verify(exactly = 0) { clarifyStore.delete(any(), any()) }
+                    verify(exactly = 0) { chatActionRouter.route(any()) }
+                }
+            }
+        }
+
+        Given("values 누락") {
+            val clarifyId = "clarify-4"
+            val stored =
+                LlmAction(
+                    action = "update",
+                    target = "task",
+                    missingFields = listOf("id"),
+                    candidates = listOf(10L),
+                )
+            every { clarifyStore.peek(userId, clarifyId) } returns stored
+
+            When("values 가 null 이면") {
+                val request = ChatResolveRequest(clarifyId = clarifyId, field = "id", values = null)
+
+                Then("IllegalArgumentException 이 발생한다") {
+                    shouldThrow<ChatResolveInvalidException> { service.resolve(request) }
+                    verify(exactly = 0) { clarifyStore.delete(any(), any()) }
+                }
+            }
+
+            When("values 가 빈 리스트이면") {
+                val request = ChatResolveRequest(clarifyId = clarifyId, field = "id", values = emptyList())
+
+                Then("IllegalArgumentException 이 발생한다") {
+                    shouldThrow<ChatResolveInvalidException> { service.resolve(request) }
+                }
+            }
+        }
+
+        Given("cardinality 위반 - 단일 필드에 복수 값") {
+            val clarifyId = "clarify-5"
+            val stored =
+                LlmAction(
+                    action = "update",
+                    target = "task",
+                    missingFields = listOf("id"),
+                    candidates = listOf(1L, 2L, 3L),
+                )
+            val request =
+                ChatResolveRequest(clarifyId = clarifyId, field = "id", values = listOf(1L, 2L))
+
+            every { clarifyStore.peek(userId, clarifyId) } returns stored
+
+            When("단일 필드에 2개 값을 보내면") {
+                Then("IllegalArgumentException 이 발생한다") {
+                    shouldThrow<ChatResolveInvalidException> { service.resolve(request) }
+                    verify(exactly = 0) { clarifyStore.delete(any(), any()) }
+                }
+            }
+        }
+
+        Given("candidates 불일치") {
+            val clarifyId = "clarify-6"
+            val stored =
+                LlmAction(
+                    action = "update",
+                    target = "task",
+                    missingFields = listOf("id"),
+                    candidates = listOf(10L, 20L),
+                )
+            val request =
+                ChatResolveRequest(clarifyId = clarifyId, field = "id", values = listOf(99L))
+
+            every { clarifyStore.peek(userId, clarifyId) } returns stored
+
+            When("후보 목록 밖 값을 보내면") {
+                Then("IllegalArgumentException 이 발생하고 세션은 유지된다") {
+                    shouldThrow<ChatResolveInvalidException> { service.resolve(request) }
+                    verify(exactly = 0) { clarifyStore.delete(any(), any()) }
+                    verify(exactly = 0) { chatActionRouter.route(any()) }
+                }
+            }
+        }
+
+        Given("candidates 가 비어있는 경우") {
+            val clarifyId = "clarify-7"
+            val stored =
+                LlmAction(
+                    action = "update",
+                    target = "task",
+                    missingFields = listOf("id"),
+                    candidates = null,
+                )
+            val request =
+                ChatResolveRequest(clarifyId = clarifyId, field = "id", values = listOf(999L))
+            val routerResponse = ChatActionResponse(action = "update", target = "task", id = 999L)
+
+            every { clarifyStore.peek(userId, clarifyId) } returns stored
+            every { chatActionRouter.route(any()) } returns routerResponse
+            every { clarifyStore.delete(userId, clarifyId) } returns Unit
+
+            When("resolve 가 호출되면") {
+                service.resolve(request)
+
+                Then("후보 검증을 건너뛰고 정상 처리된다") {
+                    verify { chatActionRouter.route(any()) }
+                    verify { clarifyStore.delete(userId, clarifyId) }
+                }
+            }
+        }
+    })


### PR DESCRIPTION
- **feat: clarify 세션용 예외,응답 타입 추가**
- **feat: clarify 세션 저장소와 라우터 연동**
- **feat: /resolve 엔드포인트 추가**
- **fix: mergeField 키 버그 수정 & refactor: 히스토리 기록 통일**
- ** feat: /resolve 요청 검증 추가**
- **feat: missing_fields 정책 정비 및 clarify 흐름 보강**
- **refactor: clarify 예외시 userIds 선택지 filter 적용**
- **feat: assign/unassign 2차 clarify 누락 처리**
- **refactor: mergeField 의 Jackson JSON 왕복을 convertValue 로 단순화**
- **refactor: ChatActionRouter 을 enum + validate 단계로 분리**
- **refactor: chat action/target 매직 스트링을 enum 으로 전환**
