### PR TITLE
feat: Teams 채널 기반 사용자 자동 가입/복원 + User soft delete 도입

### DIFF
--- a/src/main/kotlin/com/pluxity/weekly/auth/config/PasswordEncoderConfig.kt
+++ b/src/main/kotlin/com/pluxity/weekly/auth/config/PasswordEncoderConfig.kt
@@ -1,0 +1,12 @@
+package com.pluxity.weekly.auth.config
+
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder
+import org.springframework.security.crypto.password.PasswordEncoder
+
+@Configuration
+class PasswordEncoderConfig {
+    @Bean
+    fun passwordEncoder(): PasswordEncoder = BCryptPasswordEncoder()
+}

--- a/src/main/kotlin/com/pluxity/weekly/auth/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/pluxity/weekly/auth/config/SecurityConfig.kt
@@ -20,8 +20,6 @@ import org.springframework.security.config.annotation.web.configuration.EnableWe
 import org.springframework.security.config.annotation.web.configurers.SessionManagementConfigurer
 import org.springframework.security.config.http.SessionCreationPolicy
 import org.springframework.security.core.userdetails.UserDetailsService
-import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder
-import org.springframework.security.crypto.password.PasswordEncoder
 import org.springframework.security.web.SecurityFilterChain
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter
 import org.springframework.web.cors.CorsConfiguration
