### PR TITLE
refactor: EpicAssignmentService 분리 (#43)

### DIFF
--- a/src/main/kotlin/com/pluxity/weekly/chat/controller/ChatController.kt
+++ b/src/main/kotlin/com/pluxity/weekly/chat/controller/ChatController.kt
@@ -60,7 +60,7 @@ class ChatController(
                 content = [
                     Content(
                         mediaType = "application/json",
-                        schema = Schema( ClarifyErrorResponseBody::class),
+                        schema = Schema(ClarifyErrorResponseBody::class),
                     ),
                 ],
             ),

--- a/src/main/kotlin/com/pluxity/weekly/chat/service/ChatExecutor.kt
+++ b/src/main/kotlin/com/pluxity/weekly/chat/service/ChatExecutor.kt
@@ -3,6 +3,7 @@ package com.pluxity.weekly.chat.service
 import com.pluxity.weekly.chat.dto.ChatActionType
 import com.pluxity.weekly.chat.dto.ChatTarget
 import com.pluxity.weekly.chat.dto.LlmAction
+import com.pluxity.weekly.epic.service.EpicAssignmentService
 import com.pluxity.weekly.epic.service.EpicService
 import com.pluxity.weekly.project.service.ProjectService
 import com.pluxity.weekly.task.service.TaskReviewService
@@ -17,6 +18,7 @@ import org.springframework.stereotype.Component
 class ChatExecutor(
     private val projectService: ProjectService,
     private val epicService: EpicService,
+    private val epicAssignmentService: EpicAssignmentService,
     private val taskService: TaskService,
     private val taskReviewService: TaskReviewService,
 ) {
@@ -40,7 +42,7 @@ class ChatExecutor(
         if (ChatTarget.fromOrNull(action.target) != ChatTarget.EPIC) return null
         val id = action.id ?: return null
         action.userIds?.forEach { userId ->
-            epicService.assign(id, userId)
+            epicAssignmentService.assign(id, userId)
         }
         return id
     }
@@ -49,7 +51,7 @@ class ChatExecutor(
         if (ChatTarget.fromOrNull(action.target) != ChatTarget.EPIC) return null
         val id = action.id ?: return null
         action.removeUserIds?.forEach { userId ->
-            epicService.unassign(id, userId)
+            epicAssignmentService.unassign(id, userId)
         }
         return id
     }

--- a/src/main/kotlin/com/pluxity/weekly/chat/service/SelectFieldResolver.kt
+++ b/src/main/kotlin/com/pluxity/weekly/chat/service/SelectFieldResolver.kt
@@ -8,6 +8,7 @@ import com.pluxity.weekly.chat.dto.ChatTarget
 import com.pluxity.weekly.chat.dto.LlmAction
 import com.pluxity.weekly.chat.dto.SelectField
 import com.pluxity.weekly.epic.repository.EpicRepository
+import com.pluxity.weekly.epic.service.EpicAssignmentService
 import com.pluxity.weekly.epic.service.EpicService
 import com.pluxity.weekly.project.repository.ProjectRepository
 import com.pluxity.weekly.project.service.ProjectService
@@ -23,6 +24,7 @@ class SelectFieldResolver(
     private val userRepository: UserRepository,
     private val projectService: ProjectService,
     private val epicService: EpicService,
+    private val epicAssignmentService: EpicAssignmentService,
 ) {
     fun resolve(action: LlmAction): List<SelectField> {
         val missingFields = action.missingFields ?: emptyList()
@@ -105,7 +107,7 @@ class SelectFieldResolver(
 
     private fun resolveRemoveUserCandidates(action: LlmAction): SelectField? {
         if (ChatTarget.fromOrNull(action.target) != ChatTarget.EPIC || action.id == null) return null
-        val assigneeIds = epicService.findAssignments(action.id).map { it.userId }
+        val assigneeIds = epicAssignmentService.findByEpic(action.id).map { it.userId }
         if (assigneeIds.isEmpty()) return null
         val candidates =
             userRepository

--- a/src/main/kotlin/com/pluxity/weekly/epic/controller/EpicController.kt
+++ b/src/main/kotlin/com/pluxity/weekly/epic/controller/EpicController.kt
@@ -7,6 +7,7 @@ import com.pluxity.weekly.epic.dto.EpicAssignmentResponse
 import com.pluxity.weekly.epic.dto.EpicRequest
 import com.pluxity.weekly.epic.dto.EpicResponse
 import com.pluxity.weekly.epic.dto.EpicUpdateRequest
+import com.pluxity.weekly.epic.service.EpicAssignmentService
 import com.pluxity.weekly.epic.service.EpicService
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.media.Content
@@ -30,6 +31,7 @@ import org.springframework.web.bind.annotation.RestController
 @Tag(name = "Epic Controller", description = "에픽 관리 API")
 class EpicController(
     private val service: EpicService,
+    private val assignmentService: EpicAssignmentService,
 ) {
     @Operation(summary = "에픽 전체 조회", description = "에픽 전체 목록을 조회합니다")
     @ApiResponses(
@@ -131,7 +133,8 @@ class EpicController(
     @GetMapping("/{epicId}/assignments")
     fun findAssignments(
         @PathVariable epicId: Long,
-    ): ResponseEntity<DataResponseBody<List<EpicAssignmentResponse>>> = ResponseEntity.ok(DataResponseBody(service.findAssignments(epicId)))
+    ): ResponseEntity<DataResponseBody<List<EpicAssignmentResponse>>> =
+        ResponseEntity.ok(DataResponseBody(assignmentService.findByEpic(epicId)))
 
     @Operation(summary = "에픽 사용자 배정", description = "에픽에 사용자를 배정합니다")
     @ApiResponses(
@@ -154,7 +157,7 @@ class EpicController(
         @PathVariable epicId: Long,
         @PathVariable userId: Long,
     ): ResponseEntity<Void> {
-        service.assign(epicId, userId)
+        assignmentService.assign(epicId, userId)
         return ResponseEntity.noContent().build()
     }
 
@@ -174,7 +177,7 @@ class EpicController(
         @PathVariable epicId: Long,
         @PathVariable userId: Long,
     ): ResponseEntity<Void> {
-        service.unassign(epicId, userId)
+        assignmentService.unassign(epicId, userId)
         return ResponseEntity.noContent().build()
     }
 }

--- a/src/main/kotlin/com/pluxity/weekly/epic/service/EpicAssignmentService.kt
+++ b/src/main/kotlin/com/pluxity/weekly/epic/service/EpicAssignmentService.kt
@@ -1,0 +1,121 @@
+package com.pluxity.weekly.epic.service
+
+import com.pluxity.weekly.auth.authorization.AuthorizationService
+import com.pluxity.weekly.auth.user.entity.User
+import com.pluxity.weekly.auth.user.repository.UserRepository
+import com.pluxity.weekly.core.constant.ErrorCode
+import com.pluxity.weekly.core.exception.CustomException
+import com.pluxity.weekly.epic.dto.EpicAssignmentResponse
+import com.pluxity.weekly.epic.dto.toResponse
+import com.pluxity.weekly.epic.entity.Epic
+import com.pluxity.weekly.epic.repository.EpicRepository
+import com.pluxity.weekly.task.repository.TaskRepository
+import com.pluxity.weekly.teams.event.TeamsNotificationEvent
+import org.springframework.context.ApplicationEventPublisher
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+@Transactional(readOnly = true)
+class EpicAssignmentService(
+    private val epicRepository: EpicRepository,
+    private val userRepository: UserRepository,
+    private val taskRepository: TaskRepository,
+    private val authorizationService: AuthorizationService,
+    private val eventPublisher: ApplicationEventPublisher,
+) {
+    fun findByEpic(epicId: Long): List<EpicAssignmentResponse> = getEpicById(epicId).assignments.map { it.toResponse() }
+
+    @Transactional
+    fun assign(
+        epicId: Long,
+        userId: Long,
+    ) {
+        val user = authorizationService.currentUser()
+        authorizationService.requireEpicAssign(user, epicId)
+        val epic = getEpicById(epicId)
+        epic.ensureMutable("assign")
+        val assignee = getUserById(userId)
+        if (epic.assignments.any { it.user == assignee }) {
+            throw CustomException(ErrorCode.DUPLICATE_EPIC_ASSIGNMENT, userId, epicId)
+        }
+        assignAndNotify(epic, assignee)
+    }
+
+    @Transactional
+    fun unassign(
+        epicId: Long,
+        userId: Long,
+    ) {
+        val user = authorizationService.currentUser()
+        authorizationService.requireEpicAssign(user, epicId)
+        val epic = getEpicById(epicId)
+        epic.ensureMutable("unassign")
+        val assignee = getUserById(userId)
+        if (epic.assignments.none { it.user == assignee }) {
+            throw CustomException(ErrorCode.NOT_FOUND_EPIC_ASSIGNMENT, epicId, userId)
+        }
+        unassignAndNotify(epic, assignee)
+    }
+
+    @Transactional
+    fun sync(
+        epic: Epic,
+        userIds: List<Long>,
+    ) {
+        val requestedUsers = userRepository.findAllById(userIds)
+
+        epic.assignments
+            .filter { it.user !in requestedUsers }
+            .map { it.user }
+            .forEach { unassignAndNotify(epic, it) }
+
+        requestedUsers
+            .filter { user -> epic.assignments.none { it.user == user } }
+            .forEach { assignAndNotify(epic, it) }
+    }
+
+    @Transactional
+    fun ensureAssigned(
+        actor: User,
+        assigneeId: Long?,
+        epic: Epic,
+    ) {
+        if (assigneeId == null) return
+        authorizationService.requireAdminOrPm(actor)
+        if (!epicRepository.existsByAssignmentsUserIdAndId(assigneeId, epic.requiredId)) {
+            val assignee = getUserById(assigneeId)
+            assignAndNotify(epic, assignee)
+        }
+    }
+
+    private fun assignAndNotify(
+        epic: Epic,
+        assignee: User,
+    ) {
+        epic.assign(assignee)
+        eventPublisher.publishEvent(
+            TeamsNotificationEvent(assignee.requiredId, "${epic.name} 에픽에 배정되었습니다"),
+        )
+    }
+
+    private fun unassignAndNotify(
+        epic: Epic,
+        assignee: User,
+    ) {
+        epic.unassign(assignee)
+        taskRepository.deleteByEpicIdAndAssigneeId(epic.requiredId, assignee.requiredId)
+        eventPublisher.publishEvent(
+            TeamsNotificationEvent(assignee.requiredId, "${epic.name} 에픽에서 해제되었습니다"),
+        )
+    }
+
+    private fun getEpicById(id: Long): Epic =
+        epicRepository.findByIdOrNull(id)
+            ?: throw CustomException(ErrorCode.NOT_FOUND_EPIC, id)
+
+    private fun getUserById(id: Long): User =
+        userRepository.findByIdOrNull(id)
+            ?: throw CustomException(ErrorCode.NOT_FOUND_USER, id)
+}

--- a/src/main/kotlin/com/pluxity/weekly/epic/service/EpicService.kt
+++ b/src/main/kotlin/com/pluxity/weekly/epic/service/EpicService.kt
@@ -1,12 +1,9 @@
 package com.pluxity.weekly.epic.service
 
 import com.pluxity.weekly.auth.authorization.AuthorizationService
-import com.pluxity.weekly.auth.user.entity.User
-import com.pluxity.weekly.auth.user.repository.UserRepository
 import com.pluxity.weekly.chat.dto.EpicSearchFilter
 import com.pluxity.weekly.core.constant.ErrorCode
 import com.pluxity.weekly.core.exception.CustomException
-import com.pluxity.weekly.epic.dto.EpicAssignmentResponse
 import com.pluxity.weekly.epic.dto.EpicRequest
 import com.pluxity.weekly.epic.dto.EpicResponse
 import com.pluxity.weekly.epic.dto.EpicUpdateRequest
@@ -19,8 +16,6 @@ import com.pluxity.weekly.project.entity.ProjectStatus
 import com.pluxity.weekly.project.repository.ProjectRepository
 import com.pluxity.weekly.task.entity.TaskStatus
 import com.pluxity.weekly.task.repository.TaskRepository
-import com.pluxity.weekly.teams.event.TeamsNotificationEvent
-import org.springframework.context.ApplicationEventPublisher
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -31,9 +26,8 @@ class EpicService(
     private val epicRepository: EpicRepository,
     private val projectRepository: ProjectRepository,
     private val taskRepository: TaskRepository,
-    private val userRepository: UserRepository,
     private val authorizationService: AuthorizationService,
-    private val eventPublisher: ApplicationEventPublisher,
+    private val assignmentService: EpicAssignmentService,
 ) {
     fun findAll(): List<EpicResponse> = search(EpicSearchFilter())
 
@@ -68,9 +62,7 @@ class EpicService(
                     dueDate = request.dueDate,
                 ),
             )
-        request.userIds?.forEach { userId ->
-            assignAndNotify(epic, getUserById(userId))
-        }
+        request.userIds?.let { assignmentService.sync(epic, it) }
         return epic.requiredId
     }
 
@@ -102,18 +94,7 @@ class EpicService(
             startDate = request.startDate,
             dueDate = request.dueDate,
         )
-        request.userIds?.let { userIds ->
-            val requestedUsers = userRepository.findAllById(userIds)
-
-            epic.assignments
-                .filter { it.user !in requestedUsers }
-                .map { it.user }
-                .forEach { unassignAndNotify(epic, it) }
-
-            requestedUsers
-                .filter { user -> epic.assignments.none { it.user == user } }
-                .forEach { assignAndNotify(epic, it) }
-        }
+        request.userIds?.let { assignmentService.sync(epic, it) }
     }
 
     @Transactional
@@ -124,63 +105,6 @@ class EpicService(
         epicRepository.delete(epic)
     }
 
-    // ── EpicAssignment ──
-
-    fun findAssignments(epicId: Long): List<EpicAssignmentResponse> = getEpicById(epicId).assignments.map { it.toResponse() }
-
-    @Transactional
-    fun assign(
-        epicId: Long,
-        userId: Long,
-    ) {
-        val user = authorizationService.currentUser()
-        authorizationService.requireEpicAssign(user, epicId)
-        val epic = getEpicById(epicId)
-        epic.ensureMutable("assign")
-        val assignee = getUserById(userId)
-        if (epic.assignments.any { it.user == assignee }) {
-            throw CustomException(ErrorCode.DUPLICATE_EPIC_ASSIGNMENT, userId, epicId)
-        }
-        assignAndNotify(epic, assignee)
-    }
-
-    @Transactional
-    fun unassign(
-        epicId: Long,
-        userId: Long,
-    ) {
-        val user = authorizationService.currentUser()
-        authorizationService.requireEpicAssign(user, epicId)
-        val epic = getEpicById(epicId)
-        epic.ensureMutable("unassign")
-        val assignee = getUserById(userId)
-        if (epic.assignments.none { it.user == assignee }) {
-            throw CustomException(ErrorCode.NOT_FOUND_EPIC_ASSIGNMENT, epicId, userId)
-        }
-        unassignAndNotify(epic, assignee)
-    }
-
-    private fun assignAndNotify(
-        epic: Epic,
-        assignee: User,
-    ) {
-        epic.assign(assignee)
-        eventPublisher.publishEvent(
-            TeamsNotificationEvent(assignee.requiredId, "${epic.name} 에픽에 배정되었습니다"),
-        )
-    }
-
-    private fun unassignAndNotify(
-        epic: Epic,
-        assignee: User,
-    ) {
-        epic.unassign(assignee)
-        taskRepository.deleteByEpicIdAndAssigneeId(epic.requiredId, assignee.requiredId)
-        eventPublisher.publishEvent(
-            TeamsNotificationEvent(assignee.requiredId, "${epic.name} 에픽에서 해제되었습니다"),
-        )
-    }
-
     private fun getEpicById(id: Long): Epic =
         epicRepository.findByIdOrNull(id)
             ?: throw CustomException(ErrorCode.NOT_FOUND_EPIC, id)
@@ -188,8 +112,4 @@ class EpicService(
     private fun getProjectById(id: Long): Project =
         projectRepository.findByIdOrNull(id)
             ?: throw CustomException(ErrorCode.NOT_FOUND_PROJECT, id)
-
-    private fun getUserById(id: Long): User =
-        userRepository.findByIdOrNull(id)
-            ?: throw CustomException(ErrorCode.NOT_FOUND_USER, id)
 }

--- a/src/main/kotlin/com/pluxity/weekly/task/service/TaskService.kt
+++ b/src/main/kotlin/com/pluxity/weekly/task/service/TaskService.kt
@@ -8,6 +8,7 @@ import com.pluxity.weekly.core.constant.ErrorCode
 import com.pluxity.weekly.core.exception.CustomException
 import com.pluxity.weekly.epic.entity.Epic
 import com.pluxity.weekly.epic.repository.EpicRepository
+import com.pluxity.weekly.epic.service.EpicAssignmentService
 import com.pluxity.weekly.task.dto.TaskRequest
 import com.pluxity.weekly.task.dto.TaskResponse
 import com.pluxity.weekly.task.dto.TaskUpdateRequest
@@ -15,8 +16,6 @@ import com.pluxity.weekly.task.dto.toResponse
 import com.pluxity.weekly.task.entity.Task
 import com.pluxity.weekly.task.entity.TaskStatus
 import com.pluxity.weekly.task.repository.TaskRepository
-import com.pluxity.weekly.teams.event.TeamsNotificationEvent
-import org.springframework.context.ApplicationEventPublisher
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -28,7 +27,7 @@ class TaskService(
     private val epicRepository: EpicRepository,
     private val userRepository: UserRepository,
     private val authorizationService: AuthorizationService,
-    private val eventPublisher: ApplicationEventPublisher,
+    private val assignmentService: EpicAssignmentService,
 ) {
     fun findAll(): List<TaskResponse> = search(TaskSearchFilter())
 
@@ -57,7 +56,7 @@ class TaskService(
         epic.ensureMutable("create task")
         ensureUniqueTaskName(request.epicId, request.name)
         val newAssigneeId = request.assigneeId?.takeIf { it != user.requiredId }
-        autoAssignIfMissing(user, newAssigneeId, epic)
+        assignmentService.ensureAssigned(user, newAssigneeId, epic)
         return taskRepository
             .save(
                 Task(
@@ -87,7 +86,7 @@ class TaskService(
             ensureUniqueTaskName(task.epic.requiredId, newName)
         }
         val newAssigneeId = request.assigneeId?.takeIf { it != task.assignee?.requiredId }
-        autoAssignIfMissing(user, newAssigneeId, task.epic)
+        assignmentService.ensureAssigned(user, newAssigneeId, task.epic)
         task.update(
             name = request.name,
             description = request.description,
@@ -112,22 +111,6 @@ class TaskService(
     ) {
         if (taskRepository.existsByEpicIdAndName(epicId, name)) {
             throw CustomException(ErrorCode.DUPLICATE_TASK, epicId, name)
-        }
-    }
-
-    private fun autoAssignIfMissing(
-        actor: User,
-        assigneeId: Long?,
-        epic: Epic,
-    ) {
-        if (assigneeId == null) return
-        authorizationService.requireAdminOrPm(actor)
-        if (!epicRepository.existsByAssignmentsUserIdAndId(assigneeId, epic.requiredId)) {
-            val assignee = getUserById(assigneeId)
-            epic.assign(assignee)
-            eventPublisher.publishEvent(
-                TeamsNotificationEvent(assigneeId, "${epic.name} 에픽에 배정되었습니다"),
-            )
         }
     }
 

--- a/src/test/kotlin/com/pluxity/weekly/epic/service/EpicAssignmentServiceTest.kt
+++ b/src/test/kotlin/com/pluxity/weekly/epic/service/EpicAssignmentServiceTest.kt
@@ -1,0 +1,297 @@
+package com.pluxity.weekly.epic.service
+
+import com.pluxity.weekly.auth.authorization.AuthorizationService
+import com.pluxity.weekly.auth.user.entity.RoleType
+import com.pluxity.weekly.auth.user.repository.UserRepository
+import com.pluxity.weekly.core.constant.ErrorCode
+import com.pluxity.weekly.core.exception.CustomException
+import com.pluxity.weekly.epic.entity.EpicStatus
+import com.pluxity.weekly.epic.entity.dummyEpic
+import com.pluxity.weekly.epic.entity.dummyEpicAssignment
+import com.pluxity.weekly.epic.repository.EpicRepository
+import com.pluxity.weekly.project.entity.dummyProject
+import com.pluxity.weekly.task.repository.TaskRepository
+import com.pluxity.weekly.teams.event.TeamsNotificationEvent
+import com.pluxity.weekly.test.entity.dummyRole
+import com.pluxity.weekly.test.entity.dummyUser
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.runs
+import io.mockk.verify
+import org.springframework.context.ApplicationEventPublisher
+import org.springframework.data.repository.findByIdOrNull
+
+class EpicAssignmentServiceTest :
+    BehaviorSpec({
+
+        val epicRepository: EpicRepository = mockk()
+        val userRepository: UserRepository = mockk()
+        val taskRepository: TaskRepository = mockk(relaxed = true)
+        val authorizationService: AuthorizationService = mockk()
+        val eventPublisher: ApplicationEventPublisher = mockk(relaxed = true)
+        val service =
+            EpicAssignmentService(
+                epicRepository,
+                userRepository,
+                taskRepository,
+                authorizationService,
+                eventPublisher,
+            )
+
+        val adminUser =
+            dummyUser(id = 1L, name = "관리자").apply {
+                addRole(dummyRole(id = 1L, name = "ADMIN").apply { auth = RoleType.ADMIN.name })
+            }
+
+        beforeSpec {
+            every { authorizationService.currentUser() } returns adminUser
+            every { authorizationService.requireEpicAssign(any(), any()) } just runs
+            every { authorizationService.requireAdminOrPm(any()) } just runs
+        }
+
+        Given("에픽 배정 목록 조회") {
+            When("에픽에 배정된 사용자 목록을 조회하면") {
+                val epic = dummyEpic(id = 1L)
+                val u1 = dummyUser(id = 10L, name = "홍길동")
+                val u2 = dummyUser(id = 20L, name = "김영희")
+                epic.assignments.addAll(
+                    listOf(
+                        dummyEpicAssignment(id = 1L, epic = epic, user = u1),
+                        dummyEpicAssignment(id = 2L, epic = epic, user = u2),
+                    ),
+                )
+
+                every { epicRepository.findByIdOrNull(1L) } returns epic
+
+                val result = service.findByEpic(1L)
+
+                Then("배정 목록이 반환된다") {
+                    result.size shouldBe 2
+                }
+            }
+        }
+
+        Given("에픽에 사용자 배정") {
+            When("정상적으로 배정하면") {
+                val epic = dummyEpic(id = 2L)
+                val user = dummyUser(id = 30L, name = "신규")
+
+                every { epicRepository.findByIdOrNull(2L) } returns epic
+                every { userRepository.findByIdOrNull(30L) } returns user
+
+                service.assign(2L, 30L)
+
+                Then("에픽 assignments 에 추가되고 알림이 발행된다") {
+                    epic.assignments.any { it.user == user } shouldBe true
+                    verify { eventPublisher.publishEvent(match<TeamsNotificationEvent> { it.userId == 30L && it.message.contains("배정") }) }
+                }
+            }
+
+            When("이미 배정된 사용자를 배정하면") {
+                val epic = dummyEpic(id = 3L)
+                val user = dummyUser(id = 40L, name = "중복")
+                epic.assign(user)
+
+                every { epicRepository.findByIdOrNull(3L) } returns epic
+                every { userRepository.findByIdOrNull(40L) } returns user
+
+                val exception =
+                    shouldThrow<CustomException> {
+                        service.assign(3L, 40L)
+                    }
+
+                Then("DUPLICATE_EPIC_ASSIGNMENT 예외가 발생한다") {
+                    exception.code shouldBe ErrorCode.DUPLICATE_EPIC_ASSIGNMENT
+                }
+            }
+
+            When("DONE 상태 에픽에 배정하려 하면") {
+                val epic = dummyEpic(id = 4L, status = EpicStatus.DONE)
+
+                every { epicRepository.findByIdOrNull(4L) } returns epic
+
+                val exception =
+                    shouldThrow<CustomException> {
+                        service.assign(4L, 50L)
+                    }
+
+                Then("INVALID_STATUS_TRANSITION 예외가 발생한다") {
+                    exception.code shouldBe ErrorCode.INVALID_STATUS_TRANSITION
+                }
+            }
+        }
+
+        Given("에픽에서 사용자 배정 해제") {
+            When("배정된 사용자를 해제하면") {
+                val epic = dummyEpic(id = 5L, name = "해제 에픽")
+                val user = dummyUser(id = 60L, name = "해제 대상")
+                epic.assign(user)
+
+                every { epicRepository.findByIdOrNull(5L) } returns epic
+                every { userRepository.findByIdOrNull(60L) } returns user
+
+                service.unassign(5L, 60L)
+
+                Then("assignments 에서 제거되고 해당 사용자의 태스크가 삭제되며 알림이 발행된다") {
+                    epic.assignments.any { it.user == user } shouldBe false
+                    verify { taskRepository.deleteByEpicIdAndAssigneeId(5L, 60L) }
+                    verify {
+                        eventPublisher.publishEvent(
+                            match<TeamsNotificationEvent> { it.userId == 60L && it.message.contains("해제") },
+                        )
+                    }
+                }
+            }
+
+            When("배정되지 않은 사용자를 해제하면") {
+                val epic = dummyEpic(id = 6L)
+                val user = dummyUser(id = 999L)
+
+                every { epicRepository.findByIdOrNull(6L) } returns epic
+                every { userRepository.findByIdOrNull(999L) } returns user
+
+                val exception =
+                    shouldThrow<CustomException> {
+                        service.unassign(6L, 999L)
+                    }
+
+                Then("NOT_FOUND_EPIC_ASSIGNMENT 예외가 발생한다") {
+                    exception.code shouldBe ErrorCode.NOT_FOUND_EPIC_ASSIGNMENT
+                }
+            }
+
+            When("DONE 상태 에픽에서 해제하려 하면") {
+                val epic = dummyEpic(id = 7L, status = EpicStatus.DONE)
+
+                every { epicRepository.findByIdOrNull(7L) } returns epic
+
+                val exception =
+                    shouldThrow<CustomException> {
+                        service.unassign(7L, 80L)
+                    }
+
+                Then("INVALID_STATUS_TRANSITION 예외가 발생한다") {
+                    exception.code shouldBe ErrorCode.INVALID_STATUS_TRANSITION
+                }
+            }
+        }
+
+        Given("userIds 동기화 (sync)") {
+            When("[2,3] 을 요청하면 기존 [1,2] 에서 1 은 해제되고 3 은 추가된다") {
+                val project = dummyProject(id = 1L)
+                val epic = dummyEpic(id = 10L, project = project, name = "동기화 에픽")
+                val user1 = dummyUser(id = 1L, name = "유저1")
+                val user2 = dummyUser(id = 2L, name = "유저2")
+                val user3 = dummyUser(id = 3L, name = "유저3")
+                epic.assign(user1)
+                epic.assign(user2)
+
+                every { userRepository.findAllById(listOf(2L, 3L)) } returns listOf(user2, user3)
+
+                service.sync(epic, listOf(2L, 3L))
+
+                Then("user1 은 해제되고 user3 은 추가된다") {
+                    epic.assignments.map { it.user } shouldBe listOf(user2, user3)
+                    verify { taskRepository.deleteByEpicIdAndAssigneeId(10L, 1L) }
+                    verify { eventPublisher.publishEvent(match<TeamsNotificationEvent> { it.userId == 1L && it.message.contains("해제") }) }
+                    verify { eventPublisher.publishEvent(match<TeamsNotificationEvent> { it.userId == 3L && it.message.contains("배정") }) }
+                }
+            }
+
+            When("빈 배열을 요청하면 전체 해제된다") {
+                val project = dummyProject(id = 1L)
+                val epic = dummyEpic(id = 11L, project = project, name = "전체해제 에픽")
+                val user1 = dummyUser(id = 10L, name = "유저A")
+                val user2 = dummyUser(id = 20L, name = "유저B")
+                epic.assign(user1)
+                epic.assign(user2)
+
+                every { userRepository.findAllById(emptyList()) } returns emptyList()
+
+                service.sync(epic, emptyList())
+
+                Then("배정이 모두 제거된다") {
+                    epic.assignments.size shouldBe 0
+                    verify { taskRepository.deleteByEpicIdAndAssigneeId(11L, 10L) }
+                    verify { taskRepository.deleteByEpicIdAndAssigneeId(11L, 20L) }
+                }
+            }
+
+            When("기존 배정이 없고 신규 추가만 있으면") {
+                val project = dummyProject(id = 1L)
+                val epic = dummyEpic(id = 12L, project = project, name = "신규추가 에픽")
+                val u = dummyUser(id = 55L, name = "유저C")
+
+                every { userRepository.findAllById(listOf(55L)) } returns listOf(u)
+
+                service.sync(epic, listOf(55L))
+
+                Then("추가만 수행되고 해제 관련 호출이 발생하지 않는다") {
+                    epic.assignments.map { it.user } shouldBe listOf(u)
+                    verify(exactly = 0) { taskRepository.deleteByEpicIdAndAssigneeId(12L, any()) }
+                }
+            }
+        }
+
+        Given("담당자 에픽 자동 편입 (ensureAssigned)") {
+            When("assigneeId 가 null 이면 아무 동작도 하지 않는다") {
+                val epic = dummyEpic(id = 20L)
+
+                service.ensureAssigned(adminUser, null, epic)
+
+                Then("권한 체크도 호출되지 않는다") {
+                    verify(exactly = 0) { authorizationService.requireAdminOrPm(adminUser) }
+                }
+            }
+
+            When("이미 에픽에 배정된 사용자이면 추가 작업 없이 통과한다") {
+                val epic = dummyEpic(id = 21L)
+
+                every { epicRepository.existsByAssignmentsUserIdAndId(70L, 21L) } returns true
+
+                service.ensureAssigned(adminUser, 70L, epic)
+
+                Then("이벤트가 발행되지 않는다") {
+                    verify(exactly = 0) { userRepository.findByIdOrNull(70L) }
+                    verify(exactly = 0) {
+                        eventPublisher.publishEvent(match<TeamsNotificationEvent> { it.userId == 70L })
+                    }
+                }
+            }
+
+            When("에픽에 없는 사용자이면 자동 배정되고 알림이 발행된다") {
+                val epic = dummyEpic(id = 22L, name = "자동편입")
+                val assignee = dummyUser(id = 80L, name = "편입 대상")
+
+                every { epicRepository.existsByAssignmentsUserIdAndId(80L, 22L) } returns false
+                every { userRepository.findByIdOrNull(80L) } returns assignee
+
+                service.ensureAssigned(adminUser, 80L, epic)
+
+                Then("assignments 에 추가되고 배정 알림이 발행된다") {
+                    epic.assignments.any { it.user == assignee } shouldBe true
+                    verify { eventPublisher.publishEvent(match<TeamsNotificationEvent> { it.userId == 80L && it.message.contains("배정") }) }
+                }
+            }
+
+            When("권한 없는 사용자가 호출하면") {
+                val epic = dummyEpic(id = 23L)
+                val generalUser = dummyUser(id = 99L, name = "일반")
+
+                every { authorizationService.requireAdminOrPm(generalUser) } throws CustomException(ErrorCode.PERMISSION_DENIED)
+
+                val exception =
+                    shouldThrow<CustomException> {
+                        service.ensureAssigned(generalUser, 100L, epic)
+                    }
+
+                Then("PERMISSION_DENIED 예외가 발생한다") {
+                    exception.code shouldBe ErrorCode.PERMISSION_DENIED
+                }
+            }
+        }
+    })

--- a/src/test/kotlin/com/pluxity/weekly/epic/service/EpicServiceTest.kt
+++ b/src/test/kotlin/com/pluxity/weekly/epic/service/EpicServiceTest.kt
@@ -2,7 +2,6 @@ package com.pluxity.weekly.epic.service
 
 import com.pluxity.weekly.auth.authorization.AuthorizationService
 import com.pluxity.weekly.auth.user.entity.RoleType
-import com.pluxity.weekly.auth.user.repository.UserRepository
 import com.pluxity.weekly.core.constant.ErrorCode
 import com.pluxity.weekly.core.exception.CustomException
 import com.pluxity.weekly.epic.dto.dummyEpicRequest
@@ -10,12 +9,10 @@ import com.pluxity.weekly.epic.dto.dummyEpicUpdateRequest
 import com.pluxity.weekly.epic.entity.Epic
 import com.pluxity.weekly.epic.entity.EpicStatus
 import com.pluxity.weekly.epic.entity.dummyEpic
-import com.pluxity.weekly.epic.entity.dummyEpicAssignment
 import com.pluxity.weekly.epic.repository.EpicRepository
 import com.pluxity.weekly.project.entity.dummyProject
 import com.pluxity.weekly.project.repository.ProjectRepository
 import com.pluxity.weekly.task.repository.TaskRepository
-import com.pluxity.weekly.teams.event.TeamsNotificationEvent
 import com.pluxity.weekly.test.entity.dummyRole
 import com.pluxity.weekly.test.entity.dummyUser
 import io.kotest.assertions.throwables.shouldThrow
@@ -26,7 +23,6 @@ import io.mockk.just
 import io.mockk.mockk
 import io.mockk.runs
 import io.mockk.verify
-import org.springframework.context.ApplicationEventPublisher
 import org.springframework.data.repository.findByIdOrNull
 import java.time.LocalDate
 
@@ -36,10 +32,9 @@ class EpicServiceTest :
         val epicRepository: EpicRepository = mockk()
         val projectRepository: ProjectRepository = mockk()
         val taskRepository: TaskRepository = mockk()
-        val userRepository: UserRepository = mockk()
         val authorizationService: AuthorizationService = mockk()
-        val eventPublisher: ApplicationEventPublisher = mockk()
-        val service = EpicService(epicRepository, projectRepository, taskRepository, userRepository, authorizationService, eventPublisher)
+        val assignmentService: EpicAssignmentService = mockk(relaxed = true)
+        val service = EpicService(epicRepository, projectRepository, taskRepository, authorizationService, assignmentService)
 
         val adminUser =
             dummyUser(id = 1L, name = "관리자").apply {
@@ -139,30 +134,23 @@ class EpicServiceTest :
                 }
             }
 
-            When("userIds와 함께 생성하면 각 사용자에게 배정 알림이 발행된다") {
+            When("userIds와 함께 생성하면 assignmentService.sync 가 호출된다") {
                 val project = dummyProject(id = 1L)
                 val request =
                     dummyEpicRequest(
                         projectId = 1L,
-                        name = "알림 에픽",
+                        name = "동기화 에픽",
                         userIds = listOf(11L, 22L),
                     )
-                val savedEpic = dummyEpic(id = 7L, project = project, name = "알림 에픽")
-                val u1 = dummyUser(id = 11L, name = "유저1")
-                val u2 = dummyUser(id = 22L, name = "유저2")
+                val savedEpic = dummyEpic(id = 7L, project = project, name = "동기화 에픽")
 
                 every { projectRepository.findByIdOrNull(1L) } returns project
                 every { epicRepository.save(any<Epic>()) } returns savedEpic
-                every { userRepository.findByIdOrNull(11L) } returns u1
-                every { userRepository.findByIdOrNull(22L) } returns u2
-                every { eventPublisher.publishEvent(any<TeamsNotificationEvent>()) } just runs
 
                 service.create(request)
 
-                Then("두 사용자 모두 epic에 배정되고 알림이 발행된다") {
-                    savedEpic.assignments.map { it.user } shouldBe listOf(u1, u2)
-                    verify { eventPublisher.publishEvent(match<TeamsNotificationEvent> { it.userId == 11L && it.message.contains("배정") }) }
-                    verify { eventPublisher.publishEvent(match<TeamsNotificationEvent> { it.userId == 22L && it.message.contains("배정") }) }
+                Then("sync 가 저장된 epic 과 userIds 로 호출된다") {
+                    verify { assignmentService.sync(savedEpic, listOf(11L, 22L)) }
                 }
             }
 
@@ -277,127 +265,43 @@ class EpicServiceTest :
             }
         }
 
-        Given("에픽 수정 시 userIds 교체") {
-            When("userIds로 [2,3]을 보내면 기존 [1,2]에서 1은 해제되고 3은 추가된다") {
+        Given("에픽 수정 시 userIds 위임") {
+            When("userIds 가 전달되면 assignmentService.sync 가 호출된다") {
                 val project = dummyProject(id = 1L)
-                val epic = dummyEpic(id = 10L, project = project, name = "배정교체 에픽")
-                val user1 = dummyUser(id = 1L, name = "유저1")
-                val user2 = dummyUser(id = 2L, name = "유저2")
-                val user3 = dummyUser(id = 3L, name = "유저3")
-                epic.assign(user1)
-                epic.assign(user2)
+                val epic = dummyEpic(id = 10L, project = project, name = "위임 에픽")
 
                 every { epicRepository.findByIdOrNull(10L) } returns epic
-                every { userRepository.findAllById(listOf(2L, 3L)) } returns listOf(user2, user3)
-                every { taskRepository.deleteByEpicIdAndAssigneeId(10L, 1L) } just runs
-                every { eventPublisher.publishEvent(any<TeamsNotificationEvent>()) } just runs
 
                 service.update(10L, dummyEpicUpdateRequest(userIds = listOf(2L, 3L)))
 
-                Then("user1은 해제되고 user3은 추가된다") {
-                    epic.assignments.map { it.user } shouldBe listOf(user2, user3)
-                    verify { taskRepository.deleteByEpicIdAndAssigneeId(10L, 1L) }
-                    verify { eventPublisher.publishEvent(match<TeamsNotificationEvent> { it.userId == 1L && it.message.contains("해제") }) }
-                    verify { eventPublisher.publishEvent(match<TeamsNotificationEvent> { it.userId == 3L && it.message.contains("배정") }) }
+                Then("sync 가 올바른 인자로 호출된다") {
+                    verify { assignmentService.sync(epic, listOf(2L, 3L)) }
                 }
             }
 
-            When("빈 배열을 보내면 전체 해제된다") {
+            When("빈 배열을 보내도 sync 에 위임된다") {
                 val project = dummyProject(id = 1L)
-                val epic = dummyEpic(id = 11L, project = project, name = "전체해제 에픽")
-                val user1 = dummyUser(id = 10L, name = "유저A")
-                val user2 = dummyUser(id = 20L, name = "유저B")
-                epic.assign(user1)
-                epic.assign(user2)
+                val epic = dummyEpic(id = 11L, project = project, name = "빈 배열 에픽")
 
                 every { epicRepository.findByIdOrNull(11L) } returns epic
-                every { userRepository.findAllById(emptyList()) } returns emptyList()
-                every { taskRepository.deleteByEpicIdAndAssigneeId(11L, any()) } just runs
-                every { eventPublisher.publishEvent(any<TeamsNotificationEvent>()) } just runs
 
                 service.update(11L, dummyEpicUpdateRequest(userIds = emptyList()))
 
-                Then("배정이 모두 제거된다") {
-                    epic.assignments.size shouldBe 0
-                    verify { taskRepository.deleteByEpicIdAndAssigneeId(11L, 10L) }
-                    verify { taskRepository.deleteByEpicIdAndAssigneeId(11L, 20L) }
+                Then("sync 가 빈 리스트로 호출된다") {
+                    verify { assignmentService.sync(epic, emptyList()) }
                 }
             }
 
-            When("userIds가 null이면 배정이 변경되지 않는다") {
+            When("userIds 가 null 이면 sync 가 호출되지 않는다") {
                 val project = dummyProject(id = 1L)
-                val epic = dummyEpic(id = 12L, project = project, name = "변경없음 에픽")
-                val user1 = dummyUser(id = 10L, name = "유저X")
-                epic.assign(user1)
+                val epic = dummyEpic(id = 12L, project = project, name = "null 에픽")
 
                 every { epicRepository.findByIdOrNull(12L) } returns epic
 
                 service.update(12L, dummyEpicUpdateRequest(userIds = null))
 
-                Then("기존 배정이 유지된다") {
-                    epic.assignments.size shouldBe 1
-                    epic.assignments[0].user shouldBe user1
-                }
-            }
-        }
-
-        // ── EpicAssignment ──
-
-        Given("에픽 배정 목록 조회") {
-            When("에픽에 배정된 사용자를 조회하면") {
-                val epic = dummyEpic(id = 1L)
-                val user1 = dummyUser(id = 10L, name = "홍길동")
-                val user2 = dummyUser(id = 20L, name = "김영희")
-                epic.assignments.addAll(
-                    listOf(
-                        dummyEpicAssignment(id = 1L, epic = epic, user = user1),
-                        dummyEpicAssignment(id = 2L, epic = epic, user = user2),
-                    ),
-                )
-
-                every { epicRepository.findByIdOrNull(1L) } returns epic
-
-                val result = service.findAssignments(1L)
-
-                Then("배정 목록이 반환된다") {
-                    result.size shouldBe 2
-                }
-            }
-        }
-
-        Given("에픽 배정 해제") {
-            When("배정된 사용자를 해제하면") {
-                val epic = dummyEpic(id = 1L)
-                val user = dummyUser(id = 10L)
-                val event = TeamsNotificationEvent(user.requiredId, "테스트 에픽 에픽에서 해제되었습니다")
-                epic.assign(user)
-
-                every { epicRepository.findByIdOrNull(1L) } returns epic
-                every { userRepository.findByIdOrNull(10L) } returns user
-                every { taskRepository.deleteByEpicIdAndAssigneeId(1L, 10L) } just runs
-                every { eventPublisher.publishEvent(event) } just runs
-
-                service.unassign(1L, 10L)
-
-                Then("배정이 제거된다") {
-                    epic.assignments.size shouldBe 0
-                }
-            }
-
-            When("배정되지 않은 사용자를 해제하면") {
-                val epic = dummyEpic(id = 1L)
-                val user = dummyUser(id = 999L)
-
-                every { epicRepository.findByIdOrNull(1L) } returns epic
-                every { userRepository.findByIdOrNull(999L) } returns user
-
-                val exception =
-                    shouldThrow<CustomException> {
-                        service.unassign(1L, 999L)
-                    }
-
-                Then("NOT_FOUND 예외가 발생한다") {
-                    exception.code shouldBe ErrorCode.NOT_FOUND_EPIC_ASSIGNMENT
+                Then("sync 호출이 발생하지 않는다") {
+                    verify(exactly = 0) { assignmentService.sync(any(), any()) }
                 }
             }
         }

--- a/src/test/kotlin/com/pluxity/weekly/task/service/TaskServiceTest.kt
+++ b/src/test/kotlin/com/pluxity/weekly/task/service/TaskServiceTest.kt
@@ -5,15 +5,16 @@ import com.pluxity.weekly.auth.user.entity.RoleType
 import com.pluxity.weekly.auth.user.repository.UserRepository
 import com.pluxity.weekly.core.constant.ErrorCode
 import com.pluxity.weekly.core.exception.CustomException
+import com.pluxity.weekly.epic.entity.Epic
 import com.pluxity.weekly.epic.entity.dummyEpic
 import com.pluxity.weekly.epic.repository.EpicRepository
+import com.pluxity.weekly.epic.service.EpicAssignmentService
 import com.pluxity.weekly.task.dto.dummyTaskRequest
 import com.pluxity.weekly.task.dto.dummyTaskUpdateRequest
 import com.pluxity.weekly.task.entity.Task
 import com.pluxity.weekly.task.entity.TaskStatus
 import com.pluxity.weekly.task.entity.dummyTask
 import com.pluxity.weekly.task.repository.TaskRepository
-import com.pluxity.weekly.teams.event.TeamsNotificationEvent
 import com.pluxity.weekly.test.entity.dummyRole
 import com.pluxity.weekly.test.entity.dummyUser
 import io.kotest.assertions.throwables.shouldThrow
@@ -25,7 +26,6 @@ import io.mockk.mockk
 import io.mockk.runs
 import io.mockk.slot
 import io.mockk.verify
-import org.springframework.context.ApplicationEventPublisher
 import org.springframework.data.repository.findByIdOrNull
 import java.time.LocalDate
 
@@ -36,14 +36,14 @@ class TaskServiceTest :
         val epicRepository: EpicRepository = mockk()
         val userRepository: UserRepository = mockk()
         val authorizationService: AuthorizationService = mockk()
-        val eventPublisher: ApplicationEventPublisher = mockk(relaxed = true)
+        val assignmentService: EpicAssignmentService = mockk(relaxed = true)
         val service =
             TaskService(
                 taskRepository,
                 epicRepository,
                 userRepository,
                 authorizationService,
-                eventPublisher,
+                assignmentService,
             )
 
         val adminUser =
@@ -149,38 +149,34 @@ class TaskServiceTest :
             }
         }
 
-        Given("태스크 생성 시 assignee epic 배정 검증") {
-            When("ADMIN/PM이 다른 사용자를 assignee로 지정하면 epic에 자동 배정된다") {
+        Given("태스크 생성 시 assignmentService 위임") {
+            When("다른 사용자를 assignee로 지정하면 ensureAssigned 에 위임된다") {
                 val epic = dummyEpic(id = 5L)
                 val newAssignee = dummyUser(id = 30L, name = "신규 담당자")
-                val request = dummyTaskRequest(epicId = 5L, name = "자동배정 create", assigneeId = 30L)
-                val saved =
-                    dummyTask(id = 100L, epic = epic, name = "자동배정 create").apply {
-                        this.assignee = newAssignee
-                    }
+                val request = dummyTaskRequest(epicId = 5L, name = "위임 create", assigneeId = 30L)
+                val saved = dummyTask(id = 100L, epic = epic, name = "위임 create").apply { assignee = newAssignee }
 
                 every { epicRepository.findByIdOrNull(5L) } returns epic
                 every { taskRepository.existsByEpicIdAndName(5L, request.name) } returns false
-                every { authorizationService.requireAdminOrPm(any()) } just runs
-                every { epicRepository.existsByAssignmentsUserIdAndId(30L, 5L) } returns false
                 every { userRepository.findByIdOrNull(30L) } returns newAssignee
                 every { taskRepository.save(any<Task>()) } returns saved
 
                 service.create(request)
 
-                Then("epic에 자동 배정되고 알림이 발행된다") {
-                    epic.assignments.any { it.user == newAssignee } shouldBe true
-                    verify { eventPublisher.publishEvent(match<TeamsNotificationEvent> { it.userId == 30L }) }
+                Then("assignmentService.ensureAssigned 가 올바른 인자로 호출된다") {
+                    verify { assignmentService.ensureAssigned(adminUser, 30L, epic) }
                 }
             }
 
-            When("일반 사용자가 다른 사용자를 assignee로 지정하면 권한 거부") {
+            When("ensureAssigned 가 권한 예외를 던지면 전파된다") {
                 val epic = dummyEpic(id = 9L)
                 val request = dummyTaskRequest(epicId = 9L, name = "권한없음 create", assigneeId = 50L)
 
                 every { epicRepository.findByIdOrNull(9L) } returns epic
                 every { taskRepository.existsByEpicIdAndName(9L, request.name) } returns false
-                every { authorizationService.requireAdminOrPm(any()) } throws CustomException(ErrorCode.PERMISSION_DENIED)
+                every {
+                    assignmentService.ensureAssigned(any(), any(), any<Epic>())
+                } throws CustomException(ErrorCode.PERMISSION_DENIED)
 
                 val exception =
                     shouldThrow<CustomException> {
@@ -192,7 +188,7 @@ class TaskServiceTest :
                 }
             }
 
-            When("assigneeId가 현재 로그인 사용자와 같으면 권한 체크/자동배정을 건너뛴다") {
+            When("assigneeId가 현재 로그인 사용자와 같으면 null 로 위임된다") {
                 val epic = dummyEpic(id = 6L)
                 val request = dummyTaskRequest(epicId = 6L, name = "본인 지정", assigneeId = 1L)
                 val savedSlot = slot<Task>()
@@ -204,9 +200,8 @@ class TaskServiceTest :
 
                 service.create(request)
 
-                Then("권한 체크/자동배정 없이 currentUser가 assignee로 설정된다") {
-                    verify(exactly = 0) { authorizationService.requireAdminOrPm(any()) }
-                    verify(exactly = 0) { epicRepository.existsByAssignmentsUserIdAndId(1L, 6L) }
+                Then("ensureAssigned 가 null 로 호출되고 currentUser 가 assignee 로 설정된다") {
+                    verify { assignmentService.ensureAssigned(adminUser, null, epic) }
                     verify(exactly = 0) { userRepository.findByIdOrNull(1L) }
                     savedSlot.captured.assignee shouldBe adminUser
                 }
@@ -380,8 +375,8 @@ class TaskServiceTest :
             }
         }
 
-        Given("태스크 담당자 변경 권한") {
-            When("ADMIN이 담당자를 변경하면") {
+        Given("태스크 수정 시 assignmentService 위임") {
+            When("담당자가 변경되면 ensureAssigned 가 호출된다") {
                 val epic = dummyEpic(id = 1L)
                 val oldAssignee = dummyUser(id = 10L, name = "기존 담당자")
                 val newAssignee = dummyUser(id = 20L, name = "새 담당자")
@@ -391,18 +386,17 @@ class TaskServiceTest :
                     }
 
                 every { taskRepository.findWithEpicAndProjectById(70L) } returns entity
-                every { authorizationService.requireAdminOrPm(any()) } just runs
-                every { epicRepository.existsByAssignmentsUserIdAndId(20L, 1L) } returns true
                 every { userRepository.findByIdOrNull(20L) } returns newAssignee
 
                 service.update(70L, dummyTaskUpdateRequest(assigneeId = 20L))
 
-                Then("담당자가 변경된다") {
+                Then("ensureAssigned 가 새 assignee id 로 호출되고 엔티티에 반영된다") {
+                    verify { assignmentService.ensureAssigned(adminUser, 20L, epic) }
                     entity.assignee shouldBe newAssignee
                 }
             }
 
-            When("일반 사용자가 담당자를 변경하려 하면") {
+            When("ensureAssigned 가 권한 예외를 던지면 전파된다") {
                 val epic = dummyEpic(id = 1L)
                 val entity =
                     dummyTask(id = 71L, epic = epic).apply {
@@ -410,7 +404,9 @@ class TaskServiceTest :
                     }
 
                 every { taskRepository.findWithEpicAndProjectById(71L) } returns entity
-                every { authorizationService.requireAdminOrPm(any()) } throws CustomException(ErrorCode.PERMISSION_DENIED)
+                every {
+                    assignmentService.ensureAssigned(any(), any(), any<Epic>())
+                } throws CustomException(ErrorCode.PERMISSION_DENIED)
 
                 val exception =
                     shouldThrow<CustomException> {
@@ -422,30 +418,7 @@ class TaskServiceTest :
                 }
             }
 
-            When("새 담당자가 에픽에 미배정이면 자동 배정된다") {
-                val epic = dummyEpic(id = 1L)
-                val oldAssignee = dummyUser(id = 10L, name = "기존 담당자")
-                val newAssignee = dummyUser(id = 30L, name = "미배정 담당자")
-                val entity =
-                    dummyTask(id = 72L, epic = epic, name = "자동배정 태스크").apply {
-                        this.assignee = oldAssignee
-                    }
-
-                every { taskRepository.findWithEpicAndProjectById(72L) } returns entity
-                every { authorizationService.requireAdminOrPm(any()) } just runs
-                every { epicRepository.existsByAssignmentsUserIdAndId(30L, 1L) } returns false
-                every { userRepository.findByIdOrNull(30L) } returns newAssignee
-
-                service.update(72L, dummyTaskUpdateRequest(assigneeId = 30L))
-
-                Then("에픽에 자동 배정되고 담당자가 변경된다") {
-                    epic.assignments.any { it.user == newAssignee } shouldBe true
-                    entity.assignee shouldBe newAssignee
-                    verify { eventPublisher.publishEvent(match<TeamsNotificationEvent> { it.userId == 30L }) }
-                }
-            }
-
-            When("동일한 담당자 ID를 보내면 권한 체크를 건너뛴다") {
+            When("동일한 담당자 ID를 보내면 ensureAssigned 에 null 이 전달된다") {
                 val epic = dummyEpic(id = 1L)
                 val currentAssignee = dummyUser(id = 10L, name = "현재 담당자")
                 val entity =
@@ -457,8 +430,8 @@ class TaskServiceTest :
 
                 service.update(73L, dummyTaskUpdateRequest(assigneeId = 10L))
 
-                Then("requireAdminOrPm이 호출되지 않는다") {
-                    verify(exactly = 0) { authorizationService.requireAdminOrPm(any()) }
+                Then("null 로 위임되고 assignee 가 유지된다") {
+                    verify { assignmentService.ensureAssigned(adminUser, null, epic) }
                     entity.assignee shouldBe currentAssignee
                 }
             }


### PR DESCRIPTION
## Summary

- `EpicService` 에 섞여 있던 에픽 배정 라이프사이클과 `TaskService.autoAssignIfMissing` 을 `EpicAssignmentService` 로 분리
- Service 책임 경계 정리 (CRUD vs 배정 라이프사이클)
- `unassign` 시 태스크 soft-delete 동작은 현행 유지 (SoftDelete 기반 복구 가능)

Resolves #43

## Changes

### 신규
- `EpicAssignmentService.kt` — `findByEpic`, `assign`, `unassign`, `sync`, `ensureAssigned` + private `assignAndNotify`/`unassignAndNotify`
- `EpicAssignmentServiceTest.kt` — 조회/배정/해제/동기화/자동편입 전 시나리오 커버 (15개 When)

### 수정
- `EpicService.kt` — 배정 관련 메서드 제거, `create`/`update` 의 userIds 처리를 `assignmentService.sync` 로 위임, `userRepository`/`eventPublisher` 의존성 제거
- `TaskService.kt` — `autoAssignIfMissing` 제거, `create`/`update` 에서 `ensureAssigned` 호출, `eventPublisher` 의존성 제거
- `EpicController.kt` — `EpicAssignmentService` 주입, 3개 엔드포인트(`GET /epics/{id}/assignments`, `POST/DELETE /epics/{id}/assignments/{userId}`) 라우팅 변경
- `ChatExecutor.kt` — `executeAssign`/`executeUnassign` 을 `epicAssignmentService` 경유로 변경
- `SelectFieldResolver.kt` — `resolveRemoveUserCandidates` 에서 `findByEpic` 사용
- `EpicServiceTest.kt` — 배정 블록 제거, userIds 처리는 `sync` 위임 verify 로 축소
- `TaskServiceTest.kt` — assignee 관련 블록을 `ensureAssigned` 위임 verify 로 축소
- `ChatController.kt` — spotless 포매팅 (별도 커밋)

## 의존 방향

```
EpicController       ┐
TaskController       ├──→ TaskService   ──→ EpicAssignmentService
ChatExecutor, etc.   │                       ↑
                     └──→ EpicService ───────┘
```

순환 없음, AssignmentService 는 Repository/AuthorizationService/EventPublisher 만 참조.

## 동작 변화

없음. 엔드포인트·알림 이벤트·unassign 시 태스크 soft-delete 모두 현행 유지.

## Test plan

- [x] `./gradlew test` 전체 통과
- [x] `./gradlew spotlessApply` 적용
- [ ] API smoke: `GET /epics/{id}/assignments`, `POST /epics/{id}/assignments/{userId}`, `DELETE /epics/{id}/assignments/{userId}`, `PATCH /epics/{id}` (userIds 동기화), Task create/update 시 에픽 미배정 사용자 지정 케이스