### PR TITLE
feat: chat 태스크 생성 시 담당자 지정

### DIFF
--- a/promptfoo/context-task-create.json
+++ b/promptfoo/context-task-create.json
@@ -1,0 +1,34 @@
+{
+  "today": "2026-04-15",
+  "today_day_of_week": "수요일",
+  "user": { "id": 3, "name": "박서준", "role": "PM" },
+  "projects": [
+    {
+      "id": 1, "name": "스마트팩토리",
+      "epics": [
+        { "id": 101, "name": "센서 연동", "members": [
+          { "id": 3, "name": "박서준" },
+          { "id": 4, "name": "김민지" }
+        ]},
+        { "id": 102, "name": "대시보드", "members": [
+          { "id": 5, "name": "이도현" }
+        ]},
+        { "id": 103, "name": "설비 관리", "members": [
+          { "id": 4, "name": "김민지" },
+          { "id": 6, "name": "정하은" }
+        ]}
+      ]
+    },
+    {
+      "id": 2, "name": "모바일 POS",
+      "epics": [
+        { "id": 201, "name": "결제 모듈", "members": [
+          { "id": 7, "name": "최우석" }
+        ]},
+        { "id": 202, "name": "대시보드", "members": [
+          { "id": 8, "name": "한소희" }
+        ]}
+      ]
+    }
+  ]
+}

--- a/promptfoo/promptfooconfig.yaml
+++ b/promptfoo/promptfooconfig.yaml
@@ -521,3 +521,84 @@ tests:
             o.missing_fields[0] === 'id' &&
             o.candidates && o.candidates.length >= 2;
 
+  # ──────────────────────────────────────
+  # system-prompt task create with assignee tests
+  # (fixture: context-task-create.json — epic.members 노출, users 없음)
+  # ──────────────────────────────────────
+
+  ## task create - assignee 매칭 (대상 epic 멤버)
+  - description: "[system-task-create] 센서 연동에 알람 규칙 + 담당자 김민지 → epic_id=101, assignee_id=4"
+    vars:
+      contextFile: context-task-create.json
+      userMessage: "센서 연동에 알람 규칙 추가, 담당자 김민지"
+      intent: '{"actions":["create"],"target":"task","epic":"센서 연동","name":"알람 규칙"}'
+    prompts: [system]
+    assert:
+      - type: is-json
+      - type: javascript
+        value: |
+          const arr = JSON.parse(output);
+          const o = arr[0];
+          return o.action === 'create' && o.target === 'task' && o.epic_id === 101
+            && o.name === '알람 규칙' && o.assignee_id === 4;
+
+  ## task create - 담당자 미지정 → assignee_id 없음
+  - description: "[system-task-create] 센서 연동에 알람 규칙 추가 → assignee_id 없음"
+    vars:
+      contextFile: context-task-create.json
+      userMessage: "센서 연동에 알람 규칙 추가"
+      intent: '{"actions":["create"],"target":"task","epic":"센서 연동","name":"알람 규칙"}'
+    prompts: [system]
+    assert:
+      - type: is-json
+      - type: javascript
+        value: |
+          const arr = JSON.parse(output);
+          const o = arr[0];
+          return o.action === 'create' && o.target === 'task' && o.epic_id === 101 && !o.assignee_id;
+
+  ## task create - 담당자가 대상 epic 멤버 밖 → assignee_id 생략
+  - description: "[system-task-create] 결제 모듈에 환불 처리 + 김민지(비멤버) → assignee_id 생략"
+    vars:
+      contextFile: context-task-create.json
+      userMessage: "결제 모듈에 환불 처리 추가, 담당자 김민지"
+      intent: '{"actions":["create"],"target":"task","epic":"결제 모듈","name":"환불 처리"}'
+    prompts: [system]
+    assert:
+      - type: is-json
+      - type: javascript
+        value: |
+          const arr = JSON.parse(output);
+          const o = arr[0];
+          return o.action === 'create' && o.target === 'task' && o.epic_id === 201 && !o.assignee_id;
+
+  ## task create - 본인을 담당자로 (epic 멤버)
+  - description: "[system-task-create] 센서 연동에 API 설계 + 담당자 박서준 → assignee_id=3"
+    vars:
+      contextFile: context-task-create.json
+      userMessage: "센서 연동에 API 설계 추가, 담당자 박서준"
+      intent: '{"actions":["create"],"target":"task","epic":"센서 연동","name":"API 설계"}'
+    prompts: [system]
+    assert:
+      - type: is-json
+      - type: javascript
+        value: |
+          const arr = JSON.parse(output);
+          const o = arr[0];
+          return o.action === 'create' && o.target === 'task' && o.epic_id === 101 && o.assignee_id === 3;
+
+  ## task create - epic 미지정 + 담당자 단일 매칭
+  - description: "[system-task-create] API 설계 + 담당자 최우석 → assignee_id=7 (epic 미정)"
+    vars:
+      contextFile: context-task-create.json
+      userMessage: "API 설계 만들어줘, 담당자 최우석"
+      intent: '{"actions":["create"],"target":"task","name":"API 설계"}'
+    prompts: [system]
+    assert:
+      - type: is-json
+      - type: javascript
+        value: |
+          const arr = JSON.parse(output);
+          const o = arr[0];
+          return o.action === 'create' && o.target === 'task' && o.assignee_id === 7;
+

