### PR TITLE
feat: Teams 알림 발송 이력 저장/조회 API 추가

### DIFF
--- a/src/main/kotlin/com/pluxity/weekly/epic/service/EpicAssignmentService.kt
+++ b/src/main/kotlin/com/pluxity/weekly/epic/service/EpicAssignmentService.kt
@@ -10,6 +10,7 @@ import com.pluxity.weekly.epic.dto.toResponse
 import com.pluxity.weekly.epic.entity.Epic
 import com.pluxity.weekly.epic.repository.EpicRepository
 import com.pluxity.weekly.task.repository.TaskRepository
+import com.pluxity.weekly.teams.entity.TeamsNotificationType
 import com.pluxity.weekly.teams.event.TeamsNotificationEvent
 import org.springframework.context.ApplicationEventPublisher
 import org.springframework.data.repository.findByIdOrNull
@@ -96,7 +97,11 @@ class EpicAssignmentService(
     ) {
         epic.assign(assignee)
         eventPublisher.publishEvent(
-            TeamsNotificationEvent(assignee.requiredId, "${epic.name} 에픽에 배정되었습니다"),
+            TeamsNotificationEvent(
+                userId = assignee.requiredId,
+                type = TeamsNotificationType.EPIC_ASSIGN,
+                message = "${epic.name} 에픽에 배정되었습니다",
+            ),
         )
     }
 
@@ -107,7 +112,11 @@ class EpicAssignmentService(
         epic.unassign(assignee)
         taskRepository.deleteByEpicIdAndAssigneeId(epic.requiredId, assignee.requiredId)
         eventPublisher.publishEvent(
-            TeamsNotificationEvent(assignee.requiredId, "${epic.name} 에픽에서 해제되었습니다"),
+            TeamsNotificationEvent(
+                userId = assignee.requiredId,
+                type = TeamsNotificationType.EPIC_UNASSIGN,
+                message = "${epic.name} 에픽에서 해제되었습니다",
+            ),
         )
     }
 

--- a/src/main/kotlin/com/pluxity/weekly/task/service/TaskReviewService.kt
+++ b/src/main/kotlin/com/pluxity/weekly/task/service/TaskReviewService.kt
@@ -16,6 +16,7 @@ import com.pluxity.weekly.task.entity.TaskStatus
 import com.pluxity.weekly.task.repository.TaskApprovalLogRepository
 import com.pluxity.weekly.task.repository.TaskRepository
 import com.pluxity.weekly.teams.converter.TaskReviewCardBuilder
+import com.pluxity.weekly.teams.entity.TeamsNotificationType
 import com.pluxity.weekly.teams.event.TeamsNotificationEvent
 import org.springframework.context.ApplicationEventPublisher
 import org.springframework.stereotype.Service
