### PR TITLE
refactor: 알림 발송을 도메인 이벤트로 분리 + 로그 원자성 확보

### DIFF
--- a/src/main/kotlin/com/pluxity/weekly/epic/event/EpicAssignedEvent.kt
+++ b/src/main/kotlin/com/pluxity/weekly/epic/event/EpicAssignedEvent.kt
@@ -1,0 +1,7 @@
+package com.pluxity.weekly.epic.event
+
+data class EpicAssignedEvent(
+    val userId: Long,
+    val epicId: Long,
+    val epicName: String,
+)

--- a/src/main/kotlin/com/pluxity/weekly/epic/event/EpicUnassignedEvent.kt
+++ b/src/main/kotlin/com/pluxity/weekly/epic/event/EpicUnassignedEvent.kt
@@ -1,0 +1,7 @@
+package com.pluxity.weekly.epic.event
+
+data class EpicUnassignedEvent(
+    val userId: Long,
+    val epicId: Long,
+    val epicName: String,
+)

--- a/src/main/kotlin/com/pluxity/weekly/epic/service/EpicAssignmentService.kt
+++ b/src/main/kotlin/com/pluxity/weekly/epic/service/EpicAssignmentService.kt
@@ -8,10 +8,10 @@ import com.pluxity.weekly.core.exception.CustomException
 import com.pluxity.weekly.epic.dto.EpicAssignmentResponse
 import com.pluxity.weekly.epic.dto.toResponse
 import com.pluxity.weekly.epic.entity.Epic
+import com.pluxity.weekly.epic.event.EpicAssignedEvent
+import com.pluxity.weekly.epic.event.EpicUnassignedEvent
 import com.pluxity.weekly.epic.repository.EpicRepository
 import com.pluxity.weekly.task.repository.TaskRepository