@@ -36,9 +34,6 @@ class SecurityConfig(
     private val jwtProvider: JwtProvider,
     private val securityPermitConfigurer: SecurityPermitConfigurer?,
 ) {
-    @Bean
-    fun passwordEncoder(): PasswordEncoder = BCryptPasswordEncoder()
-
     @Bean
     fun defaultSecurityFilterChain(http: HttpSecurity): SecurityFilterChain {
         http

--- a/src/main/kotlin/com/pluxity/weekly/auth/properties/UserProperties.kt
+++ b/src/main/kotlin/com/pluxity/weekly/auth/properties/UserProperties.kt
@@ -5,4 +5,5 @@ import org.springframework.boot.context.properties.ConfigurationProperties
 @ConfigurationProperties(prefix = "user")
 data class UserProperties(
     val initPassword: String,
+    val allowedEmailDomains: List<String> = emptyList(),
 )

--- a/src/main/kotlin/com/pluxity/weekly/auth/user/entity/User.kt
+++ b/src/main/kotlin/com/pluxity/weekly/auth/user/entity/User.kt
@@ -8,10 +8,12 @@ import jakarta.persistence.Column
 import jakarta.persistence.Entity
 import jakarta.persistence.OneToMany
 import jakarta.persistence.Table
+import org.hibernate.annotations.SoftDelete
 import java.time.LocalDateTime
 
 @Entity
 @Table(name = "users")
+@SoftDelete(columnName = "deleted")
 class User(
     @Column(nullable = false, unique = true)
     var username: String,

--- a/src/main/kotlin/com/pluxity/weekly/auth/user/repository/RoleRepository.kt
+++ b/src/main/kotlin/com/pluxity/weekly/auth/user/repository/RoleRepository.kt
@@ -10,4 +10,6 @@ interface RoleRepository : JpaRepository<Role, Long> {
 
     @EntityGraph(attributePaths = ["userRoles.user", "userRoles.role"])
     fun findAllByOrderByCreatedAtDesc(): List<Role>
+
+    fun findByName(name: String): Role?
 }

--- a/src/main/kotlin/com/pluxity/weekly/auth/user/repository/UserRepository.kt
+++ b/src/main/kotlin/com/pluxity/weekly/auth/user/repository/UserRepository.kt
@@ -57,7 +57,7 @@ interface UserRepository : JpaRepository<User, Long> {
     )
     fun findByAadObjectIdIncludingDeleted(aadObjectId: String): User?
 
-    @Modifying
+    @Modifying(clearAutomatically = true)
     @Query(
         value = "UPDATE users SET deleted = false WHERE id = :id",
         nativeQuery = true,

--- a/src/main/kotlin/com/pluxity/weekly/auth/user/repository/UserRepository.kt
+++ b/src/main/kotlin/com/pluxity/weekly/auth/user/repository/UserRepository.kt
@@ -4,6 +4,7 @@ import com.pluxity.weekly.auth.user.entity.User
 import org.springframework.data.domain.Sort
 import org.springframework.data.jpa.repository.EntityGraph
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Modifying
 import org.springframework.data.jpa.repository.Query
 
 interface UserRepository : JpaRepository<User, Long> {
@@ -49,4 +50,17 @@ interface UserRepository : JpaRepository<User, Long> {
             "ORDER BY u.name",
     )
     fun findAllByRoleName(roleName: String): List<User>
+
+    @Query(
+        value = "SELECT * FROM users WHERE aad_object_id = :aadObjectId",
+        nativeQuery = true,
+    )
+    fun findByAadObjectIdIncludingDeleted(aadObjectId: String): User?
+
+    @Modifying
+    @Query(
+        value = "UPDATE users SET deleted = false WHERE id = :id",
+        nativeQuery = true,
+    )
+    fun restoreById(id: Long): Int
 }

--- a/src/main/kotlin/com/pluxity/weekly/auth/user/service/UserService.kt
+++ b/src/main/kotlin/com/pluxity/weekly/auth/user/service/UserService.kt
@@ -207,7 +207,7 @@ class UserService(
     ): User {
         val newUser =
             User(
-                username = email,
+                username = email.substringBefore('@'),
                 password = requireNotNull(passwordEncoder.encode(userProperties.initPassword)),
                 name = displayName,
                 code = null,

--- a/src/main/kotlin/com/pluxity/weekly/auth/user/service/UserService.kt
+++ b/src/main/kotlin/com/pluxity/weekly/auth/user/service/UserService.kt
@@ -114,7 +114,7 @@ class UserService(
     @Transactional
     fun delete(id: Long) {
         val user = findUserById(id)
-        userRoleRepository.deleteAllByUser(user)
+        refreshTokenRepository.findByIdOrNull(user.username)?.let { refreshTokenRepository.delete(it) }
         userRepository.delete(user)
     }
 

--- a/src/main/kotlin/com/pluxity/weekly/auth/user/service/UserService.kt
+++ b/src/main/kotlin/com/pluxity/weekly/auth/user/service/UserService.kt
@@ -26,7 +26,6 @@ import org.springframework.data.repository.findByIdOrNull
 import org.springframework.security.crypto.password.PasswordEncoder
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
-import java.util.UUID
 
 private val log = KotlinLogging.logger {}
 
@@ -209,7 +208,7 @@ class UserService(
         val newUser =
             User(
                 username = email,
-                password = requireNotNull(passwordEncoder.encode(UUID.randomUUID().toString())),
+                password = requireNotNull(passwordEncoder.encode(userProperties.initPassword)),
                 name = displayName,
                 code = null,
                 phoneNumber = null,

--- a/src/main/kotlin/com/pluxity/weekly/auth/user/service/UserService.kt
+++ b/src/main/kotlin/com/pluxity/weekly/auth/user/service/UserService.kt
@@ -11,6 +11,7 @@ import com.pluxity.weekly.auth.user.dto.UserUpdateRequest
 import com.pluxity.weekly.auth.user.dto.toLoggedInResponse
 import com.pluxity.weekly.auth.user.dto.toResponse
 import com.pluxity.weekly.auth.user.entity.Role
+import com.pluxity.weekly.auth.user.entity.RoleType
 import com.pluxity.weekly.auth.user.entity.User
 import com.pluxity.weekly.auth.user.repository.RoleRepository
 import com.pluxity.weekly.auth.user.repository.UserRepository
@@ -18,10 +19,14 @@ import com.pluxity.weekly.auth.user.repository.UserRoleRepository
 import com.pluxity.weekly.core.constant.ErrorCode
 import com.pluxity.weekly.core.exception.CustomException
 import com.pluxity.weekly.core.utils.SortUtils
+import io.github.oshai.kotlinlogging.KotlinLogging
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.security.crypto.password.PasswordEncoder
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import java.util.UUID
+
+private val log = KotlinLogging.logger {}
 
 @Service
 @Transactional(readOnly = true)
@@ -116,6 +121,98 @@ class UserService(
         val user = findUserById(id)
         refreshTokenRepository.findByIdOrNull(user.username)?.let { refreshTokenRepository.delete(it) }
         userRepository.delete(user)
+    }
+
+    /**
+     * Teams 채널을 통한 자동 가입/복원.
+     * - 같은 aadObjectId가 이미 있으면(soft-deleted 포함) 복원 후 Teams 정보 갱신
+     * - 같은 email로 미리 등록된 user가 있으면 aadObjectId 연결만
+     * - 둘 다 없으면 신규 생성 (USER role 부여, 임의 비밀번호)
+     * 도메인 검증 실패 또는 필수 정보 누락 시 null 반환.
+     */
+    @Transactional
+    fun provisionFromTeams(
+        aadObjectId: String,
+        displayName: String?,
+        email: String?,
+        teamsServiceUrl: String?,
+        teamsConversationId: String?,
+    ): User? {
+        if (email.isNullOrBlank() || displayName.isNullOrBlank()) {
+            log.warn { "Teams 자동 가입 실패 - 필수 정보 누락 (aadObjectId: $aadObjectId, name: $displayName, email: $email)" }
+            return null
+        }
+        if (!isEmailDomainAllowed(email)) {
+            log.warn { "Teams 자동 가입 거부 - 허용되지 않은 도메인 (email: $email)" }
+            return null
+        }
+
+        userRepository.findByAadObjectIdIncludingDeleted(aadObjectId)?.let { existing ->
+            return restoreAndSync(existing, displayName, teamsServiceUrl, teamsConversationId)
+        }
+
+        userRepository.findByEmail(email)?.let { existing ->
+            log.info { "기존 email 사용자에 Teams 정보 연결 - userId: ${existing.requiredId}, email: $email" }
+            if (teamsServiceUrl != null && teamsConversationId != null) {
+                existing.updateTeamsInfo(aadObjectId, teamsServiceUrl, teamsConversationId)
+            } else {
+                existing.aadObjectId = aadObjectId
+            }
+            return existing
+        }
+
+        return createTeamsUser(aadObjectId, displayName, email, teamsServiceUrl, teamsConversationId)
+    }
+
+    private fun isEmailDomainAllowed(email: String): Boolean {
+        val allowed = userProperties.allowedEmailDomains
+        if (allowed.isEmpty()) return false
+        val domain = email.substringAfter('@', missingDelimiterValue = "").lowercase()
+        return domain.isNotBlank() && allowed.any { it.lowercase() == domain }
+    }
+
+    private fun restoreAndSync(
+        user: User,
+        displayName: String,
+        teamsServiceUrl: String?,
+        teamsConversationId: String?,
+    ): User {
+        val id = user.requiredId
+        val wasDeleted = userRepository.restoreById(id) > 0
+        if (wasDeleted) log.info { "soft-deleted 사용자 복원 - userId: $id" }
+        val fresh = userRepository.findByIdOrNull(id) ?: error("복원 직후 사용자 조회 실패: $id")
+        fresh.changeName(displayName)
+        if (teamsServiceUrl != null && teamsConversationId != null) {
+            fresh.updateTeamsInfo(fresh.aadObjectId ?: error("aadObjectId 누락"), teamsServiceUrl, teamsConversationId)
+        }
+        return fresh
+    }
+
+    private fun createTeamsUser(
+        aadObjectId: String,
+        displayName: String,
+        email: String,
+        teamsServiceUrl: String?,
+        teamsConversationId: String?,
+    ): User {
+        val newUser =
+            User(
+                username = email,
+                password = requireNotNull(passwordEncoder.encode(UUID.randomUUID().toString())),
+                name = displayName,
+                code = null,
+                phoneNumber = null,
+                email = email,
+            )
+        newUser.aadObjectId = aadObjectId
+        if (teamsServiceUrl != null && teamsConversationId != null) {
+            newUser.updateTeamsInfo(aadObjectId, teamsServiceUrl, teamsConversationId)
+        }
+        roleRepository.findByName(RoleType.USER.roleName)?.let { newUser.addRole(it) }
+            ?: log.warn { "기본 USER role 미존재 - role 없이 사용자 생성됨" }
+        val saved = userRepository.save(newUser)
+        log.info { "Teams 자동 가입 - userId: ${saved.requiredId}, email: $email" }
+        return saved
     }
 
     @Transactional

--- a/src/main/kotlin/com/pluxity/weekly/auth/user/service/UserService.kt
+++ b/src/main/kotlin/com/pluxity/weekly/auth/user/service/UserService.kt
@@ -19,6 +19,8 @@ import com.pluxity.weekly.auth.user.repository.UserRoleRepository
 import com.pluxity.weekly.core.constant.ErrorCode
 import com.pluxity.weekly.core.exception.CustomException
 import com.pluxity.weekly.core.utils.SortUtils
+import com.pluxity.weekly.project.repository.ProjectRepository
+import com.pluxity.weekly.team.repository.TeamRepository
 import io.github.oshai.kotlinlogging.KotlinLogging
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.security.crypto.password.PasswordEncoder
@@ -37,6 +39,8 @@ class UserService(
     private val refreshTokenRepository: RefreshTokenRepository,
     private val userRoleRepository: UserRoleRepository,
     private val userProperties: UserProperties,
+    private val projectRepository: ProjectRepository,
+    private val teamRepository: TeamRepository,
 ) {
     fun findById(id: Long): UserResponse {
         val user = findUserById(id)
@@ -119,8 +123,15 @@ class UserService(
     @Transactional
     fun delete(id: Long) {
         val user = findUserById(id)
+        ensureNoActiveResponsibility(id)
         refreshTokenRepository.findByIdOrNull(user.username)?.let { refreshTokenRepository.delete(it) }
         userRepository.delete(user)
+    }
+
+    private fun ensureNoActiveResponsibility(userId: Long) {
+        if (projectRepository.existsByPmId(userId) || teamRepository.existsByLeaderId(userId)) {
+            throw CustomException(ErrorCode.USER_HAS_ACTIVE_RESPONSIBILITY)
+        }
     }
 
     /**

--- a/src/main/kotlin/com/pluxity/weekly/auth/user/service/UserService.kt
+++ b/src/main/kotlin/com/pluxity/weekly/auth/user/service/UserService.kt
@@ -145,6 +145,7 @@ class UserService(
         aadObjectId: String,
         displayName: String?,
         email: String?,
+        phoneNumber: String?,
         teamsServiceUrl: String?,
         teamsConversationId: String?,
     ): User? {
@@ -171,7 +172,7 @@ class UserService(
             return existing
         }
 
-        return createTeamsUser(aadObjectId, displayName, email, teamsServiceUrl, teamsConversationId)
+        return createTeamsUser(aadObjectId, displayName, email, phoneNumber, teamsServiceUrl, teamsConversationId)
     }
 
     private fun isEmailDomainAllowed(email: String): Boolean {
@@ -202,6 +203,7 @@ class UserService(
         aadObjectId: String,
         displayName: String,
         email: String,
+        phoneNumber: String?,
         teamsServiceUrl: String?,
         teamsConversationId: String?,
     ): User {
@@ -211,7 +213,7 @@ class UserService(
                 password = requireNotNull(passwordEncoder.encode(userProperties.initPassword)),
                 name = displayName,
                 code = null,
-                phoneNumber = null,
+                phoneNumber = phoneNumber,
                 email = email,
             )
         newUser.aadObjectId = aadObjectId

--- a/src/main/kotlin/com/pluxity/weekly/core/constant/ErrorCode.kt
+++ b/src/main/kotlin/com/pluxity/weekly/core/constant/ErrorCode.kt
@@ -20,6 +20,10 @@ enum class ErrorCode(
     NOT_FOUND_ROLE(HttpStatus.NOT_FOUND, "ID가 %s인 Role을 찾을 수 없습니다."),
     DUPLICATE_ROLE(HttpStatus.BAD_REQUEST, "이미 할당된 Role입니다: %s"),
     NOT_FOUND_USER_ROLE(HttpStatus.NOT_FOUND, "사용자에게 할당되지 않은 Role입니다: %s"),
+    USER_HAS_ACTIVE_RESPONSIBILITY(
+        HttpStatus.CONFLICT,
+        "사용자가 프로젝트 PM 또는 팀 리더로 배정되어 있어 삭제할 수 없습니다. 먼저 다른 사용자로 인계해주세요.",
+    ),
 
     // ── Team ──
     NOT_FOUND_TEAM(HttpStatus.NOT_FOUND, "ID가 %s인 팀을 찾을 수 없습니다."),

--- a/src/main/kotlin/com/pluxity/weekly/project/repository/ProjectRepository.kt
+++ b/src/main/kotlin/com/pluxity/weekly/project/repository/ProjectRepository.kt
@@ -12,6 +12,8 @@ interface ProjectRepository :
     ProjectCustomRepository {
     fun findByPmId(pmId: Long): List<Project>
 
+    fun existsByPmId(pmId: Long): Boolean
+
     fun existsByIdAndPmId(
         id: Long,
         pmId: Long,

--- a/src/main/kotlin/com/pluxity/weekly/team/repository/TeamRepository.kt
+++ b/src/main/kotlin/com/pluxity/weekly/team/repository/TeamRepository.kt
@@ -5,4 +5,6 @@ import org.springframework.data.jpa.repository.JpaRepository
 
 interface TeamRepository :
     JpaRepository<Team, Long>,
-    TeamCustomRepository
+    TeamCustomRepository {
+    fun existsByLeaderId(leaderId: Long): Boolean
+}

--- a/src/main/kotlin/com/pluxity/weekly/teams/config/TeamsAuthFilter.kt
+++ b/src/main/kotlin/com/pluxity/weekly/teams/config/TeamsAuthFilter.kt
@@ -48,20 +48,14 @@ class TeamsAuthFilter(
         }
 
         val body = request.inputStream.readAllBytes()
-        val aadObjectId =
-            try {
-                val node: JsonNode = objectMapper.readTree(body)
-                node.path("from").path("aadObjectId").asString()
-            } catch (_: Exception) {
-                null
-            }
+        val context = parseActivityContext(body)
 
-        if (!aadObjectId.isNullOrBlank()) {
-            val user = resolveUser(aadObjectId)
+        if (!context.aadObjectId.isNullOrBlank()) {
+            val user = resolveUser(context)
             if (user != null) {
                 setSecurityContext(user)
             } else {
-                log.warn { "Teams 인증 실패 - 매칭되는 사용자 없음 (aadObjectId: $aadObjectId)" }
+                log.warn { "Teams 인증 실패 - 매칭되는 사용자 없음 (aadObjectId: ${context.aadObjectId})" }
             }
         } else {
             log.warn { "Teams 인증 실패 - aadObjectId 없음" }
@@ -70,13 +64,42 @@ class TeamsAuthFilter(
         filterChain.doFilter(CachedBodyRequestWrapper(request, body), response)
     }
 
+    private data class ActivityContext(
+        val aadObjectId: String?,
+        val serviceUrl: String?,
+        val conversationId: String?,
+    )
+
+    private fun parseActivityContext(body: ByteArray): ActivityContext =
+        try {
+            val node: JsonNode = objectMapper.readTree(body)
+            ActivityContext(
+                aadObjectId =
+                    node
+                        .path("from")
+                        .path("aadObjectId")
+                        .asString()
+                        .takeIf { it.isNotBlank() },
+                serviceUrl = node.path("serviceUrl").asString().takeIf { it.isNotBlank() },
+                conversationId =
+                    node
+                        .path("conversation")
+                        .path("id")
+                        .asString()
+                        .takeIf { it.isNotBlank() },
+            )
+        } catch (_: Exception) {
+            ActivityContext(null, null, null)
+        }
+
     private fun setSecurityContext(user: User) {
         val userDetails = CustomUserDetails(user)
         val auth = UsernamePasswordAuthenticationToken(userDetails, null, userDetails.authorities)
         SecurityContextHolder.getContext().authentication = auth
     }
 
-    private fun resolveUser(aadObjectId: String): User? {
+    private fun resolveUser(context: ActivityContext): User? {
+        val aadObjectId = context.aadObjectId ?: return null
         userRepository.findByAadObjectId(aadObjectId)?.let { return it }
 
         val graphUser = teamsApiClient.getGraphUser(aadObjectId)
@@ -89,8 +112,8 @@ class TeamsAuthFilter(
             aadObjectId = aadObjectId,
             displayName = graphUser.displayName,
             email = graphUser.mail,
-            teamsServiceUrl = null,
-            teamsConversationId = null,
+            teamsServiceUrl = context.serviceUrl,
+            teamsConversationId = context.conversationId,
         )
     }
 

--- a/src/main/kotlin/com/pluxity/weekly/teams/config/TeamsAuthFilter.kt
+++ b/src/main/kotlin/com/pluxity/weekly/teams/config/TeamsAuthFilter.kt
@@ -112,6 +112,7 @@ class TeamsAuthFilter(
             aadObjectId = aadObjectId,
             displayName = graphUser.displayName,
             email = graphUser.mail,
+            phoneNumber = graphUser.mobilePhone,
             teamsServiceUrl = context.serviceUrl,
             teamsConversationId = context.conversationId,
         )

--- a/src/main/kotlin/com/pluxity/weekly/teams/config/TeamsAuthFilter.kt
+++ b/src/main/kotlin/com/pluxity/weekly/teams/config/TeamsAuthFilter.kt
@@ -3,6 +3,7 @@ package com.pluxity.weekly.teams.config
 import com.pluxity.weekly.auth.authentication.security.CustomUserDetails
 import com.pluxity.weekly.auth.user.entity.User
 import com.pluxity.weekly.auth.user.repository.UserRepository
+import com.pluxity.weekly.auth.user.service.UserService
 import com.pluxity.weekly.teams.service.TeamsApiClient
 import io.github.oshai.kotlinlogging.KotlinLogging
 import jakarta.servlet.FilterChain
@@ -30,6 +31,7 @@ class TeamsAuthFilter(
     private val objectMapper: ObjectMapper,
     private val userRepository: UserRepository,
     private val teamsApiClient: TeamsApiClient,
+    private val userService: UserService,
 ) : OncePerRequestFilter() {
     override fun shouldNotFilter(request: HttpServletRequest): Boolean = !request.requestURI.endsWith("/teams/messages")
 
@@ -75,32 +77,21 @@ class TeamsAuthFilter(
     }
 
     private fun resolveUser(aadObjectId: String): User? {
-        // 1. aadObjectId로 직접 사용자 조회
         userRepository.findByAadObjectId(aadObjectId)?.let { return it }
 
-        // 2. Graph API로 사용자 정보 조회 → email 매칭
         val graphUser = teamsApiClient.getGraphUser(aadObjectId)
         if (graphUser == null) {
             log.warn { "Graph API 사용자 조회 실패 - aadObjectId: $aadObjectId" }
             return null
         }
 
-        log.info { "Graph API 사용자 조회 성공 - mail: ${graphUser.mail}, displayName: ${graphUser.displayName}" }
-
-        val email = graphUser.mail
-        if (email.isNullOrBlank()) {
-            log.warn { "Graph API 응답에 mail 없음 - aadObjectId: $aadObjectId" }
-            return null
-        }
-
-        val user = userRepository.findByEmail(email)
-        if (user == null) {
-            log.warn { "매칭되는 사용자 없음 - email: $email" }
-            return null
-        }
-
-        log.info { "Teams 사용자 매칭 성공 - aadObjectId: $aadObjectId → userId: ${user.requiredId}" }
-        return user
+        return userService.provisionFromTeams(
+            aadObjectId = aadObjectId,
+            displayName = graphUser.displayName,
+            email = graphUser.mail,
+            teamsServiceUrl = null,
+            teamsConversationId = null,
+        )
     }
 
     /**

--- a/src/main/kotlin/com/pluxity/weekly/teams/service/TeamsApiClient.kt
+++ b/src/main/kotlin/com/pluxity/weekly/teams/service/TeamsApiClient.kt
@@ -49,8 +49,7 @@ class TeamsApiClient(
                 displayName = response["displayName"] as? String,
                 mail = response["mail"] as? String,
                 userPrincipalName = response["userPrincipalName"] as? String,
-                jobTitle = response["jobTitle"] as? String,
-                department = response["department"] as? String,
+                mobilePhone = response["mobilePhone"] as? String,
             )
         } catch (e: Exception) {
             log.error(e) { "Graph API 사용자 조회 실패 - aadObjectId: $aadObjectId" }
@@ -179,6 +178,5 @@ data class GraphUser(
     val displayName: String?,
     val mail: String?,
     val userPrincipalName: String?,
-    val jobTitle: String?,
-    val department: String?,
+    val mobilePhone: String?,
 )

--- a/src/main/kotlin/com/pluxity/weekly/teams/service/TeamsMessageHandler.kt
+++ b/src/main/kotlin/com/pluxity/weekly/teams/service/TeamsMessageHandler.kt
@@ -1,7 +1,6 @@
 package com.pluxity.weekly.teams.service
 
-import com.pluxity.weekly.auth.authorization.AuthorizationService
-import com.pluxity.weekly.auth.user.repository.UserRepository
+import com.pluxity.weekly.auth.user.service.UserService
 import com.pluxity.weekly.teams.converter.AdaptiveCardConverter
 import com.pluxity.weekly.teams.dto.Activity
 import io.github.oshai.kotlinlogging.KotlinLogging
@@ -14,8 +13,8 @@ class TeamsMessageHandler(
     private val asyncChatHandler: AsyncChatHandler,
     private val cardConverter: AdaptiveCardConverter,
     private val messageSender: TeamsMessageSender,
-    private val authorizationService: AuthorizationService,
-    private val userRepository: UserRepository,
+    private val teamsApiClient: TeamsApiClient,
+    private val userService: UserService,
 ) {
     fun handleActivity(activity: Activity) {
         when (activity.type) {
@@ -35,7 +34,8 @@ class TeamsMessageHandler(
     }
 
     /**
-     *  Teams App 설치시 받는 메시지
+     *  Teams App 설치시 받는 메시지.
+     *  허용 도메인 사용자라면 자동 가입(soft-deleted면 복원) + Teams 정보 저장까지 처리한다.
      */
     private fun handleInstallationUpdate(activity: Activity) {
         val action = activity.action ?: "unknown"
@@ -44,14 +44,18 @@ class TeamsMessageHandler(
         val serviceUrl = activity.serviceUrl
         val conversationId = activity.conversation?.id
         val aadObjectId = activity.from?.aadObjectId
-        if (serviceUrl.isNullOrBlank() || conversationId.isNullOrBlank()) {
-            log.warn { "serviceUrl 또는 conversationId 누락 - conversationReference 저장 불가" }
-        } else if (!aadObjectId.isNullOrBlank()) {
-            val currentUser = authorizationService.currentUser()
-            currentUser.updateTeamsInfo(aadObjectId, serviceUrl, conversationId)
-            userRepository.save(currentUser)
+
+        if (serviceUrl.isNullOrBlank() || conversationId.isNullOrBlank() || aadObjectId.isNullOrBlank()) {
+            log.warn { "필수 정보 누락 - serviceUrl/conversationId/aadObjectId" }
         } else {
-            log.warn { "aadObjectId 누락 - Teams 정보 저장 불가" }
+            val graphUser = teamsApiClient.getGraphUser(aadObjectId)
+            userService.provisionFromTeams(
+                aadObjectId = aadObjectId,
+                displayName = graphUser?.displayName ?: activity.from?.name,
+                email = graphUser?.mail,
+                teamsServiceUrl = serviceUrl,
+                teamsConversationId = conversationId,
+            )
         }
 
         if (action == "add") {

--- a/src/main/kotlin/com/pluxity/weekly/teams/service/TeamsMessageHandler.kt
+++ b/src/main/kotlin/com/pluxity/weekly/teams/service/TeamsMessageHandler.kt
@@ -51,7 +51,7 @@ class TeamsMessageHandler(
             val graphUser = teamsApiClient.getGraphUser(aadObjectId)
             userService.provisionFromTeams(
                 aadObjectId = aadObjectId,
-                displayName = graphUser?.displayName ?: activity.from?.name,
+                displayName = graphUser?.displayName ?: activity.from.name,
                 email = graphUser?.mail,
                 teamsServiceUrl = serviceUrl,
                 teamsConversationId = conversationId,

--- a/src/main/kotlin/com/pluxity/weekly/teams/service/TeamsMessageHandler.kt
+++ b/src/main/kotlin/com/pluxity/weekly/teams/service/TeamsMessageHandler.kt
@@ -53,6 +53,7 @@ class TeamsMessageHandler(
                 aadObjectId = aadObjectId,
                 displayName = graphUser?.displayName ?: activity.from.name,
                 email = graphUser?.mail,
+                phoneNumber = graphUser?.mobilePhone,
                 teamsServiceUrl = serviceUrl,
                 teamsConversationId = conversationId,
             )

--- a/src/main/resources/application-common.yml
+++ b/src/main/resources/application-common.yml
@@ -49,7 +49,7 @@ springdoc:
   default-produces-media-type: application/json
 
 user:
-  init-password: qwer1234
+  init-password: pluxity123!@#
   # Teams 자동 가입 시 허용할 회사 이메일 도메인
   allowed-email-domains:
     - pluxity.com

--- a/src/main/resources/application-common.yml
+++ b/src/main/resources/application-common.yml
@@ -50,3 +50,6 @@ springdoc:
 
 user:
   init-password: qwer1234
+  # Teams 자동 가입 시 허용할 회사 이메일 도메인
+  allowed-email-domains:
+    - pluxity.com

--- a/src/main/resources/db/migration/V20260512_001__add_user_soft_delete.sql
+++ b/src/main/resources/db/migration/V20260512_001__add_user_soft_delete.sql
@@ -1,0 +1,4 @@
+-- User 엔티티에 @SoftDelete 적용을 위한 deleted 컬럼 추가
+-- Hibernate @SoftDelete(columnName = "deleted") 기본값은 false
+
+ALTER TABLE users ADD COLUMN deleted BOOLEAN NOT NULL DEFAULT FALSE;

--- a/src/test/kotlin/com/pluxity/weekly/auth/user/service/UserServiceTest.kt
+++ b/src/test/kotlin/com/pluxity/weekly/auth/user/service/UserServiceTest.kt
@@ -158,7 +158,7 @@ class UserServiceTest :
                         )
                     result.shouldNotBeNull()
                     val saved = saveSlot.first()
-                    saved.username shouldBe "new@pluxity.com"
+                    saved.username shouldBe "new"
                     saved.email shouldBe "new@pluxity.com"
                     saved.aadObjectId shouldBe "aad-new"
                     saved.userRoles.any { it.role.name == RoleType.USER.roleName } shouldBe true

--- a/src/test/kotlin/com/pluxity/weekly/auth/user/service/UserServiceTest.kt
+++ b/src/test/kotlin/com/pluxity/weekly/auth/user/service/UserServiceTest.kt
@@ -1,0 +1,168 @@
+package com.pluxity.weekly.auth.user.service
+
+import com.pluxity.weekly.auth.authentication.repository.RefreshTokenRepository
+import com.pluxity.weekly.auth.properties.UserProperties
+import com.pluxity.weekly.auth.user.entity.RoleType
+import com.pluxity.weekly.auth.user.entity.User
+import com.pluxity.weekly.auth.user.repository.RoleRepository
+import com.pluxity.weekly.auth.user.repository.UserRepository
+import com.pluxity.weekly.auth.user.repository.UserRoleRepository
+import com.pluxity.weekly.core.constant.ErrorCode
+import com.pluxity.weekly.core.exception.CustomException
+import com.pluxity.weekly.project.repository.ProjectRepository
+import com.pluxity.weekly.team.repository.TeamRepository
+import com.pluxity.weekly.test.entity.dummyRole
+import com.pluxity.weekly.test.entity.dummyUser
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.security.crypto.password.PasswordEncoder
+
+class UserServiceTest :
+    BehaviorSpec({
+
+        val userRepository: UserRepository = mockk(relaxed = true)
+        val roleRepository: RoleRepository = mockk(relaxed = true)
+        val passwordEncoder: PasswordEncoder = mockk()
+        val refreshTokenRepository: RefreshTokenRepository = mockk(relaxed = true)
+        val userRoleRepository: UserRoleRepository = mockk(relaxed = true)
+        val userProperties: UserProperties = mockk()
+        val projectRepository: ProjectRepository = mockk()
+        val teamRepository: TeamRepository = mockk()
+
+        val service =
+            UserService(
+                userRepository,
+                roleRepository,
+                passwordEncoder,
+                refreshTokenRepository,
+                userRoleRepository,
+                userProperties,
+                projectRepository,
+                teamRepository,
+            )
+
+        every { passwordEncoder.encode(any()) } answers { "encoded:${firstArg<String>()}" }
+
+        Given("UserService.delete - 인수인계 강제") {
+            val targetUser = dummyUser(id = 10L, username = "u@pluxity.com", email = "u@pluxity.com")
+            every { userRepository.findWithGraphById(10L) } returns targetUser
+
+            When("사용자가 어떤 프로젝트의 PM이면") {
+                every { projectRepository.existsByPmId(10L) } returns true
+                every { teamRepository.existsByLeaderId(10L) } returns false
+
+                Then("USER_HAS_ACTIVE_RESPONSIBILITY 예외") {
+                    val ex = shouldThrow<CustomException> { service.delete(10L) }
+                    ex.code shouldBe ErrorCode.USER_HAS_ACTIVE_RESPONSIBILITY
+                    verify(exactly = 0) { userRepository.delete(any<User>()) }
+                }
+            }
+
+            When("사용자가 어떤 팀의 리더이면") {
+                every { projectRepository.existsByPmId(10L) } returns false
+                every { teamRepository.existsByLeaderId(10L) } returns true
+
+                Then("USER_HAS_ACTIVE_RESPONSIBILITY 예외") {
+                    shouldThrow<CustomException> { service.delete(10L) }
+                        .code shouldBe ErrorCode.USER_HAS_ACTIVE_RESPONSIBILITY
+                }
+            }
+
+            When("PM/리더 자리가 모두 없으면") {
+                every { projectRepository.existsByPmId(10L) } returns false
+                every { teamRepository.existsByLeaderId(10L) } returns false
+                every { refreshTokenRepository.findByIdOrNull(any<String>()) } returns null
+
+                Then("정상 soft delete") {
+                    service.delete(10L)
+                    verify(exactly = 1) { userRepository.delete(targetUser) }
+                }
+            }
+        }
+
+        Given("UserService.provisionFromTeams") {
+            every { userProperties.allowedEmailDomains } returns listOf("pluxity.com")
+            every { userProperties.initPassword } returns "pluxity123!@#"
+            every { roleRepository.findByName(RoleType.USER.roleName) } returns
+                dummyRole(id = 2L, name = RoleType.USER.roleName)
+
+            When("허용되지 않은 도메인이면") {
+                Then("null 반환, 저장 없음") {
+                    val result =
+                        service.provisionFromTeams(
+                            aadObjectId = "aad-1",
+                            displayName = "외부사용자",
+                            email = "x@external.com",
+                            teamsServiceUrl = "https://teams",
+                            teamsConversationId = "conv-1",
+                        )
+                    result.shouldBeNull()
+                    verify(exactly = 0) { userRepository.save(any<User>()) }
+                }
+            }
+
+            When("email 또는 displayName이 누락되면") {
+                Then("null 반환") {
+                    service
+                        .provisionFromTeams("aad-1", displayName = null, email = "a@pluxity.com", null, null)
+                        .shouldBeNull()
+                    service
+                        .provisionFromTeams("aad-1", displayName = "n", email = null, null, null)
+                        .shouldBeNull()
+                }
+            }
+
+            When("aadObjectId 기준 기존 사용자가 soft-deleted 상태이면") {
+                val existing = dummyUser(id = 30L, username = "a@pluxity.com", email = "a@pluxity.com")
+                existing.aadObjectId = "aad-30"
+                every { userRepository.findByAadObjectIdIncludingDeleted("aad-30") } returns existing
+                every { userRepository.restoreById(30L) } returns 1
+                every { userRepository.findByIdOrNull(30L) } returns existing
+
+                Then("restoreById 호출 + 사용자 반환") {
+                    val result =
+                        service.provisionFromTeams(
+                            aadObjectId = "aad-30",
+                            displayName = "복원이름",
+                            email = "a@pluxity.com",
+                            teamsServiceUrl = "https://teams",
+                            teamsConversationId = "conv-30",
+                        )
+                    result.shouldNotBeNull()
+                    result.name shouldBe "복원이름"
+                    verify(exactly = 1) { userRepository.restoreById(30L) }
+                }
+            }
+
+            When("기존 사용자가 없고 email도 매칭 안 되면") {
+                every { userRepository.findByAadObjectIdIncludingDeleted("aad-new") } returns null
+                every { userRepository.findByEmail("new@pluxity.com") } returns null
+                val saveSlot = mutableListOf<User>()
+                every { userRepository.save(capture(saveSlot)) } answers { firstArg() }
+
+                Then("신규 가입 + USER role 부여") {
+                    val result =
+                        service.provisionFromTeams(
+                            aadObjectId = "aad-new",
+                            displayName = "신규",
+                            email = "new@pluxity.com",
+                            teamsServiceUrl = "https://teams",
+                            teamsConversationId = "conv-new",
+                        )
+                    result.shouldNotBeNull()
+                    val saved = saveSlot.first()
+                    saved.username shouldBe "new@pluxity.com"
+                    saved.email shouldBe "new@pluxity.com"
+                    saved.aadObjectId shouldBe "aad-new"
+                    saved.userRoles.any { it.role.name == RoleType.USER.roleName } shouldBe true
+                }
+            }
+        }
+    })

--- a/src/test/kotlin/com/pluxity/weekly/auth/user/service/UserServiceTest.kt
+++ b/src/test/kotlin/com/pluxity/weekly/auth/user/service/UserServiceTest.kt
@@ -102,6 +102,7 @@ class UserServiceTest :
                             email = "x@external.com",
                             teamsServiceUrl = "https://teams",
                             teamsConversationId = "conv-1",
+                            phoneNumber = "010-1234-5678",
                         )
                     result.shouldBeNull()
                     verify(exactly = 0) { userRepository.save(any<User>()) }
@@ -111,10 +112,10 @@ class UserServiceTest :
             When("email 또는 displayName이 누락되면") {
                 Then("null 반환") {
                     service
-                        .provisionFromTeams("aad-1", displayName = null, email = "a@pluxity.com", null, null)
+                        .provisionFromTeams("aad-1", displayName = null, email = "a@pluxity.com", phoneNumber = "010-1111-2222", null, null)
                         .shouldBeNull()
                     service
-                        .provisionFromTeams("aad-1", displayName = "n", email = null, null, null)
+                        .provisionFromTeams("aad-1", displayName = "n", email = null, phoneNumber = null, null, null)
                         .shouldBeNull()
                 }
             }
@@ -132,6 +133,7 @@ class UserServiceTest :
                             aadObjectId = "aad-30",
                             displayName = "복원이름",
                             email = "a@pluxity.com",
+                            phoneNumber = "010-1234-5678",
                             teamsServiceUrl = "https://teams",
                             teamsConversationId = "conv-30",
                         )
@@ -153,6 +155,7 @@ class UserServiceTest :
                             aadObjectId = "aad-new",
                             displayName = "신규",
                             email = "new@pluxity.com",
+                            phoneNumber = "010-1234-5678",
                             teamsServiceUrl = "https://teams",
                             teamsConversationId = "conv-new",
                         )


### PR DESCRIPTION
  ## Summary

  - Teams 앱 설치/첫 메시지 시점에 **자동 가입**되도록 변경 (기존엔 admin이 사전 등록 필요)
  - User에 `@SoftDelete` 도입 → 같은 사용자가 Teams 재설치 시 **자동 복원**
  - PM/팀 리더 ROLE 보유 시 user 삭제를 거부

  ## 주요 변경

  ### Auth / User
  - `User` 엔티티에 `@SoftDelete(columnName = "deleted")` 적용 + Flyway 마이그레이션 추가
  - `UserService.provisionFromTeams()` 신규
    - 도메인 화이트리스트 검증(`user.allowed-email-domains`)
    - `aadObjectId` 기준 신규 생성 / 기존 email 연결 / soft-deleted 복원 처리
    - 기본 role `USER` 자동 부여 (없으면 role 없이 + warn 로그)
    - `username`은 email 로컬파트만 사용 (`kim@pluxity.com` → `kim`)
    - 비밀번호는 `UserProperties.initPassword`로 통합 (default `pluxity123!@#`)
  - `UserService.delete()`에 `ensureNoActiveResponsibility()` 추가
    - 활성 PM 또는 팀 리더면 `USER_HAS_ACTIVE_RESPONSIBILITY`(409) 반환
  - `UserProperties.allowedEmailDomains: List<String>` 추가
  - `ErrorCode.USER_HAS_ACTIVE_RESPONSIBILITY` 신규

  ### Teams
  - `TeamsAuthFilter.resolveUser`: 미등록 사용자에 대해 Graph API → `provisionFromTeams` 자동 호출
    - Activity body에서 `serviceUrl` / `conversation.id`도 추출해 함께 전달
  - `TeamsMessageHandler.handleInstallationUpdate`: 설치 이벤트에서 가입 + Teams 정보 일괄 저장

  ### Infra
  - `PasswordEncoder` 빈을 `PasswordEncoderConfig`로 분리
    - `UserService → PasswordEncoder → SecurityConfig → … → TeamsAuthFilter → UserService` 순환참조 해소

  ### Test
  - `UserServiceTest` 신규 (7 케이스, 모두 통과)
    - delete: PM/리더 보유 시 거부, 책임 없으면 soft delete
    - provisionFromTeams: 도메인 거부 / 필수정보 누락 / soft-deleted 복원 / 신규 가입 + USER role 부여