@@ -50,6 +51,7 @@ class TaskReviewService(
             eventPublisher.publishEvent(
                 TeamsNotificationEvent(
                     userId = pmId,
+                    type = TeamsNotificationType.TASK_REVIEW_REQUEST,
                     message = "[리뷰 요청] '${task.name}' 태스크가 리뷰 요청되었습니다. 요청자: ${user.name}",
                     card = card,
                 ),
@@ -68,6 +70,7 @@ class TaskReviewService(
             eventPublisher.publishEvent(
                 TeamsNotificationEvent(
                     userId = assigneeId,
+                    type = TeamsNotificationType.TASK_APPROVE,
                     message = "[승인] '${task.name}' 태스크가 승인되었습니다.",
                 ),
             )
@@ -90,6 +93,7 @@ class TaskReviewService(
             eventPublisher.publishEvent(
                 TeamsNotificationEvent(
                     userId = assigneeId,
+                    type = TeamsNotificationType.TASK_REJECT,
                     message = "[반려] '${task.name}' 태스크가 반려되었습니다.$suffix",
                 ),
             )

--- a/src/main/kotlin/com/pluxity/weekly/teams/controller/TeamsNotificationLogController.kt
+++ b/src/main/kotlin/com/pluxity/weekly/teams/controller/TeamsNotificationLogController.kt
@@ -1,0 +1,44 @@
+package com.pluxity.weekly.teams.controller
+
+import com.pluxity.weekly.core.response.DataResponseBody
+import com.pluxity.weekly.core.response.ErrorResponseBody
+import com.pluxity.weekly.core.response.PageResponse
+import com.pluxity.weekly.teams.dto.TeamsNotificationLogResponse
+import com.pluxity.weekly.teams.service.TeamsNotificationLogService
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.responses.ApiResponses
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.data.domain.Pageable
+import org.springframework.data.domain.Sort
+import org.springframework.data.web.PageableDefault
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/notifications")
+@Tag(name = "Notification Controller", description = "Teams 알림 이력 조회 API")
+class TeamsNotificationLogController(
+    private val service: TeamsNotificationLogService,
+) {
+    @Operation(summary = "내 알림 목록 조회", description = "현재 사용자가 수신한 Teams 알림 이력을 페이지네이션으로 조회합니다")
+    @ApiResponses(
+        value = [
+            ApiResponse(responseCode = "200", description = "조회 성공"),
+            ApiResponse(
+                responseCode = "401",
+                description = "인증 실패",
+                content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponseBody::class))],
+            ),
+        ],
+    )
+    @GetMapping
+    fun findMine(
+        @PageableDefault(size = 20, sort = ["id"], direction = Sort.Direction.DESC) pageable: Pageable,
+    ): ResponseEntity<DataResponseBody<PageResponse<TeamsNotificationLogResponse>>> =
+        ResponseEntity.ok(DataResponseBody(service.findMine(pageable)))
+}

--- a/src/main/kotlin/com/pluxity/weekly/teams/dto/TeamsNotificationLogResponse.kt
+++ b/src/main/kotlin/com/pluxity/weekly/teams/dto/TeamsNotificationLogResponse.kt
@@ -1,0 +1,36 @@
+package com.pluxity.weekly.teams.dto
+
+import com.pluxity.weekly.teams.entity.TeamsNotificationLog
+import com.pluxity.weekly.teams.entity.TeamsNotificationStatus
+import com.pluxity.weekly.teams.entity.TeamsNotificationType
+import io.swagger.v3.oas.annotations.media.Schema
+import java.time.LocalDateTime
+
+@Schema(description = "Teams 알림 로그 응답")
+data class TeamsNotificationLogResponse(
+    @field:Schema(description = "로그 ID", example = "1")
+    val id: Long,
+    @field:Schema(description = "수신자 사용자 ID", example = "10")
+    val userId: Long,
+    @field:Schema(description = "알림 유형", example = "TASK_REVIEW_REQUEST")
+    val type: TeamsNotificationType,
+    @field:Schema(description = "알림 메시지")
+    val message: String,
+    @field:Schema(description = "발송 상태", example = "SENT")
+    val status: TeamsNotificationStatus,
+    @field:Schema(description = "실패 사유 (상태가 FAILED 일 때)")
+    val failReason: String?,
+    @field:Schema(description = "생성 일시")
+    val createdAt: LocalDateTime,
+)
+
+fun TeamsNotificationLog.toResponse(): TeamsNotificationLogResponse =
+    TeamsNotificationLogResponse(
+        id = this.requiredId,
+        userId = this.userId,
+        type = this.type,
+        message = this.message,
+        status = this.status,
+        failReason = this.failReason,
+        createdAt = this.createdAt,
+    )

--- a/src/main/kotlin/com/pluxity/weekly/teams/entity/TeamsNotificationLog.kt
+++ b/src/main/kotlin/com/pluxity/weekly/teams/entity/TeamsNotificationLog.kt
@@ -1,0 +1,35 @@
+package com.pluxity.weekly.teams.entity
+
+import com.pluxity.weekly.core.entity.IdentityIdEntity
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.Table
+
+@Entity
+@Table(name = "teams_notification_logs")
+class TeamsNotificationLog(
+    @Column(name = "user_id", nullable = false)
+    val userId: Long,
+    @Enumerated(EnumType.STRING)
+    @Column(name = "type", nullable = false, length = 32)
+    val type: TeamsNotificationType,
+    @Column(name = "message", nullable = false, length = 2000)
+    val message: String,
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false, length = 16)
+    var status: TeamsNotificationStatus = TeamsNotificationStatus.PENDING,
+    @Column(name = "fail_reason", length = 1000)
+    var failReason: String? = null,
+) : IdentityIdEntity() {
+    fun markSent() {
+        status = TeamsNotificationStatus.SENT
+        failReason = null
+    }
+
+    fun markFailed(reason: String?) {
+        status = TeamsNotificationStatus.FAILED
+        failReason = reason?.take(1000)
+    }
+}

