### PR TITLE
feat: 태스크 생성 시 담당자에게 Teams 알림 발송

### DIFF
--- a/src/main/kotlin/com/pluxity/weekly/task/event/TaskAssignedEvent.kt
+++ b/src/main/kotlin/com/pluxity/weekly/task/event/TaskAssignedEvent.kt
@@ -1,0 +1,6 @@
+package com.pluxity.weekly.task.event
+
+data class TaskAssignedEvent(
+    val userId: Long,
+    val taskName: String,
+)

--- a/src/main/kotlin/com/pluxity/weekly/task/event/TaskAssignedEvent.kt
+++ b/src/main/kotlin/com/pluxity/weekly/task/event/TaskAssignedEvent.kt
@@ -2,5 +2,6 @@ package com.pluxity.weekly.task.event
 
 data class TaskAssignedEvent(
     val userId: Long,
+    val taskId: Long,
     val taskName: String,
 )

--- a/src/main/kotlin/com/pluxity/weekly/task/service/TaskService.kt
+++ b/src/main/kotlin/com/pluxity/weekly/task/service/TaskService.kt
@@ -68,7 +68,7 @@ class TaskService(
             )
         if (newAssigneeId != null) {
             eventPublisher.publishEvent(
-                TaskAssignedEvent(userId = newAssigneeId, taskName = savedTask.name),
+                TaskAssignedEvent(userId = newAssigneeId, taskId = savedTask.requiredId, taskName = savedTask.name),
             )
         }
         return savedTask.requiredId

--- a/src/main/kotlin/com/pluxity/weekly/task/service/TaskService.kt
+++ b/src/main/kotlin/com/pluxity/weekly/task/service/TaskService.kt
@@ -15,7 +15,9 @@ import com.pluxity.weekly.task.dto.TaskUpdateRequest
 import com.pluxity.weekly.task.dto.toResponse
 import com.pluxity.weekly.task.entity.Task
 import com.pluxity.weekly.task.entity.TaskStatus
+import com.pluxity.weekly.task.event.TaskAssignedEvent
 import com.pluxity.weekly.task.repository.TaskRepository