--- a/src/main/kotlin/com/pluxity/weekly/chat/context/ChatContext.kt
+++ b/src/main/kotlin/com/pluxity/weekly/chat/context/ChatContext.kt
@@ -33,8 +33,20 @@ data class TaskCreateContext(
     override val today: String,
     override val todayDayOfWeek: String,
     override val user: UserRef,
-    val projects: List<ProjectWithEpics>,
+    val projects: List<ProjectWithEpicsAndMembers>,
 ) : ChatContext()
+
+data class ProjectWithEpicsAndMembers(
+    val id: Long,
+    val name: String,
+    val epics: List<EpicWithMembers>,
+)
+
+data class EpicWithMembers(
+    val id: Long,
+    val name: String,
+    val members: List<UserRef>,
+)
 
 data class TaskContext(
     override val today: String,

--- a/src/main/kotlin/com/pluxity/weekly/chat/context/ContextBuilder.kt
+++ b/src/main/kotlin/com/pluxity/weekly/chat/context/ContextBuilder.kt
@@ -139,7 +139,7 @@ class ContextBuilder(
                 today = today,
                 todayDayOfWeek = todayDayOfWeek,
                 user = user,
-                projects = groupByProject(activeEpics),
+                projects = groupByProjectWithMembers(activeEpics),
             )
         } else {
             val tasks =
@@ -173,14 +173,24 @@ class ContextBuilder(
             users = findAllUsers(),
         )
 
-    private fun groupByProject(epics: List<EpicResponse>): List<ProjectWithEpics> =
+    private fun groupByProjectWithMembers(epics: List<EpicResponse>): List<ProjectWithEpicsAndMembers> =
         epics
             .groupBy { it.projectId to it.projectName }
             .map { (key, epics) ->
-                ProjectWithEpics(
+                ProjectWithEpicsAndMembers(
                     id = key.first,
                     name = key.second,
-                    epics = epics.map { EpicRef(id = it.id, name = it.name) },
+                    epics =
+                        epics.map { epic ->
+                            EpicWithMembers(
+                                id = epic.id,
+                                name = epic.name,
+                                members =
+                                    epic.members.map {
+                                        UserRef(id = it.userId, name = it.userName)
+                                    },
+                            )
+                        },
                 )
             }
 

--- a/src/main/kotlin/com/pluxity/weekly/chat/dto/ChatActionResponse.kt
+++ b/src/main/kotlin/com/pluxity/weekly/chat/dto/ChatActionResponse.kt
@@ -41,6 +41,18 @@ data class ChatReadResponse(
 data class SelectField(
     @field:Schema(description = "필드명", example = "projectId")
     val field: String,
-    @field:Schema(description = "후보 목록")
+    @field:Schema(description = "후보 목록 (그룹이 있으면 groups 사용)")
+    val candidates: List<Candidate> = emptyList(),
+    @field:Schema(description = "그룹화된 후보 목록 (assigneeId 등 에픽별 묶음)")
+    val groups: List<CandidateGroup>? = null,
+)
+
+@Schema(description = "후보 그룹")
+data class CandidateGroup(
+    @field:Schema(description = "그룹 라벨", example = "백엔드 구축")
+    val label: String,
+    @field:Schema(description = "그룹 ID (선택)", example = "100")
+    val id: Long? = null,
+    @field:Schema(description = "그룹 내 후보")
     val candidates: List<Candidate>,
 )

--- a/src/main/kotlin/com/pluxity/weekly/chat/service/ChatActionRouter.kt
+++ b/src/main/kotlin/com/pluxity/weekly/chat/service/ChatActionRouter.kt
@@ -1,6 +1,7 @@
 package com.pluxity.weekly.chat.service
 
 import com.pluxity.weekly.auth.authorization.AuthorizationService
+import com.pluxity.weekly.auth.user.entity.User
 import com.pluxity.weekly.chat.dto.ChatActionResponse
 import com.pluxity.weekly.chat.dto.ChatActionType
 import com.pluxity.weekly.chat.dto.ChatDto
@@ -74,6 +75,7 @@ class ChatActionRouter(
             if (visibleEpics != null && visibleEpics.isEmpty()) {
                 throw ChatClarifyException("태스크를 생성할 수 있는 업무 그룹이 없습니다. 먼저 업무 그룹에 참여해주세요.")
             }
+            validateAssigneeAccess(action, user)
         }
         if (type.validatesMissingFields && !action.missingFields.isNullOrEmpty()) {
             if (action.missingFields.size > 1) {
@@ -83,6 +85,22 @@ class ChatActionRouter(
         }
         type.requiredFields.firstOrNull { !action.hasValueFor(it) }?.let { missing ->
             throwSelectOrClarify(action, missing)
+        }
+    }
+
+    private fun validateAssigneeAccess(
+        action: LlmAction,
+        user: User,
+    ) {
+        val assigneeId = action.assigneeId ?: return
+        if (assigneeId == user.requiredId) return
+        val accessibleUserIds =
+            epicService
+                .findAll()
+                .flatMap { it.members.map { m -> m.userId } }
+                .toSet()
+        if (assigneeId !in accessibleUserIds) {
+            throw ChatClarifyException("선택한 담당자는 접근 가능한 업무 그룹의 멤버가 아닙니다. 먼저 업무 그룹에 영입한 뒤 할당해주세요.")
         }
     }
 

--- a/src/main/kotlin/com/pluxity/weekly/chat/service/SelectFieldResolver.kt
+++ b/src/main/kotlin/com/pluxity/weekly/chat/service/SelectFieldResolver.kt
@@ -3,6 +3,7 @@ package com.pluxity.weekly.chat.service
 import com.pluxity.weekly.auth.authorization.UserType
 import com.pluxity.weekly.auth.user.repository.UserRepository
 import com.pluxity.weekly.chat.dto.Candidate
+import com.pluxity.weekly.chat.dto.CandidateGroup
 import com.pluxity.weekly.chat.dto.ChatActionType
 import com.pluxity.weekly.chat.dto.ChatTarget
 import com.pluxity.weekly.chat.dto.LlmAction
@@ -136,6 +137,22 @@ class SelectFieldResolver(
         return SelectField(field = field, candidates = candidates)
     }
 
+    private fun resolveTaskAssigneeCandidates(): SelectField? {
+        val groups =
+            epicService
+                .findAll()
+                .filter { it.members.isNotEmpty() }
+                .map { epic ->
+                    CandidateGroup(
+                        label = epic.name,
+                        id = epic.id,
+                        candidates = epic.members.map { Candidate(it.userId.toString(), it.userName) },
+                    )
+                }
+        if (groups.isEmpty()) return null
+        return SelectField(field = "assigneeId", groups = groups)
+    }
+
     private fun resolveStatusCandidates(): SelectField {
         val statuses = listOf("TODO", "IN_PROGRESS")
         return SelectField(
@@ -176,6 +193,9 @@ class SelectFieldResolver(
             ChatTarget.TASK -> {
                 if ("epicId" !in existingFields) {
                     result.add(resolveEpicCandidates(emptyList()) ?: return)
+                }
+                if ("assigneeId" !in existingFields) {
+                    resolveTaskAssigneeCandidates()?.let { result.add(it) }
                 }
                 if ("status" !in existingFields) {
                     result.add(resolveStatusCandidates())

--- a/src/main/resources/llm/system-prompt.txt
+++ b/src/main/resources/llm/system-prompt.txt
@@ -14,6 +14,7 @@ JSON 배열만 출력. 설명, 마크다운, 부가 텍스트 절대 금지.
 {"today":"..","today_day_of_week":"..","user":{...},"projects":[...],"teams":[...],"users":[...]}
 - 오늘 날짜는 today, 요일은 today_day_of_week. 자체 지식으로 날짜 계산 금지. 한국 기준(월요일 시작).
 - teams, users 배열은 target+action에 따라 포함 여부가 다르다. 없으면 해당 필드 매칭 불가 → missing_fields.
+- task create는 users 없이 projects[*].epics[*].members(id,name)로 제공. assignee_id는 이 members 안에서만 매칭.
 - FK 필드는 반드시 ID(숫자). CONTEXT에서 이름→ID 변환.
 
 ## target별 필드
@@ -22,9 +23,9 @@ JSON 배열만 출력. 설명, 마크다운, 부가 텍스트 절대 금지.
 |--------|------|------|
 | project | name, description, status, start_date, due_date, pm_id | pm_id: users에서 매칭 |
 | epic | project_id(FK), name, description, status, start_date, due_date, user_ids | user_ids: ID 배열. 입력의 "업무 그룹" = "에픽" (동의어) |
-| task | epic_id(FK), name, description, status, progress(0~100), start_date, due_date | |
-| team | read 전용. CUD 불가 | |
-| review | read 전용. PM 리뷰 대기 큐 자동 조회. filters 불필요 | |
+| task | epic_id(FK), name, description, status, progress(0~100), start_date, due_date, assignee_id | assignee_id: 해당 epic.members 안에서만 매칭 |
+| team | read 전용. CUD 불가 |
+| review | read 전용. PM 리뷰 대기 큐 자동 조회. filters 불필요 |
 
 상태값:
 - task: TODO, IN_PROGRESS, IN_REVIEW, DONE
@@ -76,6 +77,7 @@ read filters:
 4. CONTEXT에 완전히 매칭되지 않는 이름 + update/delete/review_request → clarify: "'OO' 항목을 찾을 수 없습니다."
 5. CONTEXT에 없는 이름 + create → 신규 create (id 없이).
 6. 사용자 필드(pm_id, user_ids, remove_user_ids): 입력에서 명시한 경우에만 users에서 이름→ID 매칭.
+7. task.assignee_id: 입력에서 명시한 경우에만 매칭. 대상 epic이 확정됐으면 그 epic.members에서만, 미확정이면 CONTEXT 전체 epics[*].members 중 정확히 1명일 때만 확정. 2명 이상 매칭되거나 epic 멤버 밖이면 assignee_id 생략(서버 폼이 안내).
 
 ## missing_fields + candidates (create 제외)
 
@@ -107,7 +109,7 @@ update/delete/review_request/assign/unassign에만 적용:
   "project_id": N, "epic_id": N,
   "status": "...", "progress": N,
   "start_date": "YYYY-MM-DD", "due_date": "YYYY-MM-DD",
-  "pm_id": N, "user_ids": [N], "remove_user_ids": [N],
+  "pm_id": N, "assignee_id": N, "user_ids": [N], "remove_user_ids": [N],
   "filters": {...},
   "message": "...",
   "missing_fields": ["..."],
@@ -156,6 +158,17 @@ Output: [{"action":"create","target":"epic"}]
 
 [INPUT]백엔드 구축 - 신규 태스크 추가해줘[/INPUT]
 Output: [{"action":"create","target":"task","name":"신규 태스크"}]
+
+--- task create with assignee (CONTEXT: projects[*].epics[*].members) ---
+[CONTEXT]
+{"today":"2026-03-06","user":{"id":1,"name":"홍길동","role":"PM"},"projects":[{"id":10,"name":"알파 프로젝트","epics":[{"id":100,"name":"백엔드 구축","members":[{"id":1,"name":"홍길동"},{"id":2,"name":"김영희"}]},{"id":101,"name":"프론트 구축","members":[{"id":3,"name":"이순신"}]}]}]}
+[/CONTEXT]
+
+[INPUT]백엔드 구축에 API 설계 추가, 담당자는 김영희, 마감 3월 20일[/INPUT]
+Output: [{"action":"create","target":"task","epic_id":100,"name":"API 설계","assignee_id":2,"due_date":"2026-03-20"}]
+
+[INPUT]API 설계 만들어줘 할당자는 홍길동으로[/INPUT]
+Output: [{"action":"create","target":"task","name":"API 설계","assignee_id":1}]
 
 --- update ---
 [INPUT]크롤러 80%[/INPUT]

--- a/src/test/kotlin/com/pluxity/weekly/chat/service/ChatActionRouterTest.kt
+++ b/src/test/kotlin/com/pluxity/weekly/chat/service/ChatActionRouterTest.kt
@@ -9,6 +9,8 @@ import com.pluxity.weekly.chat.dto.SelectField
 import com.pluxity.weekly.chat.dto.TaskChatDto
 import com.pluxity.weekly.chat.exception.ChatClarifyException
 import com.pluxity.weekly.chat.exception.ChatSelectRequiredException
+import com.pluxity.weekly.epic.dto.EpicMemberResponse
+import com.pluxity.weekly.epic.dto.EpicResponse
 import com.pluxity.weekly.epic.service.EpicService
 import com.pluxity.weekly.project.service.ProjectService
 import com.pluxity.weekly.task.service.TaskService
@@ -166,6 +168,62 @@ class ChatActionRouterTest :
                 Then("자격 검증을 통과해 form 이 반환된다") {
                     response.action shouldBe "create"
                     response.dto shouldBe dto
+                }
+            }
+
+            When("assigneeId 가 visible epic 멤버 합집합에 속하면") {
+                val action = LlmAction(action = "create", target = "task", name = "새 태스크", assigneeId = 7L)
+                val dto = TaskChatDto("새 태스크", null, null, null, null, null, null, 7L)
+                val user = mockk<User> { every { requiredId } returns 1L }
+                val epic =
+                    mockk<EpicResponse> {
+                        every { members } returns listOf(EpicMemberResponse(userId = 7L, userName = "철수"))
+                    }
+                every { authorizationService.currentUser() } returns user
+                every { authorizationService.visibleEpicIds(user) } returns listOf(10L)
+                every { epicService.findAll() } returns listOf(epic)
+                every { chatDtoMapper.toDto(action) } returns dto
+                every { selectFieldResolver.resolve(action) } returns emptyList()
+
+                val response = router.route(action)
+
+                Then("검증을 통과해 form 이 반환된다") {
+                    response.dto shouldBe dto
+                }
+            }
+
+            When("assigneeId 가 본인이면 (epic 멤버가 아니어도)") {
+                val action = LlmAction(action = "create", target = "task", name = "새 태스크", assigneeId = 1L)
+                val dto = TaskChatDto("새 태스크", null, null, null, null, null, null, 1L)
+                val user = mockk<User> { every { requiredId } returns 1L }
+                every { authorizationService.currentUser() } returns user
+                every { authorizationService.visibleEpicIds(user) } returns listOf(10L)
+                every { chatDtoMapper.toDto(action) } returns dto
+                every { selectFieldResolver.resolve(action) } returns emptyList()
+
+                val response = router.route(action)
+
+                Then("epicService.findAll 호출 없이 통과한다") {
+                    response.dto shouldBe dto
+                    verify(exactly = 0) { epicService.findAll() }
+                }
+            }
+
+            When("assigneeId 가 visible epic 어디에도 속하지 않으면") {
+                val action = LlmAction(action = "create", target = "task", name = "새 태스크", assigneeId = 99L)
+                val user = mockk<User> { every { requiredId } returns 1L }
+                val epic =
+                    mockk<EpicResponse> {
+                        every { members } returns listOf(EpicMemberResponse(userId = 7L, userName = "철수"))
+                    }
+                every { authorizationService.currentUser() } returns user
+                every { authorizationService.visibleEpicIds(user) } returns listOf(10L)
+                every { epicService.findAll() } returns listOf(epic)
+
+                Then("ChatClarifyException 이 발생하고 form 이 만들어지지 않는다") {
+                    val ex = shouldThrow<ChatClarifyException> { router.route(action) }
+                    ex.message shouldBe "선택한 담당자는 접근 가능한 업무 그룹의 멤버가 아닙니다. 먼저 업무 그룹에 영입한 뒤 할당해주세요."
+                    verify(exactly = 0) { chatDtoMapper.toDto(any()) }
                 }
             }
         }


### PR DESCRIPTION
## Summary
  - chat 자연어 입력으로 태스크 생성 시 담당자(assignee)를 같이 지정 가능
  - LLM이 채운 담당자가 actor의 visible epic 어디에도 멤버가 아니면 chat 레이어에서 ChatClarifyException
  - promptfoo 회귀 케이스 5종 추가