### PR TITLE
feat: 프로젝트/업무 그룹/태스크 복구 API 추가

### DIFF
--- a/src/main/kotlin/com/pluxity/weekly/auth/authorization/AuthorizationService.kt
+++ b/src/main/kotlin/com/pluxity/weekly/auth/authorization/AuthorizationService.kt
@@ -7,6 +7,7 @@ import com.pluxity.weekly.chat.dto.ChatTarget
 import com.pluxity.weekly.core.constant.ErrorCode
 import com.pluxity.weekly.core.exception.CustomException
 import com.pluxity.weekly.epic.repository.EpicRepository
+import com.pluxity.weekly.project.entity.Project
 import com.pluxity.weekly.project.repository.ProjectRepository
 import com.pluxity.weekly.task.entity.Task
 import org.springframework.security.core.context.SecurityContextHolder
@@ -53,6 +54,17 @@ class AuthorizationService(
     ) {
         if (user.hasRole(UserType.ADMIN)) return
         if (user.isProjectManager() && projectRepository.existsByIdAndPmId(projectId, user.requiredId)) return
+        throw CustomException(ErrorCode.PERMISSION_DENIED)
+    }
+
+    /** soft-deleted 프로젝트에도 동작하도록 엔티티를 직접 받는 오버로드 — 복구 흐름용 */
+    fun requireProjectManager(
+        user: User,
+        project: Project,
+    ) {
+        if (user.hasRole(UserType.ADMIN)) return
+        val pmId = project.pmId
+        if (user.isProjectManager() && pmId != null && pmId == user.requiredId) return
         throw CustomException(ErrorCode.PERMISSION_DENIED)
     }
 
@@ -110,6 +122,7 @@ class AuthorizationService(
         if (user.isProjectManager() && pmId != null && pmId == user.requiredId) return
         throw CustomException(ErrorCode.PERMISSION_DENIED)
     }