+import org.springframework.context.ApplicationEventPublisher
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -28,6 +30,7 @@ class TaskService(
     private val userRepository: UserRepository,
     private val authorizationService: AuthorizationService,
     private val assignmentService: EpicAssignmentService,
+    private val eventPublisher: ApplicationEventPublisher,
 ) {
     fun findAll(): List<TaskResponse> = search(TaskSearchFilter())
 
@@ -57,8 +60,8 @@ class TaskService(
         ensureUniqueTaskName(request.epicId, request.name)
         val newAssigneeId = request.assigneeId?.takeIf { it != user.requiredId }
         assignmentService.ensureAssigned(user, newAssigneeId, epic)
-        return taskRepository
-            .save(
+        val savedTask =
+            taskRepository.save(
                 Task(
                     epic = epic,
                     name = request.name,
@@ -69,7 +72,16 @@ class TaskService(
                     dueDate = request.dueDate,
                     assignee = newAssigneeId?.let { getUserById(it) } ?: user,
                 ),
-            ).requiredId
+            )
+        if (newAssigneeId != null) {
+            eventPublisher.publishEvent(
+                TaskAssignedEvent(
+                    userId = newAssigneeId,
+                    taskName = savedTask.name,
+                ),
+            )
+        }
+        return savedTask.requiredId
     }
 
     @Transactional

--- a/src/main/kotlin/com/pluxity/weekly/task/service/TaskService.kt
+++ b/src/main/kotlin/com/pluxity/weekly/task/service/TaskService.kt
@@ -51,15 +51,8 @@ class TaskService(
     @Transactional
     fun create(request: TaskRequest): Long {
         val user = authorizationService.currentUser()
-        authorizationService.requireEpicAccess(user, request.epicId)
-        if (request.status != TaskStatus.TODO) {
-            throw CustomException(ErrorCode.INVALID_INITIAL_STATUS, request.status)
-        }
-        val epic = getEpicById(request.epicId)
-        epic.ensureMutable("create task")
-        ensureUniqueTaskName(request.epicId, request.name)
-        val newAssigneeId = request.assigneeId?.takeIf { it != user.requiredId }
-        assignmentService.ensureAssigned(user, newAssigneeId, epic)
+        val epic = validateAndLoadEpic(user, request)
+        val newAssigneeId = resolveAssigneeId(user, request, epic)
         val savedTask =
             taskRepository.save(
                 Task(
@@ -75,10 +68,7 @@ class TaskService(
             )
         if (newAssigneeId != null) {
             eventPublisher.publishEvent(
-                TaskAssignedEvent(
-                    userId = newAssigneeId,
-                    taskName = savedTask.name,
-                ),
+                TaskAssignedEvent(userId = newAssigneeId, taskName = savedTask.name),
             )
         }
         return savedTask.requiredId
@@ -134,6 +124,30 @@ class TaskService(
         taskRepository.restoreById(id)
 
         return findById(id)
+    }
+
+    private fun validateAndLoadEpic(
+        user: User,
+        request: TaskRequest,
+    ): Epic {
+        authorizationService.requireEpicAccess(user, request.epicId)
+        if (request.status != TaskStatus.TODO) {
+            throw CustomException(ErrorCode.INVALID_INITIAL_STATUS, request.status)
+        }
+        val epic = getEpicById(request.epicId)
+        epic.ensureMutable("create task")
+        ensureUniqueTaskName(request.epicId, request.name)
+        return epic
+    }
+
+    private fun resolveAssigneeId(
+        user: User,
+        request: TaskRequest,
+        epic: Epic,
+    ): Long? {
+        val newId = request.assigneeId?.takeIf { it != user.requiredId }
+        assignmentService.ensureAssigned(user, newId, epic)
+        return newId
     }
 
     private fun ensureUniqueTaskName(

--- a/src/main/kotlin/com/pluxity/weekly/teams/entity/TeamsNotificationType.kt
+++ b/src/main/kotlin/com/pluxity/weekly/teams/entity/TeamsNotificationType.kt
@@ -4,6 +4,7 @@ enum class TeamsNotificationType {
     TASK_REVIEW_REQUEST,
     TASK_APPROVE,
     TASK_REJECT,
+    TASK_ASSIGN,
     EPIC_ASSIGN,
     EPIC_UNASSIGN,
     PROJECT_PM_ASSIGN,

--- a/src/main/kotlin/com/pluxity/weekly/teams/event/TeamsNotificationEventHandler.kt
+++ b/src/main/kotlin/com/pluxity/weekly/teams/event/TeamsNotificationEventHandler.kt
@@ -4,6 +4,7 @@ import com.pluxity.weekly.epic.event.EpicAssignedEvent
 import com.pluxity.weekly.epic.event.EpicUnassignedEvent
 import com.pluxity.weekly.project.event.ProjectPmAssignedEvent
 import com.pluxity.weekly.task.event.TaskApprovedEvent
+import com.pluxity.weekly.task.event.TaskAssignedEvent
 import com.pluxity.weekly.task.event.TaskRejectedEvent
 import com.pluxity.weekly.task.event.TaskReviewRequestedEvent
 import com.pluxity.weekly.teams.converter.TaskReviewCardBuilder
@@ -81,6 +82,15 @@ class TeamsNotificationEventHandler(
             userId = event.userId,
             type = TeamsNotificationType.TASK_APPROVE,
             message = "[승인] '${event.taskName}' 태스크가 승인되었습니다.",
+        )
+    }
+
+    @EventListener
+    fun on(event: TaskAssignedEvent) {
+        publishNotification(
+            userId = event.userId,
+            type = TeamsNotificationType.TASK_ASSIGN,
+            message = "'${event.taskName}' 태스크가 할당되었습니다.",
         )
     }
 

--- a/src/main/kotlin/com/pluxity/weekly/teams/service/TeamsMessageSender.kt
+++ b/src/main/kotlin/com/pluxity/weekly/teams/service/TeamsMessageSender.kt
@@ -5,6 +5,7 @@ import io.github.oshai.kotlinlogging.KotlinLogging
 import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Component
 import org.springframework.web.reactive.function.client.WebClient
+import org.springframework.web.reactive.function.client.WebClientRequestException
 import org.springframework.web.reactive.function.client.WebClientResponseException
 import reactor.util.retry.Retry
 import java.io.IOException
@@ -172,6 +173,7 @@ class TeamsMessageSender(
         private fun Throwable.isRetryable(): Boolean =
             when (this) {
                 is WebClientResponseException -> isTransientHttpStatus(statusCode.value())
+                is WebClientRequestException -> true
                 is IOException -> true
                 is TimeoutException -> true
                 else -> false

--- a/src/test/kotlin/com/pluxity/weekly/task/service/TaskServiceTest.kt
+++ b/src/test/kotlin/com/pluxity/weekly/task/service/TaskServiceTest.kt
@@ -171,7 +171,7 @@ class TaskServiceTest :
                     verify {
                         eventPublisher.publishEvent(
                             match<TaskAssignedEvent> {
-                                it.userId == 99L && it.taskName == "이벤트 발행 태스크"
+                                it.userId == 99L && it.taskName == "이벤트 발행 태스크" && it.taskId == 200L
                             },
                         )
                     }

--- a/src/test/kotlin/com/pluxity/weekly/task/service/TaskServiceTest.kt
+++ b/src/test/kotlin/com/pluxity/weekly/task/service/TaskServiceTest.kt
@@ -14,6 +14,7 @@ import com.pluxity.weekly.task.dto.dummyTaskUpdateRequest
 import com.pluxity.weekly.task.entity.Task
 import com.pluxity.weekly.task.entity.TaskStatus
 import com.pluxity.weekly.task.entity.dummyTask
+import com.pluxity.weekly.task.event.TaskAssignedEvent
 import com.pluxity.weekly.task.repository.TaskRepository
 import com.pluxity.weekly.test.entity.dummyRole
 import com.pluxity.weekly.test.entity.dummyUser
@@ -26,6 +27,7 @@ import io.mockk.mockk
 import io.mockk.runs
 import io.mockk.slot
 import io.mockk.verify
+import org.springframework.context.ApplicationEventPublisher
 import org.springframework.data.repository.findByIdOrNull
 import java.time.LocalDate
 
@@ -37,6 +39,7 @@ class TaskServiceTest :
         val userRepository: UserRepository = mockk()
         val authorizationService: AuthorizationService = mockk()
         val assignmentService: EpicAssignmentService = mockk(relaxed = true)
+        val eventPublisher: ApplicationEventPublisher = mockk(relaxed = true)
         val service =
             TaskService(
                 taskRepository,
@@ -44,6 +47,7 @@ class TaskServiceTest :
                 userRepository,
                 authorizationService,
                 assignmentService,
+                eventPublisher,
             )
 
         val adminUser =
@@ -145,6 +149,64 @@ class TaskServiceTest :
 
                 Then("생성된 태스크의 ID가 반환된다") {
                     result shouldBe 1L
+                }
+            }
+        }
+
+        Given("태스크 생성 시 TaskAssignedEvent 발행") {
+            When("assigneeId 가 현재 사용자가 아닌 다른 사람이면") {
+                val epic = dummyEpic(id = 11L)
+                val otherUser = dummyUser(id = 99L, name = "다른 사람")
+                val request = dummyTaskRequest(epicId = 11L, name = "이벤트 발행 태스크", assigneeId = 99L)
+                val saved = dummyTask(id = 200L, epic = epic, name = "이벤트 발행 태스크").apply { assignee = otherUser }
+
+                every { epicRepository.findByIdOrNull(11L) } returns epic
+                every { taskRepository.existsByEpicIdAndName(11L, request.name) } returns false
+                every { userRepository.findByIdOrNull(99L) } returns otherUser
+                every { taskRepository.save(any<Task>()) } returns saved
+
+                service.create(request)
+
+                Then("TaskAssignedEvent 가 발행된다") {
+                    verify {
+                        eventPublisher.publishEvent(
+                            match<TaskAssignedEvent> {
+                                it.userId == 99L && it.taskName == "이벤트 발행 태스크"
+                            },
+                        )
+                    }
+                }
+            }
+
+            When("assigneeId 가 현재 사용자 본인이면") {
+                val epic = dummyEpic(id = 12L)
+                val request = dummyTaskRequest(epicId = 12L, name = "본인 할당 태스크", assigneeId = 1L)
+                val saved = dummyTask(id = 201L, epic = epic, name = "본인 할당 태스크").apply { assignee = adminUser }
+
+                every { epicRepository.findByIdOrNull(12L) } returns epic
+                every { taskRepository.existsByEpicIdAndName(12L, request.name) } returns false
+                every { taskRepository.save(any<Task>()) } returns saved
+
+                service.create(request)
+
+                Then("TaskAssignedEvent 가 발행되지 않는다") {
+                    verify(exactly = 0) { eventPublisher.publishEvent(any<TaskAssignedEvent>()) }
+                }
+            }
+
+            When("assigneeId 가 null 이면") {
+                val epic = dummyEpic(id = 13L)
+                val request = dummyTaskRequest(epicId = 13L, name = "담당자 없는 태스크", assigneeId = null)
+                val saved = dummyTask(id = 202L, epic = epic, name = "담당자 없는 태스크").apply { assignee = adminUser }
+
+                every { epicRepository.findByIdOrNull(13L) } returns epic
+                every { taskRepository.existsByEpicIdAndName(13L, request.name) } returns false
+                every { taskRepository.save(any<Task>()) } returns saved
+
+                service.create(request)
+
+                Then("TaskAssignedEvent 가 발행되지 않는다") {
+                    verify(exactly = 0) { eventPublisher.publishEvent(any<TaskAssignedEvent>()) }
                 }
             }
         }


### PR DESCRIPTION
## Summary
  - 본인이 아닌 다른 사용자를 담당자로 지정해 태스크를 생성하면 해당 사용자에게 Teams DM 알림 발송
  - 기존 도메인 이벤트 패턴(`TaskAssignedEvent` → `TeamsNotificationEventHandler`) 적용
  - 트랜잭션 원자성 유지: 태스크 저장 + 알림 로그 영속화는 같은 TX, 실제 Teams API 호출은 AFTER_COMMIT + `@Async`
  ### 알림 추가 (feat)
  - `TeamsNotificationType.TASK_ASSIGN` 추가
  - `TaskAssignedEvent(userId, taskName)` 도메인 이벤트 신규
  - `TeamsNotificationEventHandler.on(TaskAssignedEvent)` 핸들러 추가
    메시지: `'{taskName}' 태스크가 할당되었습니다.`
  - `TaskService.create()`에서 `newAssigneeId != null` 일 때 이벤트 발행

  ### TaskService.create() 책임 분리 (refactor)
  - 검증/조회 묶음을 `validateAndLoadEpic`, `resolveAssigneeId` 두 헬퍼로 추출
  - public 동작 / 시그니처 동일 — 기존 테스트 그대로 통과

  ### Teams 전송 재시도 보강 (fix)
  - `TeamsMessageSender` retry 필터에 `WebClientRequestException` 추가
  - 기존 분기(`5xx/408/429/IOException`)가 DNS 해석 실패(`UnknownHostException` 래핑 형태)를 못 잡아 단 한 번도 재시도 없이 FAILED 처리되던 케이스 보완