-import com.pluxity.weekly.teams.entity.TeamsNotificationType
-import com.pluxity.weekly.teams.event.TeamsNotificationEvent
 import org.springframework.context.ApplicationEventPublisher
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
@@ -97,10 +97,10 @@ class EpicAssignmentService(
     ) {
         epic.assign(assignee)
         eventPublisher.publishEvent(
-            TeamsNotificationEvent(
+            EpicAssignedEvent(
                 userId = assignee.requiredId,
-                type = TeamsNotificationType.EPIC_ASSIGN,
-                message = "${epic.name} 에픽에 배정되었습니다",
+                epicId = epic.requiredId,
+                epicName = epic.name,
             ),
         )
     }
@@ -112,10 +112,10 @@ class EpicAssignmentService(
         epic.unassign(assignee)
         taskRepository.deleteByEpicIdAndAssigneeId(epic.requiredId, assignee.requiredId)
         eventPublisher.publishEvent(
-            TeamsNotificationEvent(
+            EpicUnassignedEvent(
                 userId = assignee.requiredId,
-                type = TeamsNotificationType.EPIC_UNASSIGN,
-                message = "${epic.name} 에픽에서 해제되었습니다",
+                epicId = epic.requiredId,
+                epicName = epic.name,
             ),
         )
     }

--- a/src/main/kotlin/com/pluxity/weekly/task/event/TaskApprovedEvent.kt
+++ b/src/main/kotlin/com/pluxity/weekly/task/event/TaskApprovedEvent.kt
@@ -1,0 +1,6 @@
+package com.pluxity.weekly.task.event
+
+data class TaskApprovedEvent(
+    val userId: Long,
+    val taskName: String,
+)

--- a/src/main/kotlin/com/pluxity/weekly/task/event/TaskRejectedEvent.kt
+++ b/src/main/kotlin/com/pluxity/weekly/task/event/TaskRejectedEvent.kt
@@ -1,0 +1,7 @@
+package com.pluxity.weekly.task.event
+
+data class TaskRejectedEvent(
+    val userId: Long,
+    val taskName: String,
+    val reason: String?,
+)

--- a/src/main/kotlin/com/pluxity/weekly/task/event/TaskReviewRequestedEvent.kt
+++ b/src/main/kotlin/com/pluxity/weekly/task/event/TaskReviewRequestedEvent.kt
@@ -1,0 +1,10 @@
+package com.pluxity.weekly.task.event
+
+data class TaskReviewRequestedEvent(
+    val taskId: Long,
+    val taskName: String,
+    val projectName: String,
+    val epicName: String,
+    val requesterName: String,
+    val pmId: Long,
+)

--- a/src/main/kotlin/com/pluxity/weekly/task/service/TaskReviewService.kt
+++ b/src/main/kotlin/com/pluxity/weekly/task/service/TaskReviewService.kt
@@ -13,11 +13,11 @@ import com.pluxity.weekly.task.entity.Task
 import com.pluxity.weekly.task.entity.TaskApprovalAction
 import com.pluxity.weekly.task.entity.TaskApprovalLog
 import com.pluxity.weekly.task.entity.TaskStatus
+import com.pluxity.weekly.task.event.TaskApprovedEvent
+import com.pluxity.weekly.task.event.TaskRejectedEvent
+import com.pluxity.weekly.task.event.TaskReviewRequestedEvent
 import com.pluxity.weekly.task.repository.TaskApprovalLogRepository
 import com.pluxity.weekly.task.repository.TaskRepository
-import com.pluxity.weekly.teams.converter.TaskReviewCardBuilder
-import com.pluxity.weekly.teams.entity.TeamsNotificationType
-import com.pluxity.weekly.teams.event.TeamsNotificationEvent
 import org.springframework.context.ApplicationEventPublisher
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -30,7 +30,6 @@ class TaskReviewService(
     private val taskApprovalLogRepository: TaskApprovalLogRepository,
     private val authorizationService: AuthorizationService,
     private val eventPublisher: ApplicationEventPublisher,
-    private val taskReviewCardBuilder: TaskReviewCardBuilder,
 ) {
     @Transactional
     fun requestReview(id: Long) {
@@ -40,20 +39,14 @@ class TaskReviewService(
         task.requestReview()
         writeLog(task, user, TaskApprovalAction.REVIEW_REQUEST)
         task.epic.project.pmId?.let { pmId ->
-            val card =
-                taskReviewCardBuilder.build(
+            eventPublisher.publishEvent(
+                TaskReviewRequestedEvent(
                     taskId = task.requiredId,
                     taskName = task.name,
                     projectName = task.epic.project.name,
                     epicName = task.epic.name,
                     requesterName = user.name,
-                )
-            eventPublisher.publishEvent(
-                TeamsNotificationEvent(
-                    userId = pmId,
-                    type = TeamsNotificationType.TASK_REVIEW_REQUEST,
-                    message = "[리뷰 요청] '${task.name}' 태스크가 리뷰 요청되었습니다. 요청자: ${user.name}",
-                    card = card,
+                    pmId = pmId,
                 ),
             )
         }
@@ -68,10 +61,9 @@ class TaskReviewService(
         writeLog(task, user, TaskApprovalAction.APPROVE)
         task.assignee?.requiredId?.let { assigneeId ->
             eventPublisher.publishEvent(
-                TeamsNotificationEvent(
+                TaskApprovedEvent(
                     userId = assigneeId,
-                    type = TeamsNotificationType.TASK_APPROVE,
-                    message = "[승인] '${task.name}' 태스크가 승인되었습니다.",
+                    taskName = task.name,
                 ),
             )
         }
@@ -89,12 +81,11 @@ class TaskReviewService(
         val normalizedReason = reason?.takeIf { it.isNotBlank() }
         writeLog(task, user, TaskApprovalAction.REJECT, normalizedReason)
         task.assignee?.requiredId?.let { assigneeId ->
-            val suffix = normalizedReason?.let { " 사유: $it" } ?: ""
             eventPublisher.publishEvent(
-                TeamsNotificationEvent(
+                TaskRejectedEvent(
                     userId = assigneeId,
-                    type = TeamsNotificationType.TASK_REJECT,
-                    message = "[반려] '${task.name}' 태스크가 반려되었습니다.$suffix",
+                    taskName = task.name,
+                    reason = normalizedReason,
                 ),
             )
         }

--- a/src/main/kotlin/com/pluxity/weekly/teams/event/TeamsNotificationEvent.kt
+++ b/src/main/kotlin/com/pluxity/weekly/teams/event/TeamsNotificationEvent.kt
@@ -1,6 +1,5 @@
 package com.pluxity.weekly.teams.event
 
-import com.pluxity.weekly.teams.entity.TeamsNotificationType
 
 /**
  * Teams Proactive 알림 이벤트.

--- a/src/main/kotlin/com/pluxity/weekly/teams/event/TeamsNotificationEvent.kt
+++ b/src/main/kotlin/com/pluxity/weekly/teams/event/TeamsNotificationEvent.kt
@@ -5,14 +5,14 @@ import com.pluxity.weekly.teams.entity.TeamsNotificationType
 /**
  * Teams Proactive 알림 이벤트.
  *
+ * @property logId 저장된 로그 ID (teams 발송 후 상태 변경 용)
  * @property userId 알림 대상 사용자 ID (weekly-report userId)
- * @property type 알림 유형 (저장/조회 시 분류 용도)
  * @property message 알림 메시지 (card 가 null 일 때 text 로 전송)
  * @property card Adaptive Card 콘텐츠. null 이면 text 로, 있으면 card 로 전송.
  */
 data class TeamsNotificationEvent(
+    val logId: Long,
     val userId: Long,
-    val type: TeamsNotificationType,
     val message: String,
     val card: Map<String, Any>? = null,
 )

--- a/src/main/kotlin/com/pluxity/weekly/teams/event/TeamsNotificationEventHandler.kt
+++ b/src/main/kotlin/com/pluxity/weekly/teams/event/TeamsNotificationEventHandler.kt
@@ -1,0 +1,109 @@
+package com.pluxity.weekly.teams.event
+
+import com.pluxity.weekly.epic.event.EpicAssignedEvent
+import com.pluxity.weekly.epic.event.EpicUnassignedEvent
+import com.pluxity.weekly.task.event.TaskApprovedEvent
+import com.pluxity.weekly.task.event.TaskRejectedEvent
+import com.pluxity.weekly.task.event.TaskReviewRequestedEvent
+import com.pluxity.weekly.teams.converter.TaskReviewCardBuilder
+import com.pluxity.weekly.teams.entity.TeamsNotificationType
+import com.pluxity.weekly.teams.service.TeamsNotificationLogService
+import org.springframework.context.ApplicationEventPublisher
+import org.springframework.context.event.EventListener
+import org.springframework.stereotype.Component
+
+/**
+ * 도메인 이벤트를 수신해 같은 트랜잭션에서 알림 로그를 영속화하고,
+ * 외부 발사용 [TeamsNotificationEvent] 를 재발행한다.
+ *
+ * 트랜잭션 경계:
+ * - 이 핸들러는 도메인 트랜잭션과 동일한 TX 에서 동기 실행 → 도메인 변경 ↔ 알림 로그 저장의 원자성 보장
+ * - 실제 외부 API 호출은 [TeamsNotificationListener] 가 AFTER_COMMIT + @Async 로 처리
+ *
+ * 주의: `@TransactionalEventListener` 로 바꾸면 원자성이 깨진다.
+ */
+@Component
+class TeamsNotificationEventHandler(
+    private val logService: TeamsNotificationLogService,
+    private val eventPublisher: ApplicationEventPublisher,
+    private val taskReviewCardBuilder: TaskReviewCardBuilder,
+) {
+    @EventListener
+    fun on(event: EpicAssignedEvent) {
+        publishNotification(
+            userId = event.userId,
+            type = TeamsNotificationType.EPIC_ASSIGN,
+            message = "${event.epicName} 에픽에 배정되었습니다.",
+        )
+    }
+
+    @EventListener
+    fun on(event: EpicUnassignedEvent) {
+        publishNotification(
+            userId = event.userId,
+            type = TeamsNotificationType.EPIC_UNASSIGN,
+            message = "${event.epicName} 에픽 배정이 해제되었습니다.",
+        )
+    }
+
+    @EventListener
+    fun on(event: TaskReviewRequestedEvent) {
+        val card =
+            taskReviewCardBuilder.build(
+                taskId = event.taskId,
+                taskName = event.taskName,
+                projectName = event.projectName,
+                epicName = event.epicName,
+                requesterName = event.requesterName,
+            )
+
+        publishNotification(
+            userId = event.pmId,
+            type = TeamsNotificationType.TASK_REVIEW_REQUEST,
+            message = "[리뷰 요청] '${event.taskName}' 태스크가 리뷰 요청되었습니다. 요청자: ${event.requesterName}",
+            card = card,
+        )
+    }
+
+    @EventListener
+    fun on(event: TaskApprovedEvent) {
+        publishNotification(
+            userId = event.userId,
+            type = TeamsNotificationType.TASK_APPROVE,
+            message = "[승인] '${event.taskName}' 태스크가 승인되었습니다.",
+        )
+    }
+
+    @EventListener
+    fun on(event: TaskRejectedEvent) {
+        val reasonSuffix = event.reason?.let { " 사유: $it" } ?: ""
+        publishNotification(
+            userId = event.userId,
+            type = TeamsNotificationType.TASK_REJECT,
+            message = "[반려] '${event.taskName}' 태스크가 반려되었습니다.$reasonSuffix",
+        )
+    }
+
+    private fun publishNotification(
+        userId: Long,
+        type: TeamsNotificationType,
+        message: String,
+        card: Map<String, Any>? = null,
+    ) {
+        val log =
+            logService.savePending(
+                userId = userId,
+                type = type,
+                message = message,
+            )
+
+        eventPublisher.publishEvent(
+            TeamsNotificationEvent(
+                logId = log.requiredId,
+                userId = userId,
+                message = message,
+                card = card,
+            ),
+        )
+    }
+}

--- a/src/main/kotlin/com/pluxity/weekly/teams/event/TeamsNotificationListener.kt
+++ b/src/main/kotlin/com/pluxity/weekly/teams/event/TeamsNotificationListener.kt
@@ -15,13 +15,7 @@ class TeamsNotificationListener(
     @Async
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     fun handleNotification(event: TeamsNotificationEvent) {
-        val log =
-            logService.savePending(
-                userId = event.userId,
-                type = event.type,
-                message = event.message,
-            )
-        val logId = log.requiredId
+        val logId = event.logId
 
         val failReason =
             runCatching {

--- a/src/test/kotlin/com/pluxity/weekly/epic/service/EpicAssignmentServiceTest.kt
+++ b/src/test/kotlin/com/pluxity/weekly/epic/service/EpicAssignmentServiceTest.kt
@@ -8,6 +8,8 @@ import com.pluxity.weekly.core.exception.CustomException
 import com.pluxity.weekly.epic.entity.EpicStatus
 import com.pluxity.weekly.epic.entity.dummyEpic
 import com.pluxity.weekly.epic.entity.dummyEpicAssignment
+import com.pluxity.weekly.epic.event.EpicAssignedEvent
+import com.pluxity.weekly.epic.event.EpicUnassignedEvent
 import com.pluxity.weekly.epic.repository.EpicRepository
 import com.pluxity.weekly.project.entity.dummyProject
 import com.pluxity.weekly.task.repository.TaskRepository
@@ -77,7 +79,7 @@ class EpicAssignmentServiceTest :
 
         Given("에픽에 사용자 배정") {
             When("정상적으로 배정하면") {
-                val epic = dummyEpic(id = 2L)
+                val epic = dummyEpic(id = 2L, name = "테스트 에픽")
                 val user = dummyUser(id = 30L, name = "신규")
 
                 every { epicRepository.findByIdOrNull(2L) } returns epic
@@ -87,7 +89,14 @@ class EpicAssignmentServiceTest :
 
                 Then("에픽 assignments 에 추가되고 알림이 발행된다") {
                     epic.assignments.any { it.user == user } shouldBe true
-                    verify { eventPublisher.publishEvent(match<TeamsNotificationEvent> { it.userId == 30L && it.message.contains("배정") }) }
+                    verify {
+                        eventPublisher.publishEvent(
+                            match<EpicAssignedEvent> {
+                                it.userId == 30L && it.epicId == 2L &&
+                                    it.epicName == "테스트 에픽"
+                            },
+                        )
+                    }
                 }
             }
 
@@ -141,7 +150,7 @@ class EpicAssignmentServiceTest :
                     verify { taskRepository.deleteByEpicIdAndAssigneeId(5L, 60L) }
                     verify {
                         eventPublisher.publishEvent(
-                            match<TeamsNotificationEvent> { it.userId == 60L && it.message.contains("해제") },
+                            match<EpicUnassignedEvent> { it.userId == 60L && it.epicId == 5L && it.epicName == "해제 에픽" },
                         )
                     }
                 }
@@ -197,8 +206,22 @@ class EpicAssignmentServiceTest :
                 Then("user1 은 해제되고 user3 은 추가된다") {
                     epic.assignments.map { it.user } shouldBe listOf(user2, user3)
                     verify { taskRepository.deleteByEpicIdAndAssigneeId(10L, 1L) }
-                    verify { eventPublisher.publishEvent(match<TeamsNotificationEvent> { it.userId == 1L && it.message.contains("해제") }) }
-                    verify { eventPublisher.publishEvent(match<TeamsNotificationEvent> { it.userId == 3L && it.message.contains("배정") }) }
+                    verify {
+                        eventPublisher.publishEvent(
+                            match<EpicUnassignedEvent> {
+                                it.userId == 1L && it.epicId == 10L &&
+                                    it.epicName == "동기화 에픽"
+                            },
+                        )
+                    }
+                    verify {
+                        eventPublisher.publishEvent(
+                            match<EpicAssignedEvent> {
+                                it.userId == 3L && it.epicId == 10L &&
+                                    it.epicName == "동기화 에픽"
+                            },
+                        )
+                    }
                 }
             }
 
@@ -274,7 +297,14 @@ class EpicAssignmentServiceTest :
 
                 Then("assignments 에 추가되고 배정 알림이 발행된다") {
                     epic.assignments.any { it.user == assignee } shouldBe true
-                    verify { eventPublisher.publishEvent(match<TeamsNotificationEvent> { it.userId == 80L && it.message.contains("배정") }) }
+                    verify {
+                        eventPublisher.publishEvent(
+                            match<EpicAssignedEvent> {
+                                it.userId == 80L && it.epicId == 22L &&
+                                    it.epicName == "자동편입"
+                            },
+                        )
+                    }
                 }
             }
 

--- a/src/test/kotlin/com/pluxity/weekly/task/service/TaskReviewServiceTest.kt
+++ b/src/test/kotlin/com/pluxity/weekly/task/service/TaskReviewServiceTest.kt
@@ -10,11 +10,12 @@ import com.pluxity.weekly.task.entity.TaskApprovalAction
 import com.pluxity.weekly.task.entity.TaskApprovalLog
 import com.pluxity.weekly.task.entity.TaskStatus
 import com.pluxity.weekly.task.entity.dummyTask
+import com.pluxity.weekly.task.event.TaskApprovedEvent
+import com.pluxity.weekly.task.event.TaskRejectedEvent
+import com.pluxity.weekly.task.event.TaskReviewRequestedEvent
 import com.pluxity.weekly.task.repository.TaskApprovalLogRepository
 import com.pluxity.weekly.task.repository.TaskRepository
 import com.pluxity.weekly.task.repository.TaskReviewRequestedAt
-import com.pluxity.weekly.teams.converter.TaskReviewCardBuilder
-import com.pluxity.weekly.teams.event.TeamsNotificationEvent
 import com.pluxity.weekly.test.entity.dummyRole
 import com.pluxity.weekly.test.entity.dummyUser
 import io.kotest.assertions.throwables.shouldThrow
@@ -36,14 +37,12 @@ class TaskReviewServiceTest :
         val taskApprovalLogRepository: TaskApprovalLogRepository = mockk(relaxed = true)
         val authorizationService: AuthorizationService = mockk()
         val eventPublisher: ApplicationEventPublisher = mockk(relaxed = true)
-        val taskReviewCardBuilder: TaskReviewCardBuilder = mockk(relaxed = true)
         val service =
             TaskReviewService(
                 taskRepository,
                 taskApprovalLogRepository,
                 authorizationService,
                 eventPublisher,
-                taskReviewCardBuilder,
             )
 
         val adminUser =
@@ -82,7 +81,7 @@ class TaskReviewServiceTest :
                 Then("태스크 상태가 IN_REVIEW 로 변경되고 PM 에게 알림이 발행된다") {
                     entity.status shouldBe TaskStatus.IN_REVIEW
                     verify(exactly = 1) { taskApprovalLogRepository.save(any<TaskApprovalLog>()) }
-                    (eventSlot.captured as TeamsNotificationEvent).userId shouldBe pmId
+                    (eventSlot.captured as TaskReviewRequestedEvent).pmId shouldBe pmId
                 }
             }
 
@@ -132,7 +131,7 @@ class TaskReviewServiceTest :
                 Then("태스크 상태가 DONE 으로 변경되고 담당자에게 알림이 발행된다") {
                     entity.status shouldBe TaskStatus.DONE
                     verify(exactly = 1) { taskApprovalLogRepository.save(any<TaskApprovalLog>()) }
-                    (eventSlot.captured as TeamsNotificationEvent).userId shouldBe 50L
+                    (eventSlot.captured as TaskApprovedEvent).userId shouldBe 50L
                 }
             }
 
@@ -155,50 +154,85 @@ class TaskReviewServiceTest :
             When("IN_REVIEW 태스크를 사유와 함께 반려하면") {
                 val project = dummyProject(id = 1L, pmId = 99L)
                 val epic = dummyEpic(id = 1L, project = project)
+                val assignee = dummyUser(id = 70L, name = "담당자")
                 val entity =
                     dummyTask(
                         id = 30L,
                         epic = epic,
                         name = "반려 대상",
                         status = TaskStatus.IN_REVIEW,
-                    )
+                    ).apply { this.assignee = assignee }
 
                 every { taskRepository.findWithEpicAndProjectById(30L) } returns entity
-                every { eventPublisher.publishEvent(any<TeamsNotificationEvent>()) } just runs
+                val eventSlot = slot<Any>()
+                every { eventPublisher.publishEvent(capture(eventSlot)) } just runs
                 val logSlot = slot<TaskApprovalLog>()
                 every { taskApprovalLogRepository.save(capture(logSlot)) } answers { logSlot.captured }
 
                 service.reject(30L, "요구사항 불충족")
 
-                Then("태스크 상태가 IN_PROGRESS 로 복귀되고 반려 사유가 로그에 기록된다") {
+                Then("태스크 상태가 IN_PROGRESS 로 복귀되고 반려 사유가 로그와 이벤트에 전파된다") {
                     entity.status shouldBe TaskStatus.IN_PROGRESS
                     logSlot.captured.action shouldBe TaskApprovalAction.REJECT
                     logSlot.captured.reason shouldBe "요구사항 불충족"
+
+                    val event = eventSlot.captured as TaskRejectedEvent
+                    event.userId shouldBe 70L
+                    event.taskName shouldBe "반려 대상"
+                    event.reason shouldBe "요구사항 불충족"
                 }
             }
 
             When("사유 없이(null) 반려하면") {
                 val project = dummyProject(id = 1L, pmId = 99L)
                 val epic = dummyEpic(id = 1L, project = project)
+                val assignee = dummyUser(id = 71L, name = "담당자")
                 val entity =
                     dummyTask(
                         id = 31L,
                         epic = epic,
                         name = "사유 없는 반려",
                         status = TaskStatus.IN_REVIEW,
-                    )
+                    ).apply { this.assignee = assignee }
 
                 every { taskRepository.findWithEpicAndProjectById(31L) } returns entity
-                every { eventPublisher.publishEvent(any<TeamsNotificationEvent>()) } just runs
+                val eventSlot = slot<Any>()
+                every { eventPublisher.publishEvent(capture(eventSlot)) } just runs
                 val logSlot = slot<TaskApprovalLog>()
                 every { taskApprovalLogRepository.save(capture(logSlot)) } answers { logSlot.captured }
 
                 service.reject(31L, null)
 
-                Then("태스크 상태가 IN_PROGRESS 로 복귀되고 reason 은 null 로 기록된다") {
+                Then("로그와 이벤트 모두 reason 이 null 로 전파된다") {
                     entity.status shouldBe TaskStatus.IN_PROGRESS
                     logSlot.captured.action shouldBe TaskApprovalAction.REJECT
                     logSlot.captured.reason shouldBe null
+                    (eventSlot.captured as TaskRejectedEvent).reason shouldBe null
+                }
+            }
+
+            When("담당자가 없는 태스크를 반려하면") {
+                val project = dummyProject(id = 1L, pmId = 99L)
+                val epic = dummyEpic(id = 1L, project = project)
+                val entity =
+                    dummyTask(
+                        id = 33L,
+                        epic = epic,
+                        name = "담당자 없음",
+                        status = TaskStatus.IN_REVIEW,
+                    )
+
+                every { taskRepository.findWithEpicAndProjectById(33L) } returns entity
+                val eventSlot = slot<Any>()
+                every { eventPublisher.publishEvent(capture(eventSlot)) } just runs
+                val logSlot = slot<TaskApprovalLog>()
+                every { taskApprovalLogRepository.save(capture(logSlot)) } answers { logSlot.captured }
+
+                service.reject(33L, "사유")
+
+                Then("로그는 기록되지만 알림 이벤트는 발행되지 않는다") {
+                    logSlot.captured.action shouldBe TaskApprovalAction.REJECT
+                    eventSlot.isCaptured shouldBe false
                 }
             }
         }


### PR DESCRIPTION
 ## Summary

  - 알림 발송과 로그 저장의 원자성 확보 — 기존엔 도메인 변경 커밋과 알림 로그 저장이 별도 트랜잭션이라, 두 시점 사이에 프로세스가 죽거나 log DB 장애가 나면 비즈니스는 반영됐는데 "알림을 보냈어야 한다"는 흔적조차 사라져 재시도/추적이 불가능했음
  - 도메인 이벤트로 알림 책임 분리 — 도메인 서비스가 Teams 인프라(LogService, NotificationType)를 직접 의존하지 않도록