+
 
     /** target + action 조합의 사전 권한 체크 — Chat context 빌드 전 호출 */
     fun checkChatPermission(

--- a/src/main/kotlin/com/pluxity/weekly/core/constant/ErrorCode.kt
+++ b/src/main/kotlin/com/pluxity/weekly/core/constant/ErrorCode.kt
@@ -38,6 +38,8 @@ enum class ErrorCode(
     INVALID_DATE_RANGE(HttpStatus.BAD_REQUEST, "시작일(%s)이 마감일(%s)보다 늦을 수 없습니다."),
     EPIC_NOT_ALL_DONE(HttpStatus.BAD_REQUEST, "프로젝트를 완료하려면 모든 하위 업무 그룹을 먼저 완료해야 합니다."),
     TASK_NOT_ALL_DONE(HttpStatus.BAD_REQUEST, "업무 그룹을 완료하려면 모든 하위 태스크를 먼저 완료해야 합니다."),
+    PARENT_PROJECT_DELETED(HttpStatus.BAD_REQUEST, "상위 프로젝트가 삭제 상태입니다. 프로젝트부터 복구해주세요."),
+    PARENT_EPIC_DELETED(HttpStatus.BAD_REQUEST, "상위 업무 그룹이 삭제 상태입니다. 업무 그룹부터 복구해주세요."),
 
     // ── Chat / LLM ──
     LLM_SERVICE_UNAVAILABLE(HttpStatus.SERVICE_UNAVAILABLE, "LLM 서비스에 연결할 수 없습니다."),

--- a/src/main/kotlin/com/pluxity/weekly/epic/controller/EpicController.kt
+++ b/src/main/kotlin/com/pluxity/weekly/epic/controller/EpicController.kt
@@ -119,6 +119,30 @@ class EpicController(
         return ResponseEntity.noContent().build()
     }
 
+    @Operation(summary = "업무 그룹 복구", description = "소프트 삭제된 업무 그룹과 하위 태스크를 복구합니다")
+    @ApiResponses(
+        value = [
+            ApiResponse(responseCode = "204", description = "복구 성공"),
+            ApiResponse(
+                responseCode = "403",
+                description = "권한 없음",
+                content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponseBody::class))],
+            ),
+            ApiResponse(
+                responseCode = "404",
+                description = "업무 그룹을 찾을 수 없음",
+                content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponseBody::class))],
+            ),
+        ],
+    )
+    @PostMapping("/{id}/restore")
+    fun restore(
+        @PathVariable id: Long,
+    ): ResponseEntity<Void> {
+        service.restore(id)
+        return ResponseEntity.noContent().build()
+    }
+
     @Operation(summary = "업무 그룹 배정 목록 조회", description = "업무 그룹에 배정된 사용자 목록을 조회합니다")
     @ApiResponses(
         value = [

--- a/src/main/kotlin/com/pluxity/weekly/epic/repository/EpicRepository.kt
+++ b/src/main/kotlin/com/pluxity/weekly/epic/repository/EpicRepository.kt
@@ -22,10 +22,24 @@ interface EpicRepository :
 
     fun findByProjectIdIn(projectIds: List<Long>): List<Epic>
 
-    @Query(value = "SELECT * FROM epics WHERE id = :id", nativeQuery = true)
-    fun findRawById(
+    @Query(value = "SELECT project_id FROM epics WHERE id = :id", nativeQuery = true)
+    fun findProjectIdRawById(
         @Param("id") id: Long,
-    ): Epic?
+    ): Long?
+
+    @Query(
+        value = """
+            SELECT EXISTS(
+              SELECT 1 FROM epics e
+              JOIN projects p ON e.project_id = p.id
+              WHERE e.id = :id AND p.deleted = true
+            )
+        """,
+        nativeQuery = true,
+    )
+    fun isParentProjectDeletedByEpicId(
+        @Param("id") id: Long,
+    ): Boolean
 
     @Modifying
     @Query(value = "UPDATE epics SET deleted = false WHERE id = :id", nativeQuery = true)

--- a/src/main/kotlin/com/pluxity/weekly/epic/repository/EpicRepository.kt
+++ b/src/main/kotlin/com/pluxity/weekly/epic/repository/EpicRepository.kt
@@ -3,6 +3,9 @@ package com.pluxity.weekly.epic.repository
 import com.pluxity.weekly.epic.entity.Epic
 import org.springframework.data.jpa.repository.EntityGraph
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Modifying
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
 
 interface EpicRepository :
     JpaRepository<Epic, Long>,
@@ -18,4 +21,21 @@ interface EpicRepository :
     ): Boolean
 
     fun findByProjectIdIn(projectIds: List<Long>): List<Epic>
+
+    @Query(value = "SELECT * FROM epics WHERE id = :id", nativeQuery = true)
+    fun findRawById(
+        @Param("id") id: Long,
+    ): Epic?
+
+    @Modifying
+    @Query(value = "UPDATE epics SET deleted = false WHERE id = :id", nativeQuery = true)
+    fun restoreById(
+        @Param("id") id: Long,
+    ): Int
+
+    @Modifying
+    @Query(value = "UPDATE epics SET deleted = false WHERE project_id = :projectId", nativeQuery = true)
+    fun restoreByProjectId(
+        @Param("projectId") projectId: Long,
+    ): Int
 }

--- a/src/main/kotlin/com/pluxity/weekly/epic/service/EpicService.kt
+++ b/src/main/kotlin/com/pluxity/weekly/epic/service/EpicService.kt
@@ -105,6 +105,17 @@ class EpicService(
         epicRepository.delete(epic)
     }
 
+    @Transactional
+    fun restore(id: Long) {
+        val user = authorizationService.currentUser()
+        val epic = epicRepository.findRawById(id)
+            ?: throw CustomException(ErrorCode.NOT_FOUND_EPIC, id)
+        authorizationService.requireEpicManage(user, epic.project.requiredId)
+
+        epicRepository.restoreById(id)
+        taskRepository.restoreByEpicId(id)
+    }
+
     private fun getEpicById(id: Long): Epic =
         epicRepository.findByIdOrNull(id)
             ?: throw CustomException(ErrorCode.NOT_FOUND_EPIC, id)