--- a/src/main/kotlin/com/pluxity/weekly/teams/entity/TeamsNotificationStatus.kt
+++ b/src/main/kotlin/com/pluxity/weekly/teams/entity/TeamsNotificationStatus.kt
@@ -1,0 +1,7 @@
+package com.pluxity.weekly.teams.entity
+
+enum class TeamsNotificationStatus {
+    PENDING,
+    SENT,
+    FAILED,
+}

--- a/src/main/kotlin/com/pluxity/weekly/teams/entity/TeamsNotificationType.kt
+++ b/src/main/kotlin/com/pluxity/weekly/teams/entity/TeamsNotificationType.kt
@@ -1,0 +1,9 @@
+package com.pluxity.weekly.teams.entity
+
+enum class TeamsNotificationType {
+    TASK_REVIEW_REQUEST,
+    TASK_APPROVE,
+    TASK_REJECT,
+    EPIC_ASSIGN,
+    EPIC_UNASSIGN,
+}

--- a/src/main/kotlin/com/pluxity/weekly/teams/event/TeamsNotificationEvent.kt
+++ b/src/main/kotlin/com/pluxity/weekly/teams/event/TeamsNotificationEvent.kt
@@ -1,14 +1,18 @@
 package com.pluxity.weekly.teams.event
 
+import com.pluxity.weekly.teams.entity.TeamsNotificationType
+
 /**
  * Teams Proactive 알림 이벤트.
  *
  * @property userId 알림 대상 사용자 ID (weekly-report userId)
+ * @property type 알림 유형 (저장/조회 시 분류 용도)
  * @property message 알림 메시지 (card 가 null 일 때 text 로 전송)
  * @property card Adaptive Card 콘텐츠. null 이면 text 로, 있으면 card 로 전송.
  */
 data class TeamsNotificationEvent(
     val userId: Long,
+    val type: TeamsNotificationType,
     val message: String,
     val card: Map<String, Any>? = null,
 )

--- a/src/main/kotlin/com/pluxity/weekly/teams/event/TeamsNotificationListener.kt
+++ b/src/main/kotlin/com/pluxity/weekly/teams/event/TeamsNotificationListener.kt
@@ -1,5 +1,6 @@
 package com.pluxity.weekly.teams.event
 
+import com.pluxity.weekly.teams.service.TeamsNotificationLogService
 import com.pluxity.weekly.teams.service.TeamsNotificationService
 import org.springframework.scheduling.annotation.Async
 import org.springframework.stereotype.Component
@@ -9,14 +10,32 @@ import org.springframework.transaction.event.TransactionalEventListener
 @Component
 class TeamsNotificationListener(
     private val notificationService: TeamsNotificationService,
+    private val logService: TeamsNotificationLogService,
 ) {
     @Async
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     fun handleNotification(event: TeamsNotificationEvent) {
-        if (event.card != null) {
-            notificationService.sendCard(event.userId, event.card)
+        val log =
+            logService.savePending(
+                userId = event.userId,
+                type = event.type,
+                message = event.message,
+            )
+        val logId = log.requiredId
+
+        val failReason =
+            runCatching {
+                if (event.card != null) {
+                    notificationService.sendCard(event.userId, event.card)
+                } else {
+                    notificationService.sendDm(event.userId, event.message)
+                }
+            }.getOrElse { e -> e.message ?: e.javaClass.simpleName }
+
+        if (failReason == null) {
+            logService.markSent(logId)
         } else {
-            notificationService.sendDm(event.userId, event.message)
+            logService.markFailed(logId, failReason)
         }
     }
 }

--- a/src/main/kotlin/com/pluxity/weekly/teams/repository/TeamsNotificationLogRepository.kt
+++ b/src/main/kotlin/com/pluxity/weekly/teams/repository/TeamsNotificationLogRepository.kt
@@ -1,0 +1,13 @@
+package com.pluxity.weekly.teams.repository
+
+import com.pluxity.weekly.teams.entity.TeamsNotificationLog
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface TeamsNotificationLogRepository : JpaRepository<TeamsNotificationLog, Long> {
+    fun findByUserIdOrderByIdDesc(
+        userId: Long,
+        pageable: Pageable,
+    ): Page<TeamsNotificationLog>
+}

--- a/src/main/kotlin/com/pluxity/weekly/teams/repository/TeamsNotificationLogRepository.kt
+++ b/src/main/kotlin/com/pluxity/weekly/teams/repository/TeamsNotificationLogRepository.kt
@@ -6,7 +6,7 @@ import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.JpaRepository
 
 interface TeamsNotificationLogRepository : JpaRepository<TeamsNotificationLog, Long> {
-    fun findByUserIdOrderByIdDesc(
+    fun findByUserId(
         userId: Long,
         pageable: Pageable,
     ): Page<TeamsNotificationLog>

--- a/src/main/kotlin/com/pluxity/weekly/teams/service/TeamsMessageSender.kt
+++ b/src/main/kotlin/com/pluxity/weekly/teams/service/TeamsMessageSender.kt
@@ -51,11 +51,12 @@ class TeamsMessageSender(
         postActivity(serviceUrl, conversationId, typingActivity)
     }
 
+    /** @return null 이면 성공, 값이 있으면 실패 사유 */
     fun notify(
         serviceUrl: String,
         conversationId: String,
         message: String,
-    ) {
+    ): String? {
         val body =
             mapOf(
                 "type" to "message",
@@ -64,14 +65,15 @@ class TeamsMessageSender(
                 "conversation" to mapOf("id" to conversationId),
             )
 
-        postActivity(serviceUrl, conversationId, body)
+        return postActivity(serviceUrl, conversationId, body)
     }
 
+    /** @return null 이면 성공, 값이 있으면 실패 사유 */
     fun notifyCard(
         serviceUrl: String,
         conversationId: String,
         card: Map<String, Any>,
-    ) {
+    ): String? {
         val body =
             mapOf(
                 "type" to "message",
@@ -86,18 +88,18 @@ class TeamsMessageSender(
                     ),
             )
 
-        postActivity(serviceUrl, conversationId, body)
+        return postActivity(serviceUrl, conversationId, body)
     }
 
     private fun postActivity(
         serviceUrl: String,
         conversationId: String,
         body: Map<String, Any>,
-    ) {
+    ): String? {
         val encodedConvId = URLEncoder.encode(conversationId, StandardCharsets.UTF_8)
         val uri = URI.create("${serviceUrl.trimEnd('/')}/v3/conversations/$encodedConvId/activities")
 
-        try {
+        return try {
             val token = teamsApiClient.getBotToken()
             val result =
                 webClient
@@ -110,10 +112,13 @@ class TeamsMessageSender(
                     .toBodilessEntity()
                     .block()
             log.info { "전송 성공: ${result?.statusCode}" }
+            null
         } catch (e: WebClientResponseException) {
             log.error { "전송 실패 (${e.statusCode}): ${e.responseBodyAsString}" }
+            "HTTP ${e.statusCode}: ${e.responseBodyAsString.take(500)}"
         } catch (e: Exception) {
             log.error(e) { "전송 중 예외" }
+            e.message ?: e.javaClass.simpleName
         }
     }
 

--- a/src/main/kotlin/com/pluxity/weekly/teams/service/TeamsNotificationLogService.kt
+++ b/src/main/kotlin/com/pluxity/weekly/teams/service/TeamsNotificationLogService.kt
@@ -1,0 +1,59 @@
+package com.pluxity.weekly.teams.service
+
+import com.pluxity.weekly.auth.authorization.AuthorizationService
+import com.pluxity.weekly.core.constant.ErrorCode
+import com.pluxity.weekly.core.exception.CustomException
+import com.pluxity.weekly.core.response.PageResponse
+import com.pluxity.weekly.core.response.toPageResponse
+import com.pluxity.weekly.teams.dto.TeamsNotificationLogResponse
+import com.pluxity.weekly.teams.dto.toResponse
+import com.pluxity.weekly.teams.entity.TeamsNotificationLog
+import com.pluxity.weekly.teams.entity.TeamsNotificationType
+import com.pluxity.weekly.teams.repository.TeamsNotificationLogRepository
+import org.springframework.data.domain.Pageable
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+@Transactional(readOnly = true)
+class TeamsNotificationLogService(
+    private val logRepository: TeamsNotificationLogRepository,
+    private val authorizationService: AuthorizationService,
+) {
+    @Transactional
+    fun savePending(
+        userId: Long,
+        type: TeamsNotificationType,
+        message: String,
+    ): TeamsNotificationLog {
+        val log =
+            TeamsNotificationLog(
+                userId = userId,
+                type = type,
+                message = message,
+            )
+        return logRepository.save(log)
+    }
+
+    @Transactional
+    fun markSent(logId: Long) {
+        val log = logRepository.findByIdOrNull(logId) ?: return
+        log.markSent()
+    }
+
+    @Transactional
+    fun markFailed(
+        logId: Long,
+        reason: String?,
+    ) {
+        val log = logRepository.findByIdOrNull(logId) ?: return
+        log.markFailed(reason)
+    }
+
+    fun findMine(pageable: Pageable): PageResponse<TeamsNotificationLogResponse> {
+        val user = authorizationService.currentUser()
+        val userId = user.id ?: throw CustomException(ErrorCode.PERMISSION_DENIED)
+        return logRepository.findByUserIdOrderByIdDesc(userId, pageable).toPageResponse { it.toResponse() }
+    }
+}

--- a/src/main/kotlin/com/pluxity/weekly/teams/service/TeamsNotificationLogService.kt
+++ b/src/main/kotlin/com/pluxity/weekly/teams/service/TeamsNotificationLogService.kt
@@ -54,6 +54,6 @@ class TeamsNotificationLogService(
     fun findMine(pageable: Pageable): PageResponse<TeamsNotificationLogResponse> {
         val user = authorizationService.currentUser()
         val userId = user.id ?: throw CustomException(ErrorCode.PERMISSION_DENIED)
-        return logRepository.findByUserIdOrderByIdDesc(userId, pageable).toPageResponse { it.toResponse() }
+        return logRepository.findByUserId(userId, pageable).toPageResponse { it.toResponse() }
     }
 }

--- a/src/main/kotlin/com/pluxity/weekly/teams/service/TeamsNotificationService.kt
+++ b/src/main/kotlin/com/pluxity/weekly/teams/service/TeamsNotificationService.kt
@@ -12,20 +12,22 @@ class TeamsNotificationService(
     private val messageSender: TeamsMessageSender,
     private val userRepository: UserRepository,
 ) {
+    /** @return null 이면 성공, 값이 있으면 실패 사유 */
     fun sendDm(
         userId: Long,
         message: String,
-    ) {
-        val (serviceUrl, conversationId) = findTeamsInfo(userId) ?: return
-        messageSender.notify(serviceUrl, conversationId, message)
+    ): String? {
+        val (serviceUrl, conversationId) = findTeamsInfo(userId) ?: return MISSING_TEAMS_INFO
+        return messageSender.notify(serviceUrl, conversationId, message)
     }
 
+    /** @return null 이면 성공, 값이 있으면 실패 사유 */
     fun sendCard(
         userId: Long,
         card: Map<String, Any>,
-    ) {
-        val (serviceUrl, conversationId) = findTeamsInfo(userId) ?: return
-        messageSender.notifyCard(serviceUrl, conversationId, card)
+    ): String? {
+        val (serviceUrl, conversationId) = findTeamsInfo(userId) ?: return MISSING_TEAMS_INFO
+        return messageSender.notifyCard(serviceUrl, conversationId, card)
     }
 
     private fun findTeamsInfo(userId: Long): Pair<String, String>? {
@@ -37,5 +39,9 @@ class TeamsNotificationService(
             return null
         }
         return serviceUrl to conversationId
+    }
+
+    companion object {
+        private const val MISSING_TEAMS_INFO = "수신자 Teams 연동 정보 없음"
     }
 }

--- a/src/main/resources/db/migration/V20260424_001__add_teams_notification_logs.sql
+++ b/src/main/resources/db/migration/V20260424_001__add_teams_notification_logs.sql
@@ -1,0 +1,18 @@
+-- Teams(웹훅) 알림 발송 이력 테이블
+-- 발송 시점에 PENDING 으로 기록하고, 발송 결과에 따라 SENT / FAILED 로 상태를 갱신한다
+
+CREATE TABLE teams_notification_logs (
+    id           BIGSERIAL    PRIMARY KEY,
+    user_id      BIGINT       NOT NULL,
+    type         VARCHAR(32)  NOT NULL,
+    message      VARCHAR(2000) NOT NULL,
+    status       VARCHAR(16)  NOT NULL,
+    fail_reason  VARCHAR(1000),
+    created_at   TIMESTAMP    NOT NULL,
+    updated_at   TIMESTAMP    NOT NULL,
+    created_by   VARCHAR(255),
+    updated_by   VARCHAR(255)
+);
+
+CREATE INDEX idx_teams_notification_logs_user_id_id
+    ON teams_notification_logs (user_id, id DESC);

--- a/src/test/kotlin/com/pluxity/weekly/teams/service/TeamsNotificationLogServiceTest.kt
+++ b/src/test/kotlin/com/pluxity/weekly/teams/service/TeamsNotificationLogServiceTest.kt
@@ -1,0 +1,156 @@
+package com.pluxity.weekly.teams.service
+
+import com.pluxity.weekly.auth.authorization.AuthorizationService
+import com.pluxity.weekly.core.constant.ErrorCode
+import com.pluxity.weekly.core.exception.CustomException
+import com.pluxity.weekly.teams.entity.TeamsNotificationLog
+import com.pluxity.weekly.teams.entity.TeamsNotificationStatus
+import com.pluxity.weekly.teams.entity.TeamsNotificationType
+import com.pluxity.weekly.teams.repository.TeamsNotificationLogRepository
+import com.pluxity.weekly.test.entity.dummyUser
+import com.pluxity.weekly.test.withAudit
+import com.pluxity.weekly.test.withId
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import org.springframework.data.domain.PageImpl
+import org.springframework.data.domain.PageRequest
+import org.springframework.data.repository.findByIdOrNull
+import java.time.LocalDateTime
+
+class TeamsNotificationLogServiceTest :
+    BehaviorSpec({
+
+        val logRepository: TeamsNotificationLogRepository = mockk()
+        val authorizationService: AuthorizationService = mockk()
+        val service = TeamsNotificationLogService(logRepository, authorizationService)
+
+        Given("savePending") {
+            When("로그를 PENDING 상태로 저장하면") {
+                val captured = slot<TeamsNotificationLog>()
+                every { logRepository.save(capture(captured)) } answers { captured.captured.withId(1L) }
+
+                val result =
+                    service.savePending(
+                        userId = 10L,
+                        type = TeamsNotificationType.TASK_REVIEW_REQUEST,
+                        message = "리뷰 요청",
+                    )
+
+                Then("전달한 값과 PENDING 상태로 저장된다") {
+                    captured.captured.userId shouldBe 10L
+                    captured.captured.type shouldBe TeamsNotificationType.TASK_REVIEW_REQUEST
+                    captured.captured.message shouldBe "리뷰 요청"
+                    captured.captured.status shouldBe TeamsNotificationStatus.PENDING
+                    captured.captured.failReason shouldBe null
+                    result.requiredId shouldBe 1L
+                }
+            }
+        }
+
+        Given("markSent") {
+            When("존재하는 로그를 SENT 로 표시하면") {
+                val log =
+                    TeamsNotificationLog(
+                        userId = 1L,
+                        type = TeamsNotificationType.TASK_APPROVE,
+                        message = "승인",
+                    ).withId(5L)
+                every { logRepository.findByIdOrNull(5L) } returns log
+
+                service.markSent(5L)
+
+                Then("상태가 SENT 로 바뀌고 failReason 은 null 이 된다") {
+                    log.status shouldBe TeamsNotificationStatus.SENT
+                    log.failReason shouldBe null
+                }
+            }
+
+            When("존재하지 않는 로그면") {
+                every { logRepository.findByIdOrNull(999L) } returns null
+
+                Then("예외 없이 조용히 종료된다") {
+                    service.markSent(999L)
+                }
+            }
+        }
+
+        Given("markFailed") {
+            When("존재하는 로그를 FAILED 로 표시하면") {
+                val log =
+                    TeamsNotificationLog(
+                        userId = 1L,
+                        type = TeamsNotificationType.EPIC_ASSIGN,
+                        message = "배정",
+                    ).withId(7L)
+                every { logRepository.findByIdOrNull(7L) } returns log
+
+                service.markFailed(7L, "HTTP 500: boom")
+
+                Then("상태가 FAILED 로 바뀌고 실패 사유가 저장된다") {
+                    log.status shouldBe TeamsNotificationStatus.FAILED
+                    log.failReason shouldBe "HTTP 500: boom"
+                }
+            }
+
+            When("존재하지 않는 로그면") {
+                every { logRepository.findByIdOrNull(404L) } returns null
+
+                Then("예외 없이 조용히 종료된다") {
+                    service.markFailed(404L, "never applied")
+                }
+            }
+        }
+
+        Given("findMine") {
+            When("현재 사용자의 알림 목록을 조회하면") {
+                val user = dummyUser(id = 10L, name = "홍길동")
+                val log1 =
+                    TeamsNotificationLog(
+                        userId = 10L,
+                        type = TeamsNotificationType.TASK_APPROVE,
+                        message = "승인",
+                    ).withId(2L).withAudit(createdAt = LocalDateTime.of(2026, 4, 24, 10, 0))
+                val log2 =
+                    TeamsNotificationLog(
+                        userId = 10L,
+                        type = TeamsNotificationType.TASK_REVIEW_REQUEST,
+                        message = "리뷰 요청",
+                    ).withId(1L).withAudit(createdAt = LocalDateTime.of(2026, 4, 23, 10, 0))
+                val pageable = PageRequest.of(0, 20)
+                val page = PageImpl(listOf(log1, log2), pageable, 2)
+
+                every { authorizationService.currentUser() } returns user
+                every { logRepository.findByUserIdOrderByIdDesc(10L, pageable) } returns page
+
+                val result = service.findMine(pageable)
+
+                Then("현재 사용자 userId 로 조회된 결과가 Response 로 변환된다") {
+                    result.content.size shouldBe 2
+                    result.content[0].id shouldBe 2L
+                    result.content[0].type shouldBe TeamsNotificationType.TASK_APPROVE
+                    result.content[1].id shouldBe 1L
+                    result.totalElements shouldBe 2
+                    result.pageNumber shouldBe 1
+                    result.pageSize shouldBe 20
+                }
+            }
+
+            When("현재 사용자의 id 가 null 이면") {
+                val orphanUser = dummyUser(id = null, name = "고아")
+                every { authorizationService.currentUser() } returns orphanUser
+
+                val exception =
+                    shouldThrow<CustomException> {
+                        service.findMine(PageRequest.of(0, 20))
+                    }
+
+                Then("PERMISSION_DENIED 예외가 발생한다") {
+                    exception.code shouldBe ErrorCode.PERMISSION_DENIED
+                }
+            }
+        }
+    })

--- a/src/test/kotlin/com/pluxity/weekly/teams/service/TeamsNotificationLogServiceTest.kt
+++ b/src/test/kotlin/com/pluxity/weekly/teams/service/TeamsNotificationLogServiceTest.kt
@@ -124,7 +124,7 @@ class TeamsNotificationLogServiceTest :
                 val page = PageImpl(listOf(log1, log2), pageable, 2)
 
                 every { authorizationService.currentUser() } returns user
-                every { logRepository.findByUserIdOrderByIdDesc(10L, pageable) } returns page
+                every { logRepository.findByUserId(10L, pageable) } returns page
 
                 val result = service.findMine(pageable)
 


### PR DESCRIPTION
## Summary
  - Teams 알림 발송 시 `teams_notification_logs`에 저장 (PENDING → SENT/FAILED)
  - 내 알림 목록 조회 API (`GET /notifications`, 페이지네이션, id DESC)
  - `TeamsNotificationEvent`에 `type` 필드 추가 (TASK_REVIEW_REQUEST / TASK_APPROVE / TASK_REJECT /
  EPIC_ASSIGN / EPIC_UNASSIGN)
  - `TeamsMessageSender` 전송 메서드가 결과(String?)를 반환하도록 변경 — null=성공, 값=실패 사유