### PR TITLE
refactor: TaskReviewService 분리 (#42)

### DIFF
--- a/src/main/kotlin/com/pluxity/weekly/chat/dto/ChatActionType.kt
+++ b/src/main/kotlin/com/pluxity/weekly/chat/dto/ChatActionType.kt
@@ -21,7 +21,6 @@ enum class ChatActionType(
     companion object {
         fun fromOrNull(key: String?): ChatActionType? = entries.firstOrNull { it.key == key }
 
-        fun from(key: String?): ChatActionType =
-            fromOrNull(key) ?: throw ChatClarifyException(message = "지원하지 않는 요청입니다.")
+        fun from(key: String?): ChatActionType = fromOrNull(key) ?: throw ChatClarifyException(message = "지원하지 않는 요청입니다.")
     }
 }

--- a/src/main/kotlin/com/pluxity/weekly/chat/dto/ChatTarget.kt
+++ b/src/main/kotlin/com/pluxity/weekly/chat/dto/ChatTarget.kt
@@ -2,7 +2,9 @@ package com.pluxity.weekly.chat.dto
 
 import com.pluxity.weekly.chat.exception.ChatClarifyException
 
-enum class ChatTarget(val key: String) {
+enum class ChatTarget(
+    val key: String,
+) {
     TASK("task"),
     EPIC("epic"),
     PROJECT("project"),
@@ -13,7 +15,6 @@ enum class ChatTarget(val key: String) {
     companion object {
         fun fromOrNull(key: String?): ChatTarget? = entries.firstOrNull { it.key == key }
 
-        fun from(key: String?): ChatTarget =
-            fromOrNull(key) ?: throw ChatClarifyException(message = "지원하지 않는 대상입니다.")
+        fun from(key: String?): ChatTarget = fromOrNull(key) ?: throw ChatClarifyException(message = "지원하지 않는 대상입니다.")
     }
 }

--- a/src/main/kotlin/com/pluxity/weekly/chat/service/ChatExecutor.kt
+++ b/src/main/kotlin/com/pluxity/weekly/chat/service/ChatExecutor.kt
@@ -5,6 +5,7 @@ import com.pluxity.weekly.chat.dto.ChatTarget
 import com.pluxity.weekly.chat.dto.LlmAction
 import com.pluxity.weekly.epic.service.EpicService
 import com.pluxity.weekly.project.service.ProjectService
+import com.pluxity.weekly.task.service.TaskReviewService
 import com.pluxity.weekly.task.service.TaskService
 import org.springframework.stereotype.Component
 
@@ -17,6 +18,7 @@ class ChatExecutor(
     private val projectService: ProjectService,
     private val epicService: EpicService,
     private val taskService: TaskService,
+    private val taskReviewService: TaskReviewService,
 ) {
     fun execute(action: LlmAction): Long? =
         when (ChatActionType.fromOrNull(action.action)) {
@@ -30,7 +32,7 @@ class ChatExecutor(
     private fun executeReviewRequest(action: LlmAction): Long? {
         if (ChatTarget.fromOrNull(action.target) != ChatTarget.TASK) return null
         val id = action.id ?: return null
-        taskService.requestReview(id)
+        taskReviewService.requestReview(id)
         return id
     }
 

--- a/src/main/kotlin/com/pluxity/weekly/chat/service/ChatReadHandler.kt
+++ b/src/main/kotlin/com/pluxity/weekly/chat/service/ChatReadHandler.kt
@@ -13,6 +13,7 @@ import com.pluxity.weekly.epic.service.EpicService
 import com.pluxity.weekly.project.entity.ProjectStatus
 import com.pluxity.weekly.project.service.ProjectService
 import com.pluxity.weekly.task.entity.TaskStatus
+import com.pluxity.weekly.task.service.TaskReviewService
 import com.pluxity.weekly.task.service.TaskService
 import com.pluxity.weekly.team.service.TeamService
 import org.springframework.stereotype.Component
@@ -20,6 +21,7 @@ import org.springframework.stereotype.Component
 @Component
 class ChatReadHandler(
     private val taskService: TaskService,
+    private val taskReviewService: TaskReviewService,
     private val projectService: ProjectService,
     private val epicService: EpicService,
     private val teamService: TeamService,
@@ -46,7 +48,7 @@ class ChatReadHandler(
                 )
             ChatTarget.REVIEW ->
                 ChatReadResponse(
-                    pendingReviews = taskService.findPendingReviews(),
+                    pendingReviews = taskReviewService.findPendingReviews(),
                 )
         }
     }

--- a/src/main/kotlin/com/pluxity/weekly/task/controller/TaskController.kt
+++ b/src/main/kotlin/com/pluxity/weekly/task/controller/TaskController.kt
@@ -9,6 +9,7 @@ import com.pluxity.weekly.task.dto.TaskRejectRequest
 import com.pluxity.weekly.task.dto.TaskRequest
 import com.pluxity.weekly.task.dto.TaskResponse
 import com.pluxity.weekly.task.dto.TaskUpdateRequest
+import com.pluxity.weekly.task.service.TaskReviewService
 import com.pluxity.weekly.task.service.TaskService
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.media.Content
@@ -32,6 +33,7 @@ import org.springframework.web.bind.annotation.RestController
 @Tag(name = "Task Controller", description = "태스크 관리 API")
 class TaskController(
     private val service: TaskService,
+    private val reviewService: TaskReviewService,
 ) {
     @Operation(summary = "태스크 전체 조회", description = "태스크 전체 목록을 조회합니다")
     @ApiResponses(
@@ -115,7 +117,7 @@ class TaskController(
     fun requestReview(
         @PathVariable id: Long,
     ): ResponseEntity<Void> {
-        service.requestReview(id)
+        reviewService.requestReview(id)
         return ResponseEntity.noContent().build()
     }
 
@@ -134,7 +136,7 @@ class TaskController(
     fun approve(
         @PathVariable id: Long,
     ): ResponseEntity<Void> {
-        service.approve(id)
+        reviewService.approve(id)
         return ResponseEntity.noContent().build()
     }
 
@@ -154,7 +156,7 @@ class TaskController(
         @PathVariable id: Long,
         @RequestBody @Valid request: TaskRejectRequest,
     ): ResponseEntity<Void> {
-        service.reject(id, request.reason)
+        reviewService.reject(id, request.reason)
         return ResponseEntity.noContent().build()
     }
 
@@ -174,7 +176,7 @@ class TaskController(
     )
     @GetMapping("/pending-reviews")
     fun findPendingReviews(): ResponseEntity<DataResponseBody<List<PendingReviewResponse>>> =
-        ResponseEntity.ok(DataResponseBody(service.findPendingReviews()))
+        ResponseEntity.ok(DataResponseBody(reviewService.findPendingReviews()))
 
     @Operation(summary = "태스크 승인 로그 조회", description = "태스크의 전체 리뷰/승인/반려 이력을 시간순으로 조회합니다")
     @ApiResponses(
@@ -185,7 +187,8 @@ class TaskController(
     @GetMapping("/{id}/approval-logs")
     fun findApprovalLogs(
         @PathVariable id: Long,
-    ): ResponseEntity<DataResponseBody<List<TaskApprovalLogResponse>>> = ResponseEntity.ok(DataResponseBody(service.findApprovalLogs(id)))
+    ): ResponseEntity<DataResponseBody<List<TaskApprovalLogResponse>>> =
+        ResponseEntity.ok(DataResponseBody(reviewService.findApprovalLogs(id)))
 
     @Operation(summary = "태스크 삭제", description = "태스크를 삭제합니다")
     @ApiResponses(

--- a/src/main/kotlin/com/pluxity/weekly/task/service/TaskReviewService.kt
+++ b/src/main/kotlin/com/pluxity/weekly/task/service/TaskReviewService.kt
@@ -1,0 +1,167 @@
+package com.pluxity.weekly.task.service
+
+import com.pluxity.weekly.auth.authorization.AuthorizationService
+import com.pluxity.weekly.auth.user.entity.User
+import com.pluxity.weekly.core.constant.ErrorCode
+import com.pluxity.weekly.core.exception.CustomException
+import com.pluxity.weekly.task.dto.ActionLink
+import com.pluxity.weekly.task.dto.PendingReviewActions
+import com.pluxity.weekly.task.dto.PendingReviewResponse
+import com.pluxity.weekly.task.dto.TaskApprovalLogResponse
+import com.pluxity.weekly.task.dto.toResponse
+import com.pluxity.weekly.task.entity.Task
+import com.pluxity.weekly.task.entity.TaskApprovalAction
+import com.pluxity.weekly.task.entity.TaskApprovalLog
+import com.pluxity.weekly.task.entity.TaskStatus
+import com.pluxity.weekly.task.repository.TaskApprovalLogRepository
+import com.pluxity.weekly.task.repository.TaskRepository
+import com.pluxity.weekly.teams.converter.TaskReviewCardBuilder
+import com.pluxity.weekly.teams.event.TeamsNotificationEvent
+import org.springframework.context.ApplicationEventPublisher
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDateTime
+
+@Service
+@Transactional(readOnly = true)
+class TaskReviewService(
+    private val taskRepository: TaskRepository,
+    private val taskApprovalLogRepository: TaskApprovalLogRepository,
+    private val authorizationService: AuthorizationService,
+    private val eventPublisher: ApplicationEventPublisher,
+    private val taskReviewCardBuilder: TaskReviewCardBuilder,
+) {
+    @Transactional
+    fun requestReview(id: Long) {
+        val user = authorizationService.currentUser()
+        val task = getTaskById(id)
+        authorizationService.requireTaskOwner(user, task)
+        task.requestReview()
+        writeLog(task, user, TaskApprovalAction.REVIEW_REQUEST)
+        task.epic.project.pmId?.let { pmId ->
+            val card =
+                taskReviewCardBuilder.build(
+                    taskId = task.requiredId,
+                    taskName = task.name,
+                    projectName = task.epic.project.name,
+                    epicName = task.epic.name,
+                    requesterName = user.name,
+                )
+            eventPublisher.publishEvent(
+                TeamsNotificationEvent(
+                    userId = pmId,
+                    message = "[리뷰 요청] '${task.name}' 태스크가 리뷰 요청되었습니다. 요청자: ${user.name}",
+                    card = card,
+                ),
+            )
+        }
+    }
+
+    @Transactional
+    fun approve(id: Long) {
+        val user = authorizationService.currentUser()
+        val task = getTaskById(id)
+        authorizationService.requireTaskReviewer(user, task)
+        task.approve()
+        writeLog(task, user, TaskApprovalAction.APPROVE)
+        task.assignee?.requiredId?.let { assigneeId ->
+            eventPublisher.publishEvent(
+                TeamsNotificationEvent(
+                    userId = assigneeId,
+                    message = "[승인] '${task.name}' 태스크가 승인되었습니다.",
+                ),
+            )
+        }
+    }
+
+    @Transactional
+    fun reject(
+        id: Long,
+        reason: String?,
+    ) {
+        val user = authorizationService.currentUser()
+        val task = getTaskById(id)
+        authorizationService.requireTaskReviewer(user, task)
+        task.reject()
+        val normalizedReason = reason?.takeIf { it.isNotBlank() }
+        writeLog(task, user, TaskApprovalAction.REJECT, normalizedReason)
+        task.assignee?.requiredId?.let { assigneeId ->
+            val suffix = normalizedReason?.let { " 사유: $it" } ?: ""
+            eventPublisher.publishEvent(
+                TeamsNotificationEvent(
+                    userId = assigneeId,
+                    message = "[반려] '${task.name}' 태스크가 반려되었습니다.$suffix",
+                ),
+            )
+        }
+    }
+
+    fun findPendingReviews(): List<PendingReviewResponse> {
+        val user = authorizationService.currentUser()
+        val scopedProjectIds = authorizationService.pmScopedProjectIds(user)
+        val tasks =
+            when {
+                scopedProjectIds == null -> taskRepository.findByStatus(TaskStatus.IN_REVIEW)
+                scopedProjectIds.isEmpty() -> emptyList()
+                else -> taskRepository.findByStatusAndEpicProjectIdIn(TaskStatus.IN_REVIEW, scopedProjectIds)
+            }
+        if (tasks.isEmpty()) return emptyList()
+
+        val taskIds = tasks.map { it.requiredId }
+        val latestRequestedAt: Map<Long, LocalDateTime> =
+            taskApprovalLogRepository
+                .findLatestCreatedAtByTaskIdsAndAction(taskIds, TaskApprovalAction.REVIEW_REQUEST)
+                .associate { it.taskId to it.requestedAt }
+        val now = LocalDateTime.now()
+
+        return tasks
+            .map { task ->
+                val requestedAt = latestRequestedAt[task.requiredId] ?: now
+                PendingReviewResponse(
+                    taskId = task.requiredId,
+                    taskName = task.name,
+                    description = task.description,
+                    projectId = task.epic.project.requiredId,
+                    projectName = task.epic.project.name,
+                    epicId = task.epic.requiredId,
+                    epicName = task.epic.name,
+                    assigneeId = task.assignee?.id,
+                    assigneeName = task.assignee?.name,
+                    dueDate = task.dueDate,
+                    reviewRequestedAt = requestedAt,
+                    actions =
+                        PendingReviewActions(
+                            approve = ActionLink(method = "POST", url = "/tasks/${task.requiredId}/approve"),
+                            reject = ActionLink(method = "POST", url = "/tasks/${task.requiredId}/reject"),
+                        ),
+                )
+            }.sortedBy { it.reviewRequestedAt }
+    }
+
+    fun findApprovalLogs(id: Long): List<TaskApprovalLogResponse> {
+        val user = authorizationService.currentUser()
+        val task = getTaskById(id)
+        authorizationService.requireEpicAccess(user, task.epic.requiredId)
+        return taskApprovalLogRepository.findByTaskIdOrderByIdAsc(id).map { it.toResponse() }
+    }
+
+    private fun writeLog(
+        task: Task,
+        actor: User,
+        action: TaskApprovalAction,
+        reason: String? = null,
+    ) {
+        taskApprovalLogRepository.save(
+            TaskApprovalLog(
+                task = task,
+                actor = actor,
+                action = action,
+                reason = reason,
+            ),
+        )
+    }
+
+    private fun getTaskById(id: Long): Task =
+        taskRepository.findWithEpicAndProjectById(id)
+            ?: throw CustomException(ErrorCode.NOT_FOUND_TASK, id)
+}

--- a/src/main/kotlin/com/pluxity/weekly/task/service/TaskService.kt
+++ b/src/main/kotlin/com/pluxity/weekly/task/service/TaskService.kt
@@ -7,40 +7,28 @@ import com.pluxity.weekly.chat.dto.TaskSearchFilter
 import com.pluxity.weekly.core.constant.ErrorCode
 import com.pluxity.weekly.core.exception.CustomException
 import com.pluxity.weekly.epic.entity.Epic
-import com.pluxity.weekly.epic.entity.EpicStatus
 import com.pluxity.weekly.epic.repository.EpicRepository
-import com.pluxity.weekly.task.dto.ActionLink
-import com.pluxity.weekly.task.dto.PendingReviewActions
-import com.pluxity.weekly.task.dto.PendingReviewResponse
-import com.pluxity.weekly.task.dto.TaskApprovalLogResponse
 import com.pluxity.weekly.task.dto.TaskRequest
 import com.pluxity.weekly.task.dto.TaskResponse
 import com.pluxity.weekly.task.dto.TaskUpdateRequest
 import com.pluxity.weekly.task.dto.toResponse
 import com.pluxity.weekly.task.entity.Task
-import com.pluxity.weekly.task.entity.TaskApprovalAction
-import com.pluxity.weekly.task.entity.TaskApprovalLog
 import com.pluxity.weekly.task.entity.TaskStatus
-import com.pluxity.weekly.task.repository.TaskApprovalLogRepository
 import com.pluxity.weekly.task.repository.TaskRepository
-import com.pluxity.weekly.teams.converter.TaskReviewCardBuilder
 import com.pluxity.weekly.teams.event.TeamsNotificationEvent
 import org.springframework.context.ApplicationEventPublisher
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
-import java.time.LocalDateTime
 
 @Service
 @Transactional(readOnly = true)
 class TaskService(
     private val taskRepository: TaskRepository,
-    private val taskApprovalLogRepository: TaskApprovalLogRepository,
     private val epicRepository: EpicRepository,
     private val userRepository: UserRepository,
     private val authorizationService: AuthorizationService,
     private val eventPublisher: ApplicationEventPublisher,
-    private val taskReviewCardBuilder: TaskReviewCardBuilder,
 ) {
     fun findAll(): List<TaskResponse> = search(TaskSearchFilter())
 
@@ -107,136 +95,6 @@ class TaskService(
             startDate = request.startDate,
             dueDate = request.dueDate,
             assignee = newAssigneeId?.let { getUserById(it) },
-        )
-    }
-
-    @Transactional
-    fun requestReview(id: Long) {
-        val user = authorizationService.currentUser()
-        val task = getTaskById(id)
-        authorizationService.requireTaskOwner(user, task)
-        task.requestReview()
-        writeLog(task, user, TaskApprovalAction.REVIEW_REQUEST)
-        task.epic.project.pmId?.let { pmId ->
-            val card =
-                taskReviewCardBuilder.build(
-                    taskId = task.requiredId,
-                    taskName = task.name,
-                    projectName = task.epic.project.name,
-                    epicName = task.epic.name,
-                    requesterName = user.name,
-                )
-            eventPublisher.publishEvent(
-                TeamsNotificationEvent(
-                    userId = pmId,
-                    message = "[리뷰 요청] '${task.name}' 태스크가 리뷰 요청되었습니다. 요청자: ${user.name}",
-                    card = card,
-                ),
-            )
-        }
-    }
-
-    @Transactional
-    fun approve(id: Long) {
-        val user = authorizationService.currentUser()
-        val task = getTaskById(id)
-        authorizationService.requireTaskReviewer(user, task)
-        task.approve()
-        writeLog(task, user, TaskApprovalAction.APPROVE)
-        task.assignee?.requiredId?.let { assigneeId ->
-            eventPublisher.publishEvent(
-                TeamsNotificationEvent(
-                    userId = assigneeId,
-                    message = "[승인] '${task.name}' 태스크가 승인되었습니다.",
-                ),
-            )
-        }
-    }
-
-    @Transactional
-    fun reject(
-        id: Long,
-        reason: String?,
-    ) {
-        val user = authorizationService.currentUser()
-        val task = getTaskById(id)
-        authorizationService.requireTaskReviewer(user, task)
-        task.reject()
-        val normalizedReason = reason?.takeIf { it.isNotBlank() }
-        writeLog(task, user, TaskApprovalAction.REJECT, normalizedReason)
-        task.assignee?.requiredId?.let { assigneeId ->
-            val suffix = normalizedReason?.let { " 사유: $it" } ?: ""
-            eventPublisher.publishEvent(
-                TeamsNotificationEvent(
-                    userId = assigneeId,
-                    message = "[반려] '${task.name}' 태스크가 반려되었습니다.$suffix",
-                ),
-            )
-        }
-    }
-
-    fun findPendingReviews(): List<PendingReviewResponse> {
-        val user = authorizationService.currentUser()
-        val scopedProjectIds = authorizationService.pmScopedProjectIds(user)
-        val tasks =
-            when {
-                scopedProjectIds == null -> taskRepository.findByStatus(TaskStatus.IN_REVIEW)
-                scopedProjectIds.isEmpty() -> emptyList()
-                else -> taskRepository.findByStatusAndEpicProjectIdIn(TaskStatus.IN_REVIEW, scopedProjectIds)
-            }
-        if (tasks.isEmpty()) return emptyList()
-
-        val taskIds = tasks.map { it.requiredId }
-        val latestRequestedAt: Map<Long, LocalDateTime> =
-            taskApprovalLogRepository
-                .findLatestCreatedAtByTaskIdsAndAction(taskIds, TaskApprovalAction.REVIEW_REQUEST)
-                .associate { it.taskId to it.requestedAt }
-        val now = LocalDateTime.now()
-
-        return tasks
-            .map { task ->
-                val requestedAt = latestRequestedAt[task.requiredId] ?: now
-                PendingReviewResponse(
-                    taskId = task.requiredId,
-                    taskName = task.name,
-                    description = task.description,
-                    projectId = task.epic.project.requiredId,
-                    projectName = task.epic.project.name,
-                    epicId = task.epic.requiredId,
-                    epicName = task.epic.name,
-                    assigneeId = task.assignee?.id,
-                    assigneeName = task.assignee?.name,
-                    dueDate = task.dueDate,
-                    reviewRequestedAt = requestedAt,
-                    actions =
-                        PendingReviewActions(
-                            approve = ActionLink(method = "POST", url = "/tasks/${task.requiredId}/approve"),
-                            reject = ActionLink(method = "POST", url = "/tasks/${task.requiredId}/reject"),
-                        ),
-                )
-            }.sortedBy { it.reviewRequestedAt }
-    }
-
-    fun findApprovalLogs(id: Long): List<TaskApprovalLogResponse> {
-        val user = authorizationService.currentUser()
-        val task = getTaskById(id)
-        authorizationService.requireEpicAccess(user, task.epic.requiredId)
-        return taskApprovalLogRepository.findByTaskIdOrderByIdAsc(id).map { it.toResponse() }
-    }
-
-    private fun writeLog(
-        task: Task,
-        actor: User,
-        action: TaskApprovalAction,
-        reason: String? = null,
-    ) {
-        taskApprovalLogRepository.save(
-            TaskApprovalLog(
-                task = task,
-                actor = actor,
-                action = action,
-                reason = reason,
-            ),
         )
     }
 

--- a/src/main/kotlin/com/pluxity/weekly/teams/service/AsyncChatHandler.kt
+++ b/src/main/kotlin/com/pluxity/weekly/teams/service/AsyncChatHandler.kt
@@ -6,7 +6,7 @@ import com.pluxity.weekly.epic.dto.EpicRequest
 import com.pluxity.weekly.epic.service.EpicService
 import com.pluxity.weekly.project.dto.ProjectRequest
 import com.pluxity.weekly.project.service.ProjectService
-import com.pluxity.weekly.task.service.TaskService
+import com.pluxity.weekly.task.service.TaskReviewService
 import com.pluxity.weekly.teams.converter.AdaptiveCardConverter
 import com.pluxity.weekly.teams.dto.Activity
 import io.github.oshai.kotlinlogging.KotlinLogging
@@ -23,7 +23,7 @@ class AsyncChatHandler(
     private val messageSender: TeamsMessageSender,
     private val projectService: ProjectService,
     private val epicService: EpicService,
-    private val taskService: TaskService,
+    private val taskReviewService: TaskReviewService,
 ) {
     @Async
     fun handleMessage(activity: Activity) {
@@ -122,7 +122,7 @@ class AsyncChatHandler(
                         if (taskId == null) {
                             cardConverter.textMessage("태스크 ID 를 읽을 수 없습니다.")
                         } else {
-                            taskService.approve(taskId)
+                            taskReviewService.approve(taskId)
                             cardConverter.textMessage("태스크 승인이 완료되었습니다. (ID: $taskId)")
                         }
                     }
@@ -132,7 +132,7 @@ class AsyncChatHandler(
                             cardConverter.textMessage("태스크 ID 를 읽을 수 없습니다.")
                         } else {
                             val reason = (formData["reason"] as? String)?.takeIf { it.isNotBlank() }
-                            taskService.reject(taskId, reason)
+                            taskReviewService.reject(taskId, reason)
                             val suffix = reason?.let { " 사유: $it" } ?: ""
                             cardConverter.textMessage("태스크 반려가 완료되었습니다. (ID: $taskId)$suffix")
                         }

--- a/src/test/kotlin/com/pluxity/weekly/task/service/TaskReviewServiceTest.kt
+++ b/src/test/kotlin/com/pluxity/weekly/task/service/TaskReviewServiceTest.kt
@@ -271,4 +271,99 @@ class TaskReviewServiceTest :
                 }
             }
         }
+
+        Given("태스크 승인 로그 조회") {
+            When("정상적으로 조회하면") {
+                val epic = dummyEpic(id = 1L)
+                val taskEntity = dummyTask(id = 10L, epic = epic, name = "로그 대상")
+                val requester = dummyUser(id = 50L, name = "요청자")
+                val reviewer = dummyUser(id = 99L, name = "리뷰어")
+
+                val log1 = mockk<TaskApprovalLog>()
+                every { log1.requiredId } returns 1L
+                every { log1.task } returns taskEntity
+                every { log1.actor } returns requester
+                every { log1.action } returns TaskApprovalAction.REVIEW_REQUEST
+                every { log1.reason } returns null
+                every { log1.createdAt } returns LocalDateTime.of(2026, 4, 1, 9, 0)
+
+                val log2 = mockk<TaskApprovalLog>()
+                every { log2.requiredId } returns 2L
+                every { log2.task } returns taskEntity
+                every { log2.actor } returns reviewer
+                every { log2.action } returns TaskApprovalAction.APPROVE
+                every { log2.reason } returns null
+                every { log2.createdAt } returns LocalDateTime.of(2026, 4, 2, 10, 0)
+
+                every { taskRepository.findWithEpicAndProjectById(10L) } returns taskEntity
+                every { taskApprovalLogRepository.findByTaskIdOrderByIdAsc(10L) } returns listOf(log1, log2)
+
+                val result = service.findApprovalLogs(10L)
+
+                Then("저장 순서대로 DTO 로 매핑되어 반환된다") {
+                    result.size shouldBe 2
+                    result[0].id shouldBe 1L
+                    result[0].taskId shouldBe 10L
+                    result[0].actorId shouldBe 50L
+                    result[0].actorName shouldBe "요청자"
+                    result[0].action shouldBe TaskApprovalAction.REVIEW_REQUEST
+                    result[0].reason shouldBe null
+                    result[1].id shouldBe 2L
+                    result[1].actorId shouldBe 99L
+                    result[1].action shouldBe TaskApprovalAction.APPROVE
+                }
+            }
+
+            When("반려 사유가 있는 로그를 조회하면") {
+                val epic = dummyEpic(id = 2L)
+                val taskEntity = dummyTask(id = 11L, epic = epic, name = "반려 로그")
+                val reviewer = dummyUser(id = 99L, name = "리뷰어")
+
+                val rejectLog = mockk<TaskApprovalLog>()
+                every { rejectLog.requiredId } returns 3L
+                every { rejectLog.task } returns taskEntity
+                every { rejectLog.actor } returns reviewer
+                every { rejectLog.action } returns TaskApprovalAction.REJECT
+                every { rejectLog.reason } returns "요구사항 불충족"
+                every { rejectLog.createdAt } returns LocalDateTime.of(2026, 4, 3, 14, 0)
+
+                every { taskRepository.findWithEpicAndProjectById(11L) } returns taskEntity
+                every { taskApprovalLogRepository.findByTaskIdOrderByIdAsc(11L) } returns listOf(rejectLog)
+
+                val result = service.findApprovalLogs(11L)
+
+                Then("reason 이 응답에 포함된다") {
+                    result.size shouldBe 1
+                    result[0].action shouldBe TaskApprovalAction.REJECT
+                    result[0].reason shouldBe "요구사항 불충족"
+                }
+            }
+
+            When("로그가 없는 태스크를 조회하면") {
+                val epic = dummyEpic(id = 3L)
+                val taskEntity = dummyTask(id = 12L, epic = epic, name = "로그 없음")
+
+                every { taskRepository.findWithEpicAndProjectById(12L) } returns taskEntity
+                every { taskApprovalLogRepository.findByTaskIdOrderByIdAsc(12L) } returns emptyList()
+
+                val result = service.findApprovalLogs(12L)
+
+                Then("빈 목록이 반환된다") {
+                    result shouldBe emptyList()
+                }
+            }
+
+            When("존재하지 않는 태스크의 로그를 조회하면") {
+                every { taskRepository.findWithEpicAndProjectById(999L) } returns null
+
+                val exception =
+                    shouldThrow<CustomException> {
+                        service.findApprovalLogs(999L)
+                    }
+
+                Then("NOT_FOUND_TASK 예외가 발생한다") {
+                    exception.code shouldBe ErrorCode.NOT_FOUND_TASK
+                }
+            }
+        }
     })

--- a/src/test/kotlin/com/pluxity/weekly/task/service/TaskReviewServiceTest.kt
+++ b/src/test/kotlin/com/pluxity/weekly/task/service/TaskReviewServiceTest.kt
@@ -1,0 +1,274 @@
+package com.pluxity.weekly.task.service
+
+import com.pluxity.weekly.auth.authorization.AuthorizationService
+import com.pluxity.weekly.auth.user.entity.RoleType
+import com.pluxity.weekly.core.constant.ErrorCode
+import com.pluxity.weekly.core.exception.CustomException
+import com.pluxity.weekly.epic.entity.dummyEpic
+import com.pluxity.weekly.project.entity.dummyProject
+import com.pluxity.weekly.task.entity.TaskApprovalAction
+import com.pluxity.weekly.task.entity.TaskApprovalLog
+import com.pluxity.weekly.task.entity.TaskStatus
+import com.pluxity.weekly.task.entity.dummyTask
+import com.pluxity.weekly.task.repository.TaskApprovalLogRepository
+import com.pluxity.weekly.task.repository.TaskRepository
+import com.pluxity.weekly.task.repository.TaskReviewRequestedAt
+import com.pluxity.weekly.teams.converter.TaskReviewCardBuilder
+import com.pluxity.weekly.teams.event.TeamsNotificationEvent
+import com.pluxity.weekly.test.entity.dummyRole
+import com.pluxity.weekly.test.entity.dummyUser
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.runs
+import io.mockk.slot
+import io.mockk.verify
+import org.springframework.context.ApplicationEventPublisher
+import java.time.LocalDateTime
+
+class TaskReviewServiceTest :
+    BehaviorSpec({
+
+        val taskRepository: TaskRepository = mockk()
+        val taskApprovalLogRepository: TaskApprovalLogRepository = mockk(relaxed = true)
+        val authorizationService: AuthorizationService = mockk()
+        val eventPublisher: ApplicationEventPublisher = mockk(relaxed = true)
+        val taskReviewCardBuilder: TaskReviewCardBuilder = mockk(relaxed = true)
+        val service =
+            TaskReviewService(
+                taskRepository,
+                taskApprovalLogRepository,
+                authorizationService,
+                eventPublisher,
+                taskReviewCardBuilder,
+            )
+
+        val adminUser =
+            dummyUser(id = 1L, name = "관리자").apply {
+                addRole(dummyRole(id = 1L, name = "ADMIN").apply { auth = RoleType.ADMIN.name })
+            }
+
+        beforeSpec {
+            every { authorizationService.currentUser() } returns adminUser
+            every { authorizationService.requireEpicAccess(any(), any()) } just runs
+            every { authorizationService.requireTaskOwner(any(), any()) } just runs
+            every { authorizationService.requireTaskReviewer(any(), any()) } just runs
+            every { authorizationService.pmScopedProjectIds(any()) } returns null
+            every { taskApprovalLogRepository.save(any<TaskApprovalLog>()) } answers { firstArg() }
+        }
+
+        Given("태스크 검수 요청") {
+            When("IN_PROGRESS 태스크를 검수 요청하면") {
+                val pmId = 99L
+                val project = dummyProject(id = 1L, pmId = pmId)
+                val epic = dummyEpic(id = 1L, project = project)
+                val entity =
+                    dummyTask(
+                        id = 10L,
+                        epic = epic,
+                        name = "리뷰 태스크",
+                        status = TaskStatus.IN_PROGRESS,
+                    )
+
+                every { taskRepository.findWithEpicAndProjectById(10L) } returns entity
+                val eventSlot = slot<Any>()
+                every { eventPublisher.publishEvent(capture(eventSlot)) } just runs
+
+                service.requestReview(10L)
+
+                Then("태스크 상태가 IN_REVIEW 로 변경되고 PM 에게 알림이 발행된다") {
+                    entity.status shouldBe TaskStatus.IN_REVIEW
+                    verify(exactly = 1) { taskApprovalLogRepository.save(any<TaskApprovalLog>()) }
+                    (eventSlot.captured as TeamsNotificationEvent).userId shouldBe pmId
+                }
+            }
+
+            When("이미 IN_REVIEW 인 태스크를 다시 검수 요청하면") {
+                val project = dummyProject(id = 1L, pmId = 99L)
+                val epic = dummyEpic(id = 1L, project = project)
+                val entity =
+                    dummyTask(
+                        id = 11L,
+                        epic = epic,
+                        name = "이미 리뷰중",
+                        status = TaskStatus.IN_REVIEW,
+                    )
+
+                every { taskRepository.findWithEpicAndProjectById(11L) } returns entity
+
+                val exception =
+                    shouldThrow<CustomException> {
+                        service.requestReview(11L)
+                    }
+
+                Then("INVALID_TASK_STATUS_TRANSITION 예외가 발생한다") {
+                    exception.code shouldBe ErrorCode.INVALID_STATUS_TRANSITION
+                }
+            }
+        }
+
+        Given("태스크 승인") {
+            When("IN_REVIEW 태스크를 승인하면") {
+                val project = dummyProject(id = 1L, pmId = 99L)
+                val epic = dummyEpic(id = 1L, project = project)
+                val assignee = dummyUser(id = 50L, name = "담당자")
+                val entity =
+                    dummyTask(
+                        id = 20L,
+                        epic = epic,
+                        name = "승인 대상",
+                        status = TaskStatus.IN_REVIEW,
+                    ).apply { this.assignee = assignee }
+
+                every { taskRepository.findWithEpicAndProjectById(20L) } returns entity
+                val eventSlot = slot<Any>()
+                every { eventPublisher.publishEvent(capture(eventSlot)) } just runs
+
+                service.approve(20L)
+
+                Then("태스크 상태가 DONE 으로 변경되고 담당자에게 알림이 발행된다") {
+                    entity.status shouldBe TaskStatus.DONE
+                    verify(exactly = 1) { taskApprovalLogRepository.save(any<TaskApprovalLog>()) }
+                    (eventSlot.captured as TeamsNotificationEvent).userId shouldBe 50L
+                }
+            }
+
+            When("IN_PROGRESS 태스크를 승인하면") {
+                val entity = dummyTask(id = 21L, status = TaskStatus.IN_PROGRESS)
+                every { taskRepository.findWithEpicAndProjectById(21L) } returns entity
+
+                val exception =
+                    shouldThrow<CustomException> {
+                        service.approve(21L)
+                    }
+
+                Then("INVALID_TASK_STATUS_TRANSITION 예외가 발생한다") {
+                    exception.code shouldBe ErrorCode.INVALID_STATUS_TRANSITION
+                }
+            }
+        }
+
+        Given("태스크 반려") {
+            When("IN_REVIEW 태스크를 사유와 함께 반려하면") {
+                val project = dummyProject(id = 1L, pmId = 99L)
+                val epic = dummyEpic(id = 1L, project = project)
+                val entity =
+                    dummyTask(
+                        id = 30L,
+                        epic = epic,
+                        name = "반려 대상",
+                        status = TaskStatus.IN_REVIEW,
+                    )
+
+                every { taskRepository.findWithEpicAndProjectById(30L) } returns entity
+                every { eventPublisher.publishEvent(any<TeamsNotificationEvent>()) } just runs
+                val logSlot = slot<TaskApprovalLog>()
+                every { taskApprovalLogRepository.save(capture(logSlot)) } answers { logSlot.captured }
+
+                service.reject(30L, "요구사항 불충족")
+
+                Then("태스크 상태가 IN_PROGRESS 로 복귀되고 반려 사유가 로그에 기록된다") {
+                    entity.status shouldBe TaskStatus.IN_PROGRESS
+                    logSlot.captured.action shouldBe TaskApprovalAction.REJECT
+                    logSlot.captured.reason shouldBe "요구사항 불충족"
+                }
+            }
+
+            When("사유 없이(null) 반려하면") {
+                val project = dummyProject(id = 1L, pmId = 99L)
+                val epic = dummyEpic(id = 1L, project = project)
+                val entity =
+                    dummyTask(
+                        id = 31L,
+                        epic = epic,
+                        name = "사유 없는 반려",
+                        status = TaskStatus.IN_REVIEW,
+                    )
+
+                every { taskRepository.findWithEpicAndProjectById(31L) } returns entity
+                every { eventPublisher.publishEvent(any<TeamsNotificationEvent>()) } just runs
+                val logSlot = slot<TaskApprovalLog>()
+                every { taskApprovalLogRepository.save(capture(logSlot)) } answers { logSlot.captured }
+
+                service.reject(31L, null)
+
+                Then("태스크 상태가 IN_PROGRESS 로 복귀되고 reason 은 null 로 기록된다") {
+                    entity.status shouldBe TaskStatus.IN_PROGRESS
+                    logSlot.captured.action shouldBe TaskApprovalAction.REJECT
+                    logSlot.captured.reason shouldBe null
+                }
+            }
+        }
+
+        Given("검수 대기 큐 조회") {
+            When("ADMIN 이 조회하면") {
+                val project = dummyProject(id = 1L, pmId = 99L)
+                val epic = dummyEpic(id = 1L, project = project)
+                val t1 = dummyTask(id = 100L, epic = epic, name = "먼저 요청", status = TaskStatus.IN_REVIEW)
+                val t2 = dummyTask(id = 101L, epic = epic, name = "나중 요청", status = TaskStatus.IN_REVIEW)
+
+                every { authorizationService.pmScopedProjectIds(any()) } returns null
+                every { taskRepository.findByStatus(TaskStatus.IN_REVIEW) } returns listOf(t2, t1)
+                every {
+                    taskApprovalLogRepository.findLatestCreatedAtByTaskIdsAndAction(
+                        any(),
+                        TaskApprovalAction.REVIEW_REQUEST,
+                    )
+                } returns
+                    listOf(
+                        TaskReviewRequestedAt(100L, LocalDateTime.of(2026, 4, 1, 9, 0)),
+                        TaskReviewRequestedAt(101L, LocalDateTime.of(2026, 4, 8, 9, 0)),
+                    )
+
+                val result = service.findPendingReviews()
+
+                Then("오래 기다린 순으로 정렬되고 actions URL 이 포함된다") {
+                    result.size shouldBe 2
+                    result[0].taskId shouldBe 100L
+                    result[1].taskId shouldBe 101L
+                    result[0].actions.approve.url shouldBe "/tasks/100/approve"
+                    result[0].actions.reject.url shouldBe "/tasks/100/reject"
+                    result[0].actions.approve.method shouldBe "POST"
+                    result[0].reviewRequestedAt shouldBe LocalDateTime.of(2026, 4, 1, 9, 0)
+                }
+            }
+
+            When("PM 이 본인 프로젝트 범위만 조회하면") {
+                val project = dummyProject(id = 5L, pmId = 99L)
+                val epic = dummyEpic(id = 50L, project = project)
+                val t = dummyTask(id = 200L, epic = epic, status = TaskStatus.IN_REVIEW)
+
+                every { authorizationService.pmScopedProjectIds(any()) } returns listOf(5L)
+                every {
+                    taskRepository.findByStatusAndEpicProjectIdIn(TaskStatus.IN_REVIEW, listOf(5L))
+                } returns listOf(t)
+                every {
+                    taskApprovalLogRepository.findLatestCreatedAtByTaskIdsAndAction(
+                        listOf(200L),
+                        TaskApprovalAction.REVIEW_REQUEST,
+                    )
+                } returns listOf(TaskReviewRequestedAt(200L, LocalDateTime.of(2026, 4, 5, 12, 0)))
+
+                val result = service.findPendingReviews()
+
+                Then("PM 범위 프로젝트의 태스크만 반환된다") {
+                    result.size shouldBe 1
+                    result[0].taskId shouldBe 200L
+                    result[0].projectId shouldBe 5L
+                }
+            }
+
+            When("PM 이 담당 프로젝트가 없으면") {
+                every { authorizationService.pmScopedProjectIds(any()) } returns emptyList()
+
+                val result = service.findPendingReviews()
+
+                Then("빈 목록이 반환된다") {
+                    result shouldBe emptyList()
+                }
+            }
+        }
+    })

--- a/src/test/kotlin/com/pluxity/weekly/task/service/TaskServiceTest.kt
+++ b/src/test/kotlin/com/pluxity/weekly/task/service/TaskServiceTest.kt
@@ -7,18 +7,12 @@ import com.pluxity.weekly.core.constant.ErrorCode
 import com.pluxity.weekly.core.exception.CustomException
 import com.pluxity.weekly.epic.entity.dummyEpic
 import com.pluxity.weekly.epic.repository.EpicRepository
-import com.pluxity.weekly.project.entity.dummyProject
 import com.pluxity.weekly.task.dto.dummyTaskRequest
 import com.pluxity.weekly.task.dto.dummyTaskUpdateRequest
 import com.pluxity.weekly.task.entity.Task
-import com.pluxity.weekly.task.entity.TaskApprovalAction
-import com.pluxity.weekly.task.entity.TaskApprovalLog
 import com.pluxity.weekly.task.entity.TaskStatus
 import com.pluxity.weekly.task.entity.dummyTask
-import com.pluxity.weekly.task.repository.TaskApprovalLogRepository
 import com.pluxity.weekly.task.repository.TaskRepository
-import com.pluxity.weekly.task.repository.TaskReviewRequestedAt
-import com.pluxity.weekly.teams.converter.TaskReviewCardBuilder
 import com.pluxity.weekly.teams.event.TeamsNotificationEvent
 import com.pluxity.weekly.test.entity.dummyRole
 import com.pluxity.weekly.test.entity.dummyUser
@@ -34,27 +28,22 @@ import io.mockk.verify
 import org.springframework.context.ApplicationEventPublisher
 import org.springframework.data.repository.findByIdOrNull
 import java.time.LocalDate
-import java.time.LocalDateTime
 
 class TaskServiceTest :
     BehaviorSpec({
 
         val taskRepository: TaskRepository = mockk()
-        val taskApprovalLogRepository: TaskApprovalLogRepository = mockk(relaxed = true)
         val epicRepository: EpicRepository = mockk()
         val userRepository: UserRepository = mockk()
         val authorizationService: AuthorizationService = mockk()
         val eventPublisher: ApplicationEventPublisher = mockk(relaxed = true)
-        val taskReviewCardBuilder: TaskReviewCardBuilder = mockk(relaxed = true)
         val service =
             TaskService(
                 taskRepository,
-                taskApprovalLogRepository,
                 epicRepository,
                 userRepository,
                 authorizationService,
                 eventPublisher,
-                taskReviewCardBuilder,
             )
 
         val adminUser =
@@ -66,11 +55,8 @@ class TaskServiceTest :
             every { authorizationService.currentUser() } returns adminUser
             every { authorizationService.requireEpicAccess(any(), any()) } just runs
             every { authorizationService.requireTaskOwner(any(), any()) } just runs
-            every { authorizationService.requireTaskReviewer(any(), any()) } just runs
             every { authorizationService.visibleEpicIds(any()) } returns null
             every { authorizationService.restrictedAssigneeId(any()) } returns null
-            every { authorizationService.pmScopedProjectIds(any()) } returns null
-            every { taskApprovalLogRepository.save(any<TaskApprovalLog>()) } answers { firstArg() }
         }
 
         Given("태스크 전체 조회") {
@@ -390,218 +376,6 @@ class TaskServiceTest :
 
                 Then("NOT_FOUND 예외가 발생한다") {
                     exception.code shouldBe ErrorCode.NOT_FOUND_TASK
-                }
-            }
-        }
-
-        Given("태스크 검수 요청") {
-            When("IN_PROGRESS 태스크를 검수 요청하면") {
-                val pmId = 99L
-                val project = dummyProject(id = 1L, pmId = pmId)
-                val epic = dummyEpic(id = 1L, project = project)
-                val entity =
-                    dummyTask(
-                        id = 10L,
-                        epic = epic,
-                        name = "리뷰 태스크",
-                        status = TaskStatus.IN_PROGRESS,
-                    )
-
-                every { taskRepository.findWithEpicAndProjectById(10L) } returns entity
-                val eventSlot = slot<Any>()
-                every { eventPublisher.publishEvent(capture(eventSlot)) } just runs
-
-                service.requestReview(10L)
-
-                Then("태스크 상태가 IN_REVIEW 로 변경되고 PM 에게 알림이 발행된다") {
-                    entity.status shouldBe TaskStatus.IN_REVIEW
-                    verify(exactly = 1) { taskApprovalLogRepository.save(any<TaskApprovalLog>()) }
-                    (eventSlot.captured as TeamsNotificationEvent).userId shouldBe pmId
-                }
-            }
-
-            When("이미 IN_REVIEW 인 태스크를 다시 검수 요청하면") {
-                val project = dummyProject(id = 1L, pmId = 99L)
-                val epic = dummyEpic(id = 1L, project = project)
-                val entity =
-                    dummyTask(
-                        id = 11L,
-                        epic = epic,
-                        name = "이미 리뷰중",
-                        status = TaskStatus.IN_REVIEW,
-                    )
-
-                every { taskRepository.findWithEpicAndProjectById(11L) } returns entity
-
-                val exception =
-                    shouldThrow<CustomException> {
-                        service.requestReview(11L)
-                    }
-
-                Then("INVALID_TASK_STATUS_TRANSITION 예외가 발생한다") {
-                    exception.code shouldBe ErrorCode.INVALID_STATUS_TRANSITION
-                }
-            }
-        }
-
-        Given("태스크 승인") {
-            When("IN_REVIEW 태스크를 승인하면") {
-                val project = dummyProject(id = 1L, pmId = 99L)
-                val epic = dummyEpic(id = 1L, project = project)
-                val assignee = dummyUser(id = 50L, name = "담당자")
-                val entity =
-                    dummyTask(
-                        id = 20L,
-                        epic = epic,
-                        name = "승인 대상",
-                        status = TaskStatus.IN_REVIEW,
-                    ).apply { this.assignee = assignee }
-
-                every { taskRepository.findWithEpicAndProjectById(20L) } returns entity
-                val eventSlot = slot<Any>()
-                every { eventPublisher.publishEvent(capture(eventSlot)) } just runs
-
-                service.approve(20L)
-
-                Then("태스크 상태가 DONE 으로 변경되고 담당자에게 알림이 발행된다") {
-                    entity.status shouldBe TaskStatus.DONE
-                    verify(exactly = 1) { taskApprovalLogRepository.save(any<TaskApprovalLog>()) }
-                    (eventSlot.captured as TeamsNotificationEvent).userId shouldBe 50L
-                }
-            }
-
-            When("IN_PROGRESS 태스크를 승인하면") {
-                val entity = dummyTask(id = 21L, status = TaskStatus.IN_PROGRESS)
-                every { taskRepository.findWithEpicAndProjectById(21L) } returns entity
-
-                val exception =
-                    shouldThrow<CustomException> {
-                        service.approve(21L)
-                    }
-
-                Then("INVALID_TASK_STATUS_TRANSITION 예외가 발생한다") {
-                    exception.code shouldBe ErrorCode.INVALID_STATUS_TRANSITION
-                }
-            }
-        }
-
-        Given("태스크 반려") {
-            When("IN_REVIEW 태스크를 사유와 함께 반려하면") {
-                val project = dummyProject(id = 1L, pmId = 99L)
-                val epic = dummyEpic(id = 1L, project = project)
-                val entity =
-                    dummyTask(
-                        id = 30L,
-                        epic = epic,
-                        name = "반려 대상",
-                        status = TaskStatus.IN_REVIEW,
-                    )
-
-                every { taskRepository.findWithEpicAndProjectById(30L) } returns entity
-                every { eventPublisher.publishEvent(any<TeamsNotificationEvent>()) } just runs
-                val logSlot = slot<TaskApprovalLog>()
-                every { taskApprovalLogRepository.save(capture(logSlot)) } answers { logSlot.captured }
-
-                service.reject(30L, "요구사항 불충족")
-
-                Then("태스크 상태가 IN_PROGRESS 로 복귀되고 반려 사유가 로그에 기록된다") {
-                    entity.status shouldBe TaskStatus.IN_PROGRESS
-                    logSlot.captured.action shouldBe TaskApprovalAction.REJECT
-                    logSlot.captured.reason shouldBe "요구사항 불충족"
-                }
-            }
-
-            When("사유 없이(null) 반려하면") {
-                val project = dummyProject(id = 1L, pmId = 99L)
-                val epic = dummyEpic(id = 1L, project = project)
-                val entity =
-                    dummyTask(
-                        id = 31L,
-                        epic = epic,
-                        name = "사유 없는 반려",
-                        status = TaskStatus.IN_REVIEW,
-                    )
-
-                every { taskRepository.findWithEpicAndProjectById(31L) } returns entity
-                every { eventPublisher.publishEvent(any<TeamsNotificationEvent>()) } just runs
-                val logSlot = slot<TaskApprovalLog>()
-                every { taskApprovalLogRepository.save(capture(logSlot)) } answers { logSlot.captured }
-
-                service.reject(31L, null)
-
-                Then("태스크 상태가 IN_PROGRESS 로 복귀되고 reason 은 null 로 기록된다") {
-                    entity.status shouldBe TaskStatus.IN_PROGRESS
-                    logSlot.captured.action shouldBe TaskApprovalAction.REJECT
-                    logSlot.captured.reason shouldBe null
-                }
-            }
-        }
-
-        Given("검수 대기 큐 조회") {
-            When("ADMIN 이 조회하면") {
-                val project = dummyProject(id = 1L, pmId = 99L)
-                val epic = dummyEpic(id = 1L, project = project)
-                val t1 = dummyTask(id = 100L, epic = epic, name = "먼저 요청", status = TaskStatus.IN_REVIEW)
-                val t2 = dummyTask(id = 101L, epic = epic, name = "나중 요청", status = TaskStatus.IN_REVIEW)
-
-                every { authorizationService.pmScopedProjectIds(any()) } returns null
-                every { taskRepository.findByStatus(TaskStatus.IN_REVIEW) } returns listOf(t2, t1)
-                every {
-                    taskApprovalLogRepository.findLatestCreatedAtByTaskIdsAndAction(
-                        any(),
-                        TaskApprovalAction.REVIEW_REQUEST,
-                    )
-                } returns
-                    listOf(
-                        TaskReviewRequestedAt(100L, LocalDateTime.of(2026, 4, 1, 9, 0)),
-                        TaskReviewRequestedAt(101L, LocalDateTime.of(2026, 4, 8, 9, 0)),
-                    )
-
-                val result = service.findPendingReviews()
-
-                Then("오래 기다린 순으로 정렬되고 actions URL 이 포함된다") {
-                    result.size shouldBe 2
-                    result[0].taskId shouldBe 100L
-                    result[1].taskId shouldBe 101L
-                    result[0].actions.approve.url shouldBe "/tasks/100/approve"
-                    result[0].actions.reject.url shouldBe "/tasks/100/reject"
-                    result[0].actions.approve.method shouldBe "POST"
-                    result[0].reviewRequestedAt shouldBe LocalDateTime.of(2026, 4, 1, 9, 0)
-                }
-            }
-
-            When("PM 이 본인 프로젝트 범위만 조회하면") {
-                val project = dummyProject(id = 5L, pmId = 99L)
-                val epic = dummyEpic(id = 50L, project = project)
-                val t = dummyTask(id = 200L, epic = epic, status = TaskStatus.IN_REVIEW)
-
-                every { authorizationService.pmScopedProjectIds(any()) } returns listOf(5L)
-                every {
-                    taskRepository.findByStatusAndEpicProjectIdIn(TaskStatus.IN_REVIEW, listOf(5L))
-                } returns listOf(t)
-                every {
-                    taskApprovalLogRepository.findLatestCreatedAtByTaskIdsAndAction(
-                        listOf(200L),
-                        TaskApprovalAction.REVIEW_REQUEST,
-                    )
-                } returns listOf(TaskReviewRequestedAt(200L, LocalDateTime.of(2026, 4, 5, 12, 0)))
-
-                val result = service.findPendingReviews()
-
-                Then("PM 범위 프로젝트의 태스크만 반환된다") {
-                    result.size shouldBe 1
-                    result[0].taskId shouldBe 200L
-                    result[0].projectId shouldBe 5L
-                }
-            }
-
-            When("PM 이 담당 프로젝트가 없으면") {
-                every { authorizationService.pmScopedProjectIds(any()) } returns emptyList()
-
-                val result = service.findPendingReviews()
-
-                Then("빈 목록이 반환된다") {
-                    result shouldBe emptyList()
                 }
             }
         }


### PR DESCRIPTION
## Summary

- `TaskService`에 섞여 있던 리뷰 플로우를 별도 `TaskReviewService`로 분리
- 서비스 책임 분리 (CRUD vs 리뷰 라이프사이클), 테스트 격리

Resolves #42

## Changes

### 신규
- `TaskReviewService.kt` — `requestReview` / `approve` / `reject` / `findPendingReviews` / `findApprovalLogs` + 내부 `writeLog` / `getTaskById`
- `TaskReviewServiceTest.kt` — 4개 Given 블록 이관 (검수 요청 / 승인 / 반려 / 대기 큐)

### 수정
- `TaskService.kt` — 리뷰 관련 메서드·`writeLog` 제거, 생성자에서 `taskApprovalLogRepository`/`taskReviewCardBuilder` 의존성 제거
- `TaskController.kt` — `TaskReviewService` 주입, 5개 리뷰 엔드포인트 라우팅 변경
- `ChatExecutor.kt` / `ChatReadHandler.kt` / `AsyncChatHandler.kt` — 리뷰 호출을 `taskReviewService` 경유로 변경
- `TaskServiceTest.kt` — 리뷰 블록 및 관련 import/mock 정리
- `ChatActionType.kt` / `ChatTarget.kt` — spotless 포매팅 (별도 커밋)

## 동작 변화

없음. 엔드포인트·스펙·흐름 모두 동일. 내부 구조 리팩터링만.

## Test plan

- [x] `./gradlew test` 전체 통과
- [x] `./gradlew spotlessApply` 적용
- [ ] API 엔드포인트 smoke test (`POST /tasks/{id}/review-request`, `/approve`, `/reject`, `GET /tasks/pending-reviews`, `/tasks/{id}/approval-logs`)