--- a/src/main/kotlin/com/pluxity/weekly/epic/service/EpicService.kt
+++ b/src/main/kotlin/com/pluxity/weekly/epic/service/EpicService.kt
@@ -108,9 +108,12 @@ class EpicService(
     @Transactional
     fun restore(id: Long) {
         val user = authorizationService.currentUser()
-        val epic = epicRepository.findRawById(id)
+        val projectId = epicRepository.findProjectIdRawById(id)
             ?: throw CustomException(ErrorCode.NOT_FOUND_EPIC, id)
-        authorizationService.requireEpicManage(user, epic.project.requiredId)
+        if (epicRepository.isParentProjectDeletedByEpicId(id)) {
+            throw CustomException(ErrorCode.PARENT_PROJECT_DELETED)
+        }
+        authorizationService.requireEpicManage(user, projectId)
 
         epicRepository.restoreById(id)
         taskRepository.restoreByEpicId(id)

--- a/src/main/kotlin/com/pluxity/weekly/project/controller/ProjectController.kt
+++ b/src/main/kotlin/com/pluxity/weekly/project/controller/ProjectController.kt
@@ -115,4 +115,28 @@ class ProjectController(
         service.delete(id)
         return ResponseEntity.noContent().build()
     }
+
+    @Operation(summary = "프로젝트 복구", description = "소프트 삭제된 프로젝트와 하위 업무 그룹/태스크를 복구합니다")
+    @ApiResponses(
+        value = [
+            ApiResponse(responseCode = "204", description = "복구 성공"),
+            ApiResponse(
+                responseCode = "403",
+                description = "권한 없음",
+                content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponseBody::class))],
+            ),
+            ApiResponse(
+                responseCode = "404",
+                description = "프로젝트를 찾을 수 없음",
+                content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponseBody::class))],
+            ),
+        ],
+    )
+    @PostMapping("/{id}/restore")
+    fun restore(
+        @PathVariable id: Long,
+    ): ResponseEntity<Void> {
+        service.restore(id)
+        return ResponseEntity.noContent().build()
+    }
 }

--- a/src/main/kotlin/com/pluxity/weekly/project/repository/ProjectRepository.kt
+++ b/src/main/kotlin/com/pluxity/weekly/project/repository/ProjectRepository.kt
@@ -3,7 +3,9 @@ package com.pluxity.weekly.project.repository
 import com.pluxity.weekly.project.dto.ProjectMemberResponse
 import com.pluxity.weekly.project.entity.Project
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Modifying
 import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
 
 interface ProjectRepository :
     JpaRepository<Project, Long>,
@@ -14,6 +16,17 @@ interface ProjectRepository :
         id: Long,
         pmId: Long,
     ): Boolean
+
+    @Query(value = "SELECT * FROM projects WHERE id = :id", nativeQuery = true)
+    fun findRawById(
+        @Param("id") id: Long,
+    ): Project?
+
+    @Modifying
+    @Query(value = "UPDATE projects SET deleted = false WHERE id = :id", nativeQuery = true)
+    fun restoreById(
+        @Param("id") id: Long,
+    ): Int
 
     @Query(
         """

--- a/src/main/kotlin/com/pluxity/weekly/project/service/ProjectService.kt
+++ b/src/main/kotlin/com/pluxity/weekly/project/service/ProjectService.kt
@@ -15,6 +15,7 @@ import com.pluxity.weekly.project.entity.Project
 import com.pluxity.weekly.project.entity.ProjectStatus
 import com.pluxity.weekly.project.event.ProjectPmAssignedEvent
 import com.pluxity.weekly.project.repository.ProjectRepository
+import com.pluxity.weekly.task.repository.TaskRepository
 import org.springframework.context.ApplicationEventPublisher
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
@@ -25,6 +26,7 @@ import org.springframework.transaction.annotation.Transactional
 class ProjectService(
     private val projectRepository: ProjectRepository,
     private val epicRepository: EpicRepository,
+    private val taskRepository: TaskRepository,
     private val userRepository: UserRepository,
     private val authorizationService: AuthorizationService,
     private val eventPublisher: ApplicationEventPublisher,
@@ -119,6 +121,18 @@ class ProjectService(
         val user = authorizationService.currentUser()
         authorizationService.requireProjectManager(user, id)
         projectRepository.delete(getById(id))
+    }
+
+    @Transactional
+    fun restore(id: Long) {
+        val user = authorizationService.currentUser()
+        val project = projectRepository.findRawById(id)
+            ?: throw CustomException(ErrorCode.NOT_FOUND_PROJECT, id)
+        authorizationService.requireProjectManager(user, project)
+
+        projectRepository.restoreById(id)
+        epicRepository.restoreByProjectId(id)
+        taskRepository.restoreByProjectId(id)
     }
 
     private fun getById(id: Long): Project =

--- a/src/main/kotlin/com/pluxity/weekly/task/controller/TaskController.kt
+++ b/src/main/kotlin/com/pluxity/weekly/task/controller/TaskController.kt
@@ -208,4 +208,28 @@ class TaskController(
         service.delete(id)
         return ResponseEntity.noContent().build()
     }
+
+    @Operation(summary = "태스크 복구", description = "소프트 삭제된 태스크를 복구합니다")
+    @ApiResponses(
+        value = [
+            ApiResponse(responseCode = "204", description = "복구 성공"),
+            ApiResponse(
+                responseCode = "403",
+                description = "권한 없음",
+                content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponseBody::class))],
+            ),
+            ApiResponse(
+                responseCode = "404",
+                description = "태스크를 찾을 수 없음",
+                content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponseBody::class))],
+            ),
+        ],
+    )
+    @PostMapping("/{id}/restore")
+    fun restore(
+        @PathVariable id: Long,
+    ): ResponseEntity<Void> {
+        service.restore(id)
+        return ResponseEntity.noContent().build()
+    }
 }

--- a/src/main/kotlin/com/pluxity/weekly/task/repository/TaskRepository.kt
+++ b/src/main/kotlin/com/pluxity/weekly/task/repository/TaskRepository.kt
@@ -5,6 +5,9 @@ import com.pluxity.weekly.task.entity.Task
 import com.pluxity.weekly.task.entity.TaskStatus
 import org.springframework.data.jpa.repository.EntityGraph
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Modifying
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
 
 interface TaskRepository :
     JpaRepository<Task, Long>,
@@ -43,4 +46,33 @@ interface TaskRepository :
         epicId: Long,
         assigneeId: Long,
     )
+
+    @Query(value = "SELECT * FROM tasks WHERE id = :id", nativeQuery = true)
+    fun findRawById(
+        @Param("id") id: Long,
+    ): Task?
+
+    @Modifying
+    @Query(value = "UPDATE tasks SET deleted = false WHERE id = :id", nativeQuery = true)
+    fun restoreById(
+        @Param("id") id: Long,
+    ): Int
+
+    @Modifying
+    @Query(value = "UPDATE tasks SET deleted = false WHERE epic_id = :epicId", nativeQuery = true)
+    fun restoreByEpicId(
+        @Param("epicId") epicId: Long,
+    ): Int
+
+    @Modifying
+    @Query(
+        value = """
+            UPDATE tasks SET deleted = false
+            WHERE epic_id IN (SELECT id FROM epics WHERE project_id = :projectId)
+        """,
+        nativeQuery = true,
+    )
+    fun restoreByProjectId(
+        @Param("projectId") projectId: Long,
+    ): Int
 }

--- a/src/main/kotlin/com/pluxity/weekly/task/repository/TaskRepository.kt
+++ b/src/main/kotlin/com/pluxity/weekly/task/repository/TaskRepository.kt
@@ -52,6 +52,35 @@ interface TaskRepository :
         @Param("id") id: Long,
     ): Task?
 
+    @Query(
+        value = """
+            SELECT EXISTS(
+              SELECT 1 FROM tasks t
+              JOIN epics e ON t.epic_id = e.id
+              WHERE t.id = :id AND e.deleted = true
+            )
+        """,
+        nativeQuery = true,
+    )
+    fun isParentEpicDeletedByTaskId(
+        @Param("id") id: Long,
+    ): Boolean
+
+    @Query(
+        value = """
+            SELECT EXISTS(
+              SELECT 1 FROM tasks t
+              JOIN epics e ON t.epic_id = e.id
+              JOIN projects p ON e.project_id = p.id
+              WHERE t.id = :id AND p.deleted = true
+            )
+        """,
+        nativeQuery = true,
+    )
+    fun isParentProjectDeletedByTaskId(
+        @Param("id") id: Long,
+    ): Boolean
+
     @Modifying
     @Query(value = "UPDATE tasks SET deleted = false WHERE id = :id", nativeQuery = true)
     fun restoreById(

--- a/src/main/kotlin/com/pluxity/weekly/task/service/TaskService.kt
+++ b/src/main/kotlin/com/pluxity/weekly/task/service/TaskService.kt
@@ -110,6 +110,12 @@ class TaskService(
         val user = authorizationService.currentUser()
         val task = taskRepository.findRawById(id)
             ?: throw CustomException(ErrorCode.NOT_FOUND_TASK, id)
+        if (taskRepository.isParentProjectDeletedByTaskId(id)) {
+            throw CustomException(ErrorCode.PARENT_PROJECT_DELETED)
+        }
+        if (taskRepository.isParentEpicDeletedByTaskId(id)) {
+            throw CustomException(ErrorCode.PARENT_EPIC_DELETED)
+        }
         authorizationService.requireTaskOwner(user, task)
 
         taskRepository.restoreById(id)

--- a/src/main/kotlin/com/pluxity/weekly/task/service/TaskService.kt
+++ b/src/main/kotlin/com/pluxity/weekly/task/service/TaskService.kt
@@ -105,6 +105,16 @@ class TaskService(
         taskRepository.delete(task)
     }
 
+    @Transactional
+    fun restore(id: Long) {
+        val user = authorizationService.currentUser()
+        val task = taskRepository.findRawById(id)
+            ?: throw CustomException(ErrorCode.NOT_FOUND_TASK, id)
+        authorizationService.requireTaskOwner(user, task)
+
+        taskRepository.restoreById(id)
+    }
+
     private fun ensureUniqueTaskName(
         epicId: Long,
         name: String,

--- a/src/test/kotlin/com/pluxity/weekly/epic/service/EpicServiceTest.kt
+++ b/src/test/kotlin/com/pluxity/weekly/epic/service/EpicServiceTest.kt
@@ -378,4 +378,36 @@ class EpicServiceTest :
                 }
             }
         }
+
+        Given("에픽 복구") {
+            When("존재하는 에픽을 복구하면") {
+                val parent = dummyProject(id = 700L, pmId = 1L)
+                val entity = dummyEpic(id = 710L, project = parent, name = "복구 대상")
+                every { epicRepository.findRawById(710L) } returns entity
+                every { epicRepository.restoreById(710L) } returns 1
+                every { taskRepository.restoreByEpicId(710L) } returns 0
+
+                service.restore(710L)
+
+                Then("에픽 + 하위 태스크 모두 복구된다") {
+                    verify(exactly = 1) { epicRepository.restoreById(710L) }
+                    verify(exactly = 1) { taskRepository.restoreByEpicId(710L) }
+                }
+            }
+
+            When("존재하지 않는 에픽을 복구하면") {
+                every { epicRepository.findRawById(999L) } returns null
+
+                val exception =
+                    shouldThrow<CustomException> {
+                        service.restore(999L)
+                    }
+
+                Then("NOT_FOUND_EPIC 예외가 발생하고 어떤 복구 쿼리도 실행되지 않는다") {
+                    exception.code shouldBe ErrorCode.NOT_FOUND_EPIC
+                    verify(exactly = 0) { epicRepository.restoreById(any()) }
+                    verify(exactly = 0) { taskRepository.restoreByEpicId(any()) }
+                }
+            }
+        }
     })

--- a/src/test/kotlin/com/pluxity/weekly/epic/service/EpicServiceTest.kt
+++ b/src/test/kotlin/com/pluxity/weekly/epic/service/EpicServiceTest.kt
@@ -380,10 +380,9 @@ class EpicServiceTest :
         }
 
         Given("에픽 복구") {
-            When("존재하는 에픽을 복구하면") {
-                val parent = dummyProject(id = 700L, pmId = 1L)
-                val entity = dummyEpic(id = 710L, project = parent, name = "복구 대상")
-                every { epicRepository.findRawById(710L) } returns entity
+            When("존재하는 에픽을 복구하면 (부모 프로젝트 alive)") {
+                every { epicRepository.findProjectIdRawById(710L) } returns 700L
+                every { epicRepository.isParentProjectDeletedByEpicId(710L) } returns false
                 every { epicRepository.restoreById(710L) } returns 1
                 every { taskRepository.restoreByEpicId(710L) } returns 0
 
@@ -395,8 +394,24 @@ class EpicServiceTest :
                 }
             }
 
+            When("부모 프로젝트가 삭제 상태이면") {
+                every { epicRepository.findProjectIdRawById(720L) } returns 700L
+                every { epicRepository.isParentProjectDeletedByEpicId(720L) } returns true
+
+                val exception =
+                    shouldThrow<CustomException> {
+                        service.restore(720L)
+                    }
+
+                Then("PARENT_PROJECT_DELETED 예외가 발생하고 복구 쿼리가 실행되지 않는다") {
+                    exception.code shouldBe ErrorCode.PARENT_PROJECT_DELETED
+                    verify(exactly = 0) { epicRepository.restoreById(720L) }
+                    verify(exactly = 0) { taskRepository.restoreByEpicId(720L) }
+                }
+            }
+
             When("존재하지 않는 에픽을 복구하면") {
-                every { epicRepository.findRawById(999L) } returns null
+                every { epicRepository.findProjectIdRawById(999L) } returns null
 
                 val exception =
                     shouldThrow<CustomException> {

--- a/src/test/kotlin/com/pluxity/weekly/project/service/ProjectServiceTest.kt
+++ b/src/test/kotlin/com/pluxity/weekly/project/service/ProjectServiceTest.kt
@@ -13,6 +13,7 @@ import com.pluxity.weekly.project.entity.ProjectStatus
 import com.pluxity.weekly.project.entity.dummyProject
 import com.pluxity.weekly.project.event.ProjectPmAssignedEvent
 import com.pluxity.weekly.project.repository.ProjectRepository
+import com.pluxity.weekly.task.repository.TaskRepository
 import com.pluxity.weekly.test.entity.dummyRole
 import com.pluxity.weekly.test.entity.dummyUser
 import io.kotest.assertions.throwables.shouldThrow
@@ -32,10 +33,19 @@ class ProjectServiceTest :
 
         val projectRepository: ProjectRepository = mockk()
         val epicRepository: EpicRepository = mockk()
+        val taskRepository: TaskRepository = mockk()
         val userRepository: UserRepository = mockk()
         val authorizationService: AuthorizationService = mockk()
         val eventPublisher: ApplicationEventPublisher = mockk(relaxed = true)
-        val service = ProjectService(projectRepository, epicRepository, userRepository, authorizationService, eventPublisher)
+        val service =
+            ProjectService(
+                projectRepository,
+                epicRepository,
+                taskRepository,
+                userRepository,
+                authorizationService,
+                eventPublisher,
+            )
 
         val adminUser =
             dummyUser(id = 1L, name = "관리자").apply {
@@ -44,7 +54,8 @@ class ProjectServiceTest :
 
         beforeSpec {
             every { authorizationService.currentUser() } returns adminUser
-            every { authorizationService.requireProjectManager(any(), any()) } just runs
+            every { authorizationService.requireProjectManager(any(), any<Long>()) } just runs
+            every { authorizationService.requireProjectManager(any(), any<Project>()) } just runs
             every { authorizationService.requireAdmin(any()) } just runs
             every { authorizationService.visibleProjectIds(any()) } returns null
         }
@@ -409,6 +420,40 @@ class ProjectServiceTest :
                             match<ProjectPmAssignedEvent> { it.projectId == 312L },
                         )
                     }
+                }
+            }
+        }
+
+        Given("프로젝트 복구") {
+            When("존재하는 프로젝트를 복구하면") {
+                val entity = dummyProject(id = 600L, name = "복구 대상", pmId = 1L)
+                every { projectRepository.findRawById(600L) } returns entity
+                every { projectRepository.restoreById(600L) } returns 1
+                every { epicRepository.restoreByProjectId(600L) } returns 0
+                every { taskRepository.restoreByProjectId(600L) } returns 0
+
+                service.restore(600L)
+
+                Then("프로젝트 + 하위 에픽 + 하위 태스크 모두 복구된다") {
+                    verify(exactly = 1) { projectRepository.restoreById(600L) }
+                    verify(exactly = 1) { epicRepository.restoreByProjectId(600L) }
+                    verify(exactly = 1) { taskRepository.restoreByProjectId(600L) }
+                }
+            }
+
+            When("존재하지 않는 프로젝트를 복구하면") {
+                every { projectRepository.findRawById(999L) } returns null
+
+                val exception =
+                    shouldThrow<CustomException> {
+                        service.restore(999L)
+                    }
+
+                Then("NOT_FOUND_PROJECT 예외가 발생하고 어떤 복구 쿼리도 실행되지 않는다") {
+                    exception.code shouldBe ErrorCode.NOT_FOUND_PROJECT
+                    verify(exactly = 0) { projectRepository.restoreById(any()) }
+                    verify(exactly = 0) { epicRepository.restoreByProjectId(any()) }
+                    verify(exactly = 0) { taskRepository.restoreByProjectId(any()) }
                 }
             }
         }

--- a/src/test/kotlin/com/pluxity/weekly/task/service/TaskServiceTest.kt
+++ b/src/test/kotlin/com/pluxity/weekly/task/service/TaskServiceTest.kt
@@ -482,4 +482,32 @@ class TaskServiceTest :
                 }
             }
         }
+
+        Given("태스크 복구") {
+            When("존재하는 태스크를 복구하면") {
+                val entity = dummyTask(id = 800L, name = "복구 대상")
+                every { taskRepository.findRawById(800L) } returns entity
+                every { taskRepository.restoreById(800L) } returns 1
+
+                service.restore(800L)
+
+                Then("태스크가 복구된다") {
+                    verify(exactly = 1) { taskRepository.restoreById(800L) }
+                }
+            }
+
+            When("존재하지 않는 태스크를 복구하면") {
+                every { taskRepository.findRawById(999L) } returns null
+
+                val exception =
+                    shouldThrow<CustomException> {
+                        service.restore(999L)
+                    }
+
+                Then("NOT_FOUND_TASK 예외가 발생하고 복구 쿼리는 실행되지 않는다") {
+                    exception.code shouldBe ErrorCode.NOT_FOUND_TASK
+                    verify(exactly = 0) { taskRepository.restoreById(any()) }
+                }
+            }
+        }
     })

--- a/src/test/kotlin/com/pluxity/weekly/task/service/TaskServiceTest.kt
+++ b/src/test/kotlin/com/pluxity/weekly/task/service/TaskServiceTest.kt
@@ -484,15 +484,50 @@ class TaskServiceTest :
         }
 
         Given("태스크 복구") {
-            When("존재하는 태스크를 복구하면") {
-                val entity = dummyTask(id = 800L, name = "복구 대상")
-                every { taskRepository.findRawById(800L) } returns entity
+            When("존재하는 태스크를 복구하면 (부모 모두 alive)") {
+                val task = dummyTask(id = 800L, name = "복구 대상")
+                every { taskRepository.findRawById(800L) } returns task
+                every { taskRepository.isParentProjectDeletedByTaskId(800L) } returns false
+                every { taskRepository.isParentEpicDeletedByTaskId(800L) } returns false
                 every { taskRepository.restoreById(800L) } returns 1
 
                 service.restore(800L)
 
                 Then("태스크가 복구된다") {
                     verify(exactly = 1) { taskRepository.restoreById(800L) }
+                }
+            }
+
+            When("부모 업무 그룹이 삭제 상태이면") {
+                val task = dummyTask(id = 810L)
+                every { taskRepository.findRawById(810L) } returns task
+                every { taskRepository.isParentProjectDeletedByTaskId(810L) } returns false
+                every { taskRepository.isParentEpicDeletedByTaskId(810L) } returns true
+
+                val exception =
+                    shouldThrow<CustomException> {
+                        service.restore(810L)
+                    }
+
+                Then("PARENT_EPIC_DELETED 예외가 발생하고 복구 쿼리가 실행되지 않는다") {
+                    exception.code shouldBe ErrorCode.PARENT_EPIC_DELETED
+                    verify(exactly = 0) { taskRepository.restoreById(810L) }
+                }
+            }
+
+            When("부모 프로젝트가 삭제 상태이면") {
+                val task = dummyTask(id = 820L)
+                every { taskRepository.findRawById(820L) } returns task
+                every { taskRepository.isParentProjectDeletedByTaskId(820L) } returns true
+
+                val exception =
+                    shouldThrow<CustomException> {
+                        service.restore(820L)
+                    }
+
+                Then("PARENT_PROJECT_DELETED 예외가 발생한다") {
+                    exception.code shouldBe ErrorCode.PARENT_PROJECT_DELETED
+                    verify(exactly = 0) { taskRepository.restoreById(820L) }
                 }
             }
 


### PR DESCRIPTION
 ## Summary
  - soft-delete된 프로젝트/업무 그룹/태스크를 복구하는 API 추가
  - `POST /{projects|epics|tasks}/{id}/restore` — 응답 204
  - 복구는 하향 cascade: Project restore → 하위 epic + task 모두 복구, Epic restore → 하위 task 복구
  - 권한은 삭제와 동일 (Project: PM/Admin, Epic: 동일, Task: assignee/PM/Admin)
  - 30일 정책, 복구 이력 기록은 이번 PR 범위 밖