### PR TITLE
feat: 주간보고 도메인 GET API 구현

### DIFF
--- a/src/main/kotlin/com/pluxity/weekly/auth/authorization/AuthorizationService.kt
+++ b/src/main/kotlin/com/pluxity/weekly/auth/authorization/AuthorizationService.kt
@@ -10,6 +10,7 @@ import com.pluxity.weekly.epic.repository.EpicRepository
 import com.pluxity.weekly.project.entity.Project
 import com.pluxity.weekly.project.repository.ProjectRepository
 import com.pluxity.weekly.task.entity.Task
+import com.pluxity.weekly.team.repository.TeamRepository
 import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.stereotype.Service
 
@@ -18,6 +19,7 @@ class AuthorizationService(
     private val userService: UserService,
     private val projectRepository: ProjectRepository,
     private val epicRepository: EpicRepository,
+    private val teamRepository: TeamRepository,
 ) {
     fun currentUser(): User {
         val authentication =
@@ -37,6 +39,12 @@ class AuthorizationService(
     fun requireAdminOrPm(user: User) {
         if (user.hasRole(UserType.ADMIN)) return
         if (user.isProjectManager()) return
+        throw CustomException(ErrorCode.PERMISSION_DENIED)
+    }
+
+    fun requireAdminOrLeader(user: User) {
+        if (user.hasRole(UserType.ADMIN)) return
+        if (user.hasRole(UserType.TEAM_LEADER)) return
         throw CustomException(ErrorCode.PERMISSION_DENIED)
     }
 
@@ -173,6 +181,22 @@ class AuthorizationService(
         if (user.hasRole(UserType.ADMIN)) return null
         if (user.isProjectManager()) return null
         return user.requiredId
+    }
+
+    /** 사용자가 볼 수 있는 팀 ID. null=전체(Admin), Leader는 본인이 leader인 팀들 */
+    fun visibleTeamIds(user: User): List<Long>? {
+        if (user.hasRole(UserType.ADMIN)) return null
+        return teamRepository.findByLeaderId(user.requiredId).map { it.requiredId }
+    }
+
+    /** ADMIN 또는 해당 팀의 leader만 허용 — 주간보고 팀별 조회 */
+    fun requireTeamAccess(
+        user: User,
+        teamId: Long,
+    ) {
+        if (user.hasRole(UserType.ADMIN)) return
+        if (teamRepository.existsByIdAndLeaderId(teamId, user.requiredId)) return
+        throw CustomException(ErrorCode.PERMISSION_DENIED)
     }
 
     fun User.hasRole(userType: UserType): Boolean = userRoles.any { it.role.name.equals(userType.roleName, ignoreCase = true) }

--- a/src/main/kotlin/com/pluxity/weekly/chat/dto/WeeklyReportSearchFilter.kt
+++ b/src/main/kotlin/com/pluxity/weekly/chat/dto/WeeklyReportSearchFilter.kt
@@ -4,6 +4,7 @@ import java.time.LocalDate
 
 data class WeeklyReportSearchFilter(
     val teamId: Long? = null,
+    val teamIds: List<Long>? = null,
     val weekStart: LocalDate? = null,
     val weekEnd: LocalDate? = null,
 )

--- a/src/main/kotlin/com/pluxity/weekly/chat/dto/WeeklyReportSearchFilter.kt
+++ b/src/main/kotlin/com/pluxity/weekly/chat/dto/WeeklyReportSearchFilter.kt
@@ -1,0 +1,9 @@
+package com.pluxity.weekly.chat.dto
+
+import java.time.LocalDate
+
+data class WeeklyReportSearchFilter(
+    val teamId: Long? = null,
+    val weekStart: LocalDate? = null,
+    val weekEnd: LocalDate? = null,
+)

--- a/src/main/kotlin/com/pluxity/weekly/core/constant/ErrorCode.kt
+++ b/src/main/kotlin/com/pluxity/weekly/core/constant/ErrorCode.kt
@@ -57,6 +57,8 @@ enum class ErrorCode(
     CHAT_RESOLVE_INVALID(HttpStatus.BAD_REQUEST, "%s"),
     CHAT_ALREADY_PROCESSING(HttpStatus.TOO_MANY_REQUESTS, "이전 요청을 처리 중입니다. 잠시 후 다시 시도해주세요."),
 
+    NOT_FOUND_WEEKLY_REPORT(HttpStatus.NOT_FOUND, "ID가 %s인 주간보고를 찾을 수 없습니다."),
+
     // ── Common (DB / Request) ──
     DUPLICATE_RESOURCE_ID(HttpStatus.BAD_REQUEST, "중복된 리소스 ID가 포함되어 있습니다."),
     REFERENCED_RESOURCE_NOT_FOUND(HttpStatus.BAD_REQUEST, "참조 대상이 존재하지 않습니다."),

--- a/src/main/kotlin/com/pluxity/weekly/report/controller/WeeklyReportController.kt
+++ b/src/main/kotlin/com/pluxity/weekly/report/controller/WeeklyReportController.kt
@@ -108,12 +108,12 @@ class WeeklyReportController(
     )
     @GetMapping("/summary")
     fun findSummary(
-        @Parameter(description = "검색 범위 시작 주차 (해당 주 월요일, ISO yyyy-MM-dd, inclusive)", example = "2026-05-18")
-        @RequestParam(required = false)
-        @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) weekStart: LocalDate?,
-        @Parameter(description = "검색 범위 종료 주차 (해당 주 월요일, ISO yyyy-MM-dd, inclusive)", example = "2026-06-15")
-        @RequestParam(required = false)
-        @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) weekEnd: LocalDate?,
+        @Parameter(description = "검색 범위 시작 주차 (해당 주 월요일, ISO yyyy-MM-dd, inclusive). 필수.", example = "2026-05-18")
+        @RequestParam
+        @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) weekStart: LocalDate,
+        @Parameter(description = "검색 범위 종료 주차 (해당 주 월요일, ISO yyyy-MM-dd, inclusive). 필수.", example = "2026-06-15")
+        @RequestParam
+        @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) weekEnd: LocalDate,
     ): ResponseEntity<DataResponseBody<List<WeeklyReportSummaryResponse>>> =
         ResponseEntity.ok(DataResponseBody(service.findSummary(weekStart, weekEnd)))
 }

--- a/src/main/kotlin/com/pluxity/weekly/report/dto/WeeklyReportResponse.kt
+++ b/src/main/kotlin/com/pluxity/weekly/report/dto/WeeklyReportResponse.kt
@@ -2,6 +2,8 @@ package com.pluxity.weekly.report.dto
 
 import com.fasterxml.jackson.annotation.JsonUnwrapped
 import com.pluxity.weekly.core.response.BaseResponse
+import com.pluxity.weekly.core.response.toBaseResponse
+import com.pluxity.weekly.report.entity.WeeklyReport
 import io.swagger.v3.oas.annotations.media.Schema
 import java.time.LocalDate
 
@@ -9,10 +11,10 @@ import java.time.LocalDate
 data class WeeklyReportResponse(
     @field:Schema(description = "ID", example = "1")
     val id: Long,
-    @field:Schema(description = "팀 ID (LLM이 team_name_raw → teams.name 매칭 실패 시 null)", example = "10")
-    val teamId: Long?,
-    @field:Schema(description = "teams 테이블에서 매칭된 정식 팀명. 매칭 실패 시 null", example = "개발팀")
-    val teamName: String?,
+    @field:Schema(description = "팀 ID. 주간보고는 항상 팀에 종속됨", example = "10")
+    val teamId: Long,
+    @field:Schema(description = "팀명 (teams.name)", example = "개발팀")
+    val teamName: String,
     @field:Schema(description = "LLM이 원문에서 추출한 팀명 원본 (항상 보존, 매칭 실패 시 표시용)", example = "본부A 개발팀")
     val teamNameRaw: String,
     @field:Schema(description = "주차 시작일 (해당 주 월요일로 정규화)", example = "2026-05-18")
@@ -31,3 +33,17 @@ data class WeeklyReportResponse(
     @field:JsonUnwrapped
     val baseResponse: BaseResponse,
 )
+
+fun WeeklyReport.toResponse(): WeeklyReportResponse =
+    WeeklyReportResponse(
+        id = this.requiredId,
+        teamId = this.team.requiredId,
+        teamName = this.team.name,
+        teamNameRaw = this.teamNameRaw,
+        weekStart = this.weekStart,
+        weekLabel = this.weekLabel,
+        rawContent = this.rawContent,
+        formatted = this.formatted,
+        matchedAgainstPrev = this.matchedAgainstPrev,
+        baseResponse = this.toBaseResponse(),
+    )

--- a/src/main/kotlin/com/pluxity/weekly/report/dto/WeeklyReportSummaryResponse.kt
+++ b/src/main/kotlin/com/pluxity/weekly/report/dto/WeeklyReportSummaryResponse.kt
@@ -1,14 +1,13 @@
 package com.pluxity.weekly.report.dto
 
-import com.fasterxml.jackson.annotation.JsonUnwrapped
-import com.pluxity.weekly.core.response.BaseResponse
 import io.swagger.v3.oas.annotations.media.Schema
 import java.time.LocalDate
+import java.time.LocalDateTime
 
 @Schema(
     description = """
     주간보고 요약 (팀 × 주차의 작성 상태). 풀 데이터 없이 메타만 내려주는 경량 응답.
-    
+
     용도:
     - 주차 네비에서 미작성 주차 표시 (amber/badge)
     - 팀 리스트에서 미작성/지각 팀 표시
@@ -21,6 +20,8 @@ data class WeeklyReportSummaryResponse(
     val weekStart: LocalDate,
     @field:Schema(description = "해당 팀×주차의 보고 작성 여부", example = "true")
     val exists: Boolean,
-    @field:JsonUnwrapped
-    val baseResponse: BaseResponse,
+    @field:Schema(description = "작성 시각. 미작성이면 null", example = "2026-05-16T18:42:00")
+    val createdAt: LocalDateTime?,
+    @field:Schema(description = "작성자 (username). 미작성이면 null", example = "leader1")
+    val createdBy: String?,
 )

--- a/src/main/kotlin/com/pluxity/weekly/report/entity/WeeklyReport.kt
+++ b/src/main/kotlin/com/pluxity/weekly/report/entity/WeeklyReport.kt
@@ -3,8 +3,12 @@ package com.pluxity.weekly.report.entity
 import com.pluxity.weekly.core.entity.IdentityIdEntity
 import com.pluxity.weekly.report.dto.FormattedReport
 import com.pluxity.weekly.report.dto.MatchedAgainstPrev
+import com.pluxity.weekly.team.entity.Team
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
+import jakarta.persistence.FetchType
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
 import jakarta.persistence.Table
 import jakarta.persistence.UniqueConstraint
 import org.hibernate.annotations.JdbcTypeCode
@@ -19,8 +23,9 @@ import java.time.LocalDate
     ],
 )
 class WeeklyReport(
-    @Column(name = "team_id")
-    var teamId: Long?,
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "team_id", nullable = false)
+    var team: Team,
     @Column(name = "team_name_raw", nullable = false, length = 255)
     var teamNameRaw: String,
     @Column(name = "week_start", nullable = false)
@@ -35,17 +40,4 @@ class WeeklyReport(
     @JdbcTypeCode(SqlTypes.JSON)
     @Column(name = "matched_against_prev", columnDefinition = "jsonb")
     var matchedAgainstPrev: MatchedAgainstPrev? = null,
-) : IdentityIdEntity() {
-    fun update(
-        rawContent: String? = null,
-        formatted: FormattedReport? = null,
-    ) {
-        rawContent?.let { this.rawContent = it }
-        formatted?.let { this.formatted = it }
-        this.matchedAgainstPrev = null
-    }
-
-    fun updateMatching(matchedAgainstPrev: MatchedAgainstPrev) {
-        this.matchedAgainstPrev = matchedAgainstPrev
-    }
-}
+) : IdentityIdEntity()

--- a/src/main/kotlin/com/pluxity/weekly/report/repository/WeeklyReportCustomRepository.kt
+++ b/src/main/kotlin/com/pluxity/weekly/report/repository/WeeklyReportCustomRepository.kt
@@ -1,0 +1,8 @@
+package com.pluxity.weekly.report.repository
+
+import com.pluxity.weekly.chat.dto.WeeklyReportSearchFilter
+import com.pluxity.weekly.report.entity.WeeklyReport
+
+interface WeeklyReportCustomRepository {
+    fun findByFilter(filter: WeeklyReportSearchFilter): List<WeeklyReport>
+}

--- a/src/main/kotlin/com/pluxity/weekly/report/repository/WeeklyReportCustomRepositoryImpl.kt
+++ b/src/main/kotlin/com/pluxity/weekly/report/repository/WeeklyReportCustomRepositoryImpl.kt
@@ -1,0 +1,24 @@
+package com.pluxity.weekly.report.repository
+
+import com.linecorp.kotlinjdsl.support.spring.data.jpa.repository.KotlinJdslJpqlExecutor
+import com.pluxity.weekly.chat.dto.WeeklyReportSearchFilter
+import com.pluxity.weekly.core.utils.findAllNotNull
+import com.pluxity.weekly.report.entity.WeeklyReport
+import com.pluxity.weekly.team.entity.Team
+
+class WeeklyReportCustomRepositoryImpl(
+    private val executor: KotlinJdslJpqlExecutor,
+) : WeeklyReportCustomRepository {
+    override fun findByFilter(filter: WeeklyReportSearchFilter): List<WeeklyReport> =
+        executor.findAllNotNull {
+            select(entity(WeeklyReport::class))
+                .from(
+                    entity(WeeklyReport::class),
+                    fetchJoin(WeeklyReport::team),
+                ).whereAnd(
+                    filter.teamId?.let { path(WeeklyReport::team)(Team::id).eq(it) },
+                    filter.weekStart?.let { path(WeeklyReport::weekStart).greaterThanOrEqualTo(it) },
+                    filter.weekEnd?.let { path(WeeklyReport::weekStart).lessThanOrEqualTo(it) },
+                ).orderBy(path(WeeklyReport::weekStart).desc())
+        }
+}

--- a/src/main/kotlin/com/pluxity/weekly/report/repository/WeeklyReportCustomRepositoryImpl.kt
+++ b/src/main/kotlin/com/pluxity/weekly/report/repository/WeeklyReportCustomRepositoryImpl.kt
@@ -17,6 +17,7 @@ class WeeklyReportCustomRepositoryImpl(
                     fetchJoin(WeeklyReport::team),
                 ).whereAnd(
                     filter.teamId?.let { path(WeeklyReport::team)(Team::id).eq(it) },
+                    filter.teamIds?.let { path(WeeklyReport::team)(Team::id).`in`(it) },
                     filter.weekStart?.let { path(WeeklyReport::weekStart).greaterThanOrEqualTo(it) },
                     filter.weekEnd?.let { path(WeeklyReport::weekStart).lessThanOrEqualTo(it) },
                 ).orderBy(path(WeeklyReport::weekStart).desc())

--- a/src/main/kotlin/com/pluxity/weekly/report/repository/WeeklyReportRepository.kt
+++ b/src/main/kotlin/com/pluxity/weekly/report/repository/WeeklyReportRepository.kt
@@ -23,5 +23,4 @@ interface WeeklyReportRepository :
         @Param("weekStart") weekStart: LocalDate,
         @Param("weekEnd") weekEnd: LocalDate,
     ): List<WeeklyReportSummaryRow>
-
 }

--- a/src/main/kotlin/com/pluxity/weekly/report/repository/WeeklyReportRepository.kt
+++ b/src/main/kotlin/com/pluxity/weekly/report/repository/WeeklyReportRepository.kt
@@ -1,0 +1,27 @@
+package com.pluxity.weekly.report.repository
+
+import com.pluxity.weekly.report.entity.WeeklyReport
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
+import java.time.LocalDate
+
+interface WeeklyReportRepository :
+    JpaRepository<WeeklyReport, Long>,
+    WeeklyReportCustomRepository {
+    @Query(
+        """
+        SELECT w.team.id AS teamId,
+               w.weekStart AS weekStart,
+               w.createdAt AS createdAt,
+               w.createdBy AS createdBy
+          FROM WeeklyReport w
+         WHERE w.weekStart BETWEEN :weekStart AND :weekEnd
+        """,
+    )
+    fun findSummaryRows(
+        @Param("weekStart") weekStart: LocalDate,
+        @Param("weekEnd") weekEnd: LocalDate,
+    ): List<WeeklyReportSummaryRow>
+
+}

--- a/src/main/kotlin/com/pluxity/weekly/report/repository/WeeklyReportSummaryRow.kt
+++ b/src/main/kotlin/com/pluxity/weekly/report/repository/WeeklyReportSummaryRow.kt
@@ -1,0 +1,11 @@
+package com.pluxity.weekly.report.repository
+
+import java.time.LocalDate
+import java.time.LocalDateTime
+
+interface WeeklyReportSummaryRow {
+    val teamId: Long
+    val weekStart: LocalDate
+    val createdAt: LocalDateTime
+    val createdBy: String?
+}

--- a/src/main/kotlin/com/pluxity/weekly/report/service/WeeklyReportService.kt
+++ b/src/main/kotlin/com/pluxity/weekly/report/service/WeeklyReportService.kt
@@ -12,7 +12,9 @@ import com.pluxity.weekly.team.repository.TeamRepository
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import java.time.DayOfWeek
 import java.time.LocalDate
+import java.time.temporal.TemporalAdjusters
 
 @Service
 @Transactional(readOnly = true)
@@ -71,6 +73,10 @@ class WeeklyReportService(
         val user = authorizationService.currentUser()
         authorizationService.requireAdminOrLeader(user)
 
+        val normalizedStart = weekStart.with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY))
+        val normalizedEnd = weekEnd.with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY))
+        if (normalizedStart.isAfter(normalizedEnd)) return emptyList()
+
         val visibleTeams = authorizationService.visibleTeamIds(user)
         val teams =
             if (visibleTeams == null) {
@@ -78,10 +84,10 @@ class WeeklyReportService(
             } else {
                 teamRepository.findAllById(visibleTeams)
             }
-        val weeks = generateMondays(weekStart, weekEnd)
+        val weeks = generateMondays(normalizedStart, normalizedEnd)
         val rowsByKey =
             weeklyReportRepository
-                .findSummaryRows(weekStart, weekEnd)
+                .findSummaryRows(normalizedStart, normalizedEnd)
                 .associateBy { it.teamId to it.weekStart }
 
         return teams.flatMap { team ->

--- a/src/main/kotlin/com/pluxity/weekly/report/service/WeeklyReportService.kt
+++ b/src/main/kotlin/com/pluxity/weekly/report/service/WeeklyReportService.kt
@@ -1,5 +1,6 @@
 package com.pluxity.weekly.report.service
 
+import com.pluxity.weekly.auth.authorization.AuthorizationService
 import com.pluxity.weekly.chat.dto.WeeklyReportSearchFilter
 import com.pluxity.weekly.core.constant.ErrorCode
 import com.pluxity.weekly.core.exception.CustomException
@@ -18,14 +19,33 @@ import java.time.LocalDate
 class WeeklyReportService(
     private val weeklyReportRepository: WeeklyReportRepository,
     private val teamRepository: TeamRepository,
+    private val authorizationService: AuthorizationService,
 ) {
     fun findAll(
         teamId: Long?,
         weekStart: LocalDate?,
         weekEnd: LocalDate?,
     ): List<WeeklyReportResponse> {
-        // TODO: 권한 가드 — ADMIN 전체 / Leader 본인 팀만
-        val filter = WeeklyReportSearchFilter(teamId = teamId, weekStart = weekStart, weekEnd = weekEnd)
+        val user = authorizationService.currentUser()
+        authorizationService.requireAdminOrLeader(user)
+
+        val visibleTeams = authorizationService.visibleTeamIds(user)
+        val filter =
+            when {
+                teamId != null -> {
+                    authorizationService.requireTeamAccess(user, teamId)
+                    WeeklyReportSearchFilter(teamId = teamId, weekStart = weekStart, weekEnd = weekEnd)
+                }
+                visibleTeams == null -> {
+                    // ADMIN, teamId 미지정 → 전체
+                    WeeklyReportSearchFilter(weekStart = weekStart, weekEnd = weekEnd)
+                }
+                else -> {
+                    // Leader, teamId 미지정 → 본인 팀들로 제한
+                    WeeklyReportSearchFilter(teamIds = visibleTeams, weekStart = weekStart, weekEnd = weekEnd)
+                }
+            }
+
         return weeklyReportRepository.findByFilter(filter).map { it.toResponse() }
     }
 
@@ -33,17 +53,31 @@ class WeeklyReportService(
         val report =
             weeklyReportRepository.findByIdOrNull(id)
                 ?: throw CustomException(ErrorCode.NOT_FOUND_WEEKLY_REPORT, id)
+
+        val user = authorizationService.currentUser()
+        authorizationService.requireTeamAccess(user, report.team.requiredId)
+
         return report.toResponse()
     }
 
     /**
      * 팀 × 주차 슬롯을 앱에서 생성하고, 실제 작성된 보고는 projection으로 lookup.
+     * ADMIN은 전체 팀, Leader는 본인 팀들만 그리드에 노출.
      */
     fun findSummary(
         weekStart: LocalDate,
         weekEnd: LocalDate,
     ): List<WeeklyReportSummaryResponse> {
-        val teams = teamRepository.findAll()
+        val user = authorizationService.currentUser()
+        authorizationService.requireAdminOrLeader(user)
+
+        val visibleTeams = authorizationService.visibleTeamIds(user)
+        val teams =
+            if (visibleTeams == null) {
+                teamRepository.findAll()
+            } else {
+                teamRepository.findAllById(visibleTeams)
+            }
         val weeks = generateMondays(weekStart, weekEnd)
         val rowsByKey =
             weeklyReportRepository

--- a/src/main/kotlin/com/pluxity/weekly/report/service/WeeklyReportService.kt
+++ b/src/main/kotlin/com/pluxity/weekly/report/service/WeeklyReportService.kt
@@ -1,118 +1,80 @@
 package com.pluxity.weekly.report.service
 
-import com.pluxity.weekly.core.response.BaseResponse
-import com.pluxity.weekly.report.dto.FormattedReport
-import com.pluxity.weekly.report.dto.MatchedAgainstPrev
-import com.pluxity.weekly.report.dto.MatchedPair
-import com.pluxity.weekly.report.dto.ReportItem
+import com.pluxity.weekly.chat.dto.WeeklyReportSearchFilter
+import com.pluxity.weekly.core.constant.ErrorCode
+import com.pluxity.weekly.core.exception.CustomException
 import com.pluxity.weekly.report.dto.WeeklyReportResponse
 import com.pluxity.weekly.report.dto.WeeklyReportSummaryResponse
+import com.pluxity.weekly.report.dto.toResponse
+import com.pluxity.weekly.report.repository.WeeklyReportRepository
+import com.pluxity.weekly.team.repository.TeamRepository
+import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.time.LocalDate
 
 @Service
 @Transactional(readOnly = true)
-class WeeklyReportService {
+class WeeklyReportService(
+    private val weeklyReportRepository: WeeklyReportRepository,
+    private val teamRepository: TeamRepository,
+) {
     fun findAll(
         teamId: Long?,
         weekStart: LocalDate?,
         weekEnd: LocalDate?,
-    ): List<WeeklyReportResponse> = listOf(sampleResponse())
+    ): List<WeeklyReportResponse> {
+        // TODO: 권한 가드 — ADMIN 전체 / Leader 본인 팀만
+        val filter = WeeklyReportSearchFilter(teamId = teamId, weekStart = weekStart, weekEnd = weekEnd)
+        return weeklyReportRepository.findByFilter(filter).map { it.toResponse() }
+    }
 
-    fun findById(id: Long): WeeklyReportResponse = sampleResponse().copy(id = id)
+    fun findById(id: Long): WeeklyReportResponse {
+        val report =
+            weeklyReportRepository.findByIdOrNull(id)
+                ?: throw CustomException(ErrorCode.NOT_FOUND_WEEKLY_REPORT, id)
+        return report.toResponse()
+    }
 
+    /**
+     * 팀 × 주차 슬롯을 앱에서 생성하고, 실제 작성된 보고는 projection으로 lookup.
+     */
     fun findSummary(
-        weekStart: LocalDate?,
-        weekEnd: LocalDate?,
-    ): List<WeeklyReportSummaryResponse> =
-        listOf(
-            WeeklyReportSummaryResponse(
-                teamId = 10L,
-                weekStart = LocalDate.of(2026, 5, 11),
-                exists = true,
-                baseResponse =
-                    BaseResponse(
-                        createdAt = "2026-05-16T18:42:00",
-                        createdBy = "sample.user",
-                        updatedAt = "2026-05-16T18:42:00",
-                        updatedBy = "sample.user",
-                    ),
-            ),
-            WeeklyReportSummaryResponse(
-                teamId = 11L,
-                weekStart = LocalDate.of(2026, 5, 11),
-                exists = false,
-                baseResponse =
-                    BaseResponse(
-                        createdAt = "",
-                        createdBy = "",
-                        updatedAt = "",
-                        updatedBy = "",
-                    ),
-            ),
-        )
+        weekStart: LocalDate,
+        weekEnd: LocalDate,
+    ): List<WeeklyReportSummaryResponse> {
+        val teams = teamRepository.findAll()
+        val weeks = generateMondays(weekStart, weekEnd)
+        val rowsByKey =
+            weeklyReportRepository
+                .findSummaryRows(weekStart, weekEnd)
+                .associateBy { it.teamId to it.weekStart }
 
-    // TODO: entity/repository 도입 후 실제 조회 로직 + 권한 가드 구현
-    private fun sampleResponse(): WeeklyReportResponse =
-        WeeklyReportResponse(
-            id = 1L,
-            teamId = 10L,
-            teamName = "개발팀",
-            teamNameRaw = "본부A 개발팀",
-            weekStart = LocalDate.of(2026, 5, 11),
-            weekLabel = "5월 2주(05/11~05/15)",
-            rawContent =
-                """
-                주간업무보고
-                보고 기간 금주: 2026.05.11 ~ 05.15
+        return teams.flatMap { team ->
+            val teamId = team.requiredId
+            weeks.map { week ->
+                val row = rowsByKey[teamId to week]
+                WeeklyReportSummaryResponse(
+                    teamId = teamId,
+                    weekStart = week,
+                    exists = row != null,
+                    createdAt = row?.createdAt,
+                    createdBy = row?.createdBy,
+                )
+            }
+        }
+    }
 
-                홍길동
-                금주 (05/11 ~ 05/15)
-                프로젝트 | 업무 내용 | 진행률
-                ProductA v1.0 | #95 메인 페이지 구현 | 100%
-                """.trimIndent(),
-            formatted =
-                FormattedReport(
-                    thisWeek =
-                        listOf(
-                            ReportItem(
-                                assignee = "홍길동",
-                                category = "ProductA v1.0",
-                                text = "#95 메인 페이지 구현",
-                                progress = "100%",
-                                dueDate = null,
-                            ),
-                        ),
-                    nextWeek =
-                        listOf(
-                            ReportItem(
-                                assignee = "홍길동",
-                                category = "ProductB",
-                                text = "신규 모듈 검토",
-                                progress = null,
-                                dueDate = LocalDate.of(2026, 5, 22),
-                            ),
-                        ),
-                ),
-            matchedAgainstPrev =
-                MatchedAgainstPrev(
-                    matched =
-                        listOf(
-                            MatchedPair(
-                                prev = "#95 메인 페이지 구현",
-                                curr = "#95 메인 페이지 구현 완료",
-                            ),
-                        ),
-                    missing = listOf("로그인 모듈 리팩토링"),
-                    new = listOf("신규 모듈 검토"),
-                ),
-            baseResponse =
-                BaseResponse(
-                    createdAt = "2026-05-20T14:30:00",
-                    createdBy = "sample.user",
-                    updatedAt = "2026-05-20T14:30:00",
-                    updatedBy = "sample.user",
-                ),
-        )
+    private fun generateMondays(
+        start: LocalDate,
+        end: LocalDate,
+    ): List<LocalDate> {
+        val list = mutableListOf<LocalDate>()
+        var current = start
+        while (!current.isAfter(end)) {
+            list.add(current)
+            current = current.plusWeeks(1)
+        }
+        return list
+    }
 }

--- a/src/main/kotlin/com/pluxity/weekly/team/repository/TeamRepository.kt
+++ b/src/main/kotlin/com/pluxity/weekly/team/repository/TeamRepository.kt
@@ -7,4 +7,11 @@ interface TeamRepository :
     JpaRepository<Team, Long>,
     TeamCustomRepository {
     fun existsByLeaderId(leaderId: Long): Boolean
+
+    fun findByLeaderId(leaderId: Long): List<Team>
+
+    fun existsByIdAndLeaderId(
+        id: Long,
+        leaderId: Long,
+    ): Boolean
 }

--- a/src/main/resources/db/migration/V20260521_001__weekly_reports_team_not_null.sql
+++ b/src/main/resources/db/migration/V20260521_001__weekly_reports_team_not_null.sql
@@ -1,0 +1,5 @@
+-- 주간보고는 항상 한 팀에 종속된다는 도메인 결정 반영 (이슈 #56 명세의 "nullable: 사업 단위 보고 대비"를 거스름)
+-- LLM 매칭 실패 시 chat 라우터(#57)에서 작성 거부 + 재입력 요청으로 처리하기로 합의.
+
+ALTER TABLE weekly_reports
+    ALTER COLUMN team_id SET NOT NULL;

--- a/src/test/kotlin/com/pluxity/weekly/report/entity/DummyEntities.kt
+++ b/src/test/kotlin/com/pluxity/weekly/report/entity/DummyEntities.kt
@@ -1,0 +1,28 @@
+package com.pluxity.weekly.report.entity
+
+import com.pluxity.weekly.report.dto.FormattedReport
+import com.pluxity.weekly.report.dto.MatchedAgainstPrev
+import com.pluxity.weekly.team.entity.Team
+import com.pluxity.weekly.team.entity.dummyTeam
+import com.pluxity.weekly.test.withAudit
+import com.pluxity.weekly.test.withId
+import java.time.LocalDate
+
+fun dummyWeeklyReport(
+    id: Long? = null,
+    team: Team = dummyTeam(id = 1L),
+    teamNameRaw: String = team.name,
+    weekStart: LocalDate = LocalDate.of(2026, 5, 11),
+    weekLabel: String? = null,
+    rawContent: String = "원문 내용",
+    formatted: FormattedReport = FormattedReport(),
+    matchedAgainstPrev: MatchedAgainstPrev? = null,
+) = WeeklyReport(
+    team = team,
+    teamNameRaw = teamNameRaw,
+    weekStart = weekStart,
+    weekLabel = weekLabel,
+    rawContent = rawContent,
+    formatted = formatted,
+    matchedAgainstPrev = matchedAgainstPrev,
+).withId(id).withAudit()

--- a/src/test/kotlin/com/pluxity/weekly/report/service/WeeklyReportServiceTest.kt
+++ b/src/test/kotlin/com/pluxity/weekly/report/service/WeeklyReportServiceTest.kt
@@ -261,5 +261,40 @@ class WeeklyReportServiceTest :
                     exception.code shouldBe ErrorCode.PERMISSION_DENIED
                 }
             }
+
+            When("비월요일 날짜를 입력하면") {
+                // 5/13 (수) → 5/11 (월), 5/20 (수) → 5/18 (월) 로 정규화돼야 함
+                val inputStart = LocalDate.of(2026, 5, 13)
+                val inputEnd = LocalDate.of(2026, 5, 20)
+                val expectedStart = LocalDate.of(2026, 5, 11)
+                val expectedEnd = LocalDate.of(2026, 5, 18)
+
+                every { authorizationService.currentUser() } returns adminUser
+                every { authorizationService.requireAdminOrLeader(adminUser) } just runs
+                every { authorizationService.visibleTeamIds(adminUser) } returns null
+                every { teamRepository.findAll() } returns listOf(team10)
+                every { weeklyReportRepository.findSummaryRows(expectedStart, expectedEnd) } returns emptyList()
+
+                val result = service.findSummary(inputStart, inputEnd)
+
+                Then("월요일로 정규화된 주차 슬롯이 반환된다") {
+                    result.size shouldBe 2
+                    result.map { it.weekStart } shouldBe listOf(expectedStart, expectedEnd)
+                }
+            }
+
+            When("시작일이 종료일보다 늦으면") {
+                val laterStart = LocalDate.of(2026, 6, 1)
+                val earlierEnd = LocalDate.of(2026, 5, 18)
+
+                every { authorizationService.currentUser() } returns adminUser
+                every { authorizationService.requireAdminOrLeader(adminUser) } just runs
+
+                val result = service.findSummary(laterStart, earlierEnd)
+
+                Then("빈 응답이 반환된다") {
+                    result shouldBe emptyList()
+                }
+            }
         }
     })

--- a/src/test/kotlin/com/pluxity/weekly/report/service/WeeklyReportServiceTest.kt
+++ b/src/test/kotlin/com/pluxity/weekly/report/service/WeeklyReportServiceTest.kt
@@ -1,0 +1,265 @@
+package com.pluxity.weekly.report.service
+
+import com.pluxity.weekly.auth.authorization.AuthorizationService
+import com.pluxity.weekly.core.constant.ErrorCode
+import com.pluxity.weekly.core.exception.CustomException
+import com.pluxity.weekly.report.entity.dummyWeeklyReport
+import com.pluxity.weekly.report.repository.WeeklyReportRepository
+import com.pluxity.weekly.report.repository.WeeklyReportSummaryRow
+import com.pluxity.weekly.team.entity.dummyTeam
+import com.pluxity.weekly.team.repository.TeamRepository
+import com.pluxity.weekly.test.entity.dummyUser
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.runs
+import org.springframework.data.repository.findByIdOrNull
+import java.time.LocalDate
+import java.time.LocalDateTime
+
+class WeeklyReportServiceTest :
+    BehaviorSpec({
+
+        val weeklyReportRepository: WeeklyReportRepository = mockk()
+        val teamRepository: TeamRepository = mockk()
+        val authorizationService: AuthorizationService = mockk()
+        val service = WeeklyReportService(weeklyReportRepository, teamRepository, authorizationService)
+
+        val adminUser = dummyUser(id = 1L, name = "관리자")
+        val leaderUser = dummyUser(id = 2L, name = "리더")
+        val workerUser = dummyUser(id = 3L, name = "워커")
+        val team10 = dummyTeam(id = 10L, name = "개발팀", leaderId = 2L)
+        val team20 = dummyTeam(id = 20L, name = "디자인팀", leaderId = 99L)
+
+        Given("findAll - ADMIN") {
+            every { authorizationService.currentUser() } returns adminUser
+            every { authorizationService.requireAdminOrLeader(adminUser) } just runs
+            every { authorizationService.visibleTeamIds(adminUser) } returns null
+
+            When("teamId 없이 조회하면") {
+                every {
+                    weeklyReportRepository.findByFilter(
+                        match { it.teamId == null && it.teamIds == null },
+                    )
+                } returns listOf(dummyWeeklyReport(id = 1L, team = team10))
+
+                val result = service.findAll(null, null, null)
+
+                Then("teamId/teamIds 제약 없이 조회된다") {
+                    result.size shouldBe 1
+                    result[0].id shouldBe 1L
+                }
+            }
+
+            When("teamId를 지정하면") {
+                every { authorizationService.requireTeamAccess(adminUser, 10L) } just runs
+                every {
+                    weeklyReportRepository.findByFilter(
+                        match { it.teamId == 10L && it.teamIds == null },
+                    )
+                } returns listOf(dummyWeeklyReport(id = 1L, team = team10))
+
+                val result = service.findAll(10L, null, null)
+
+                Then("해당 팀 보고만 조회된다") {
+                    result.size shouldBe 1
+                    result[0].teamId shouldBe 10L
+                }
+            }
+        }
+
+        Given("findAll - Leader") {
+            every { authorizationService.currentUser() } returns leaderUser
+            every { authorizationService.requireAdminOrLeader(leaderUser) } just runs
+            every { authorizationService.visibleTeamIds(leaderUser) } returns listOf(10L)
+
+            When("teamId 없이 조회하면") {
+                every {
+                    weeklyReportRepository.findByFilter(
+                        match { it.teamId == null && it.teamIds == listOf(10L) },
+                    )
+                } returns listOf(dummyWeeklyReport(id = 1L, team = team10))
+
+                val result = service.findAll(null, null, null)
+
+                Then("본인이 leader인 팀들로 제한된다") {
+                    result.size shouldBe 1
+                    result[0].teamId shouldBe 10L
+                }
+            }
+
+            When("본인이 leader인 팀의 teamId를 지정하면") {
+                every { authorizationService.requireTeamAccess(leaderUser, 10L) } just runs
+                every {
+                    weeklyReportRepository.findByFilter(
+                        match { it.teamId == 10L },
+                    )
+                } returns listOf(dummyWeeklyReport(id = 1L, team = team10))
+
+                val result = service.findAll(10L, null, null)
+
+                Then("해당 팀 보고가 조회된다") {
+                    result.size shouldBe 1
+                }
+            }
+
+            When("본인이 leader가 아닌 teamId를 지정하면") {
+                every { authorizationService.requireTeamAccess(leaderUser, 20L) } throws
+                    CustomException(ErrorCode.PERMISSION_DENIED)
+
+                val exception =
+                    shouldThrow<CustomException> {
+                        service.findAll(20L, null, null)
+                    }
+
+                Then("PERMISSION_DENIED 예외가 발생한다") {
+                    exception.code shouldBe ErrorCode.PERMISSION_DENIED
+                }
+            }
+        }
+
+        Given("findAll - 권한 없는 사용자") {
+            When("ADMIN/Leader가 아닌 사용자가 호출하면") {
+                every { authorizationService.currentUser() } returns workerUser
+                every { authorizationService.requireAdminOrLeader(workerUser) } throws
+                    CustomException(ErrorCode.PERMISSION_DENIED)
+
+                val exception =
+                    shouldThrow<CustomException> {
+                        service.findAll(null, null, null)
+                    }
+
+                Then("PERMISSION_DENIED 예외가 발생한다") {
+                    exception.code shouldBe ErrorCode.PERMISSION_DENIED
+                }
+            }
+        }
+
+        Given("findById") {
+            every { authorizationService.currentUser() } returns leaderUser
+
+            When("존재하는 보고를 본인 팀으로 조회하면") {
+                val report = dummyWeeklyReport(id = 1L, team = team10)
+                every { weeklyReportRepository.findByIdOrNull(1L) } returns report
+                every { authorizationService.requireTeamAccess(leaderUser, 10L) } just runs
+
+                val result = service.findById(1L)
+
+                Then("보고가 반환된다") {
+                    result.id shouldBe 1L
+                    result.teamId shouldBe 10L
+                }
+            }
+
+            When("존재하지 않는 보고를 조회하면") {
+                every { weeklyReportRepository.findByIdOrNull(999L) } returns null
+
+                val exception =
+                    shouldThrow<CustomException> {
+                        service.findById(999L)
+                    }
+
+                Then("NOT_FOUND_WEEKLY_REPORT 예외가 발생한다") {
+                    exception.code shouldBe ErrorCode.NOT_FOUND_WEEKLY_REPORT
+                }
+            }
+
+            When("본인이 leader가 아닌 팀의 보고를 조회하면") {
+                val report = dummyWeeklyReport(id = 2L, team = team20)
+                every { weeklyReportRepository.findByIdOrNull(2L) } returns report
+                every { authorizationService.requireTeamAccess(leaderUser, 20L) } throws
+                    CustomException(ErrorCode.PERMISSION_DENIED)
+
+                val exception =
+                    shouldThrow<CustomException> {
+                        service.findById(2L)
+                    }
+
+                Then("PERMISSION_DENIED 예외가 발생한다") {
+                    exception.code shouldBe ErrorCode.PERMISSION_DENIED
+                }
+            }
+        }
+
+        Given("findSummary") {
+            val weekStart = LocalDate.of(2026, 5, 11)
+            val weekEnd = LocalDate.of(2026, 5, 18) // 5/11 + 5/18 = 2주
+
+            When("ADMIN이 조회하면") {
+                every { authorizationService.currentUser() } returns adminUser
+                every { authorizationService.requireAdminOrLeader(adminUser) } just runs
+                every { authorizationService.visibleTeamIds(adminUser) } returns null
+                every { teamRepository.findAll() } returns listOf(team10, team20)
+                every { weeklyReportRepository.findSummaryRows(weekStart, weekEnd) } returns emptyList()
+
+                val result = service.findSummary(weekStart, weekEnd)
+
+                Then("모든 팀 × 모든 주차 슬롯이 반환된다 (2팀 × 2주 = 4)") {
+                    result.size shouldBe 4
+                    result.all { !it.exists } shouldBe true
+                }
+            }
+
+            When("Leader가 조회하면") {
+                every { authorizationService.currentUser() } returns leaderUser
+                every { authorizationService.requireAdminOrLeader(leaderUser) } just runs
+                every { authorizationService.visibleTeamIds(leaderUser) } returns listOf(10L)
+                every { teamRepository.findAllById(listOf(10L)) } returns listOf(team10)
+                every { weeklyReportRepository.findSummaryRows(weekStart, weekEnd) } returns emptyList()
+
+                val result = service.findSummary(weekStart, weekEnd)
+
+                Then("본인 팀 × 주차 슬롯만 반환된다 (1팀 × 2주 = 2)") {
+                    result.size shouldBe 2
+                    result.all { it.teamId == 10L } shouldBe true
+                }
+            }
+
+            When("실제 row가 일부 존재하면") {
+                every { authorizationService.currentUser() } returns leaderUser
+                every { authorizationService.requireAdminOrLeader(leaderUser) } just runs
+                every { authorizationService.visibleTeamIds(leaderUser) } returns listOf(10L)
+                every { teamRepository.findAllById(listOf(10L)) } returns listOf(team10)
+                val row =
+                    mockk<WeeklyReportSummaryRow>().apply {
+                        every { teamId } returns 10L
+                        every { this@apply.weekStart } returns LocalDate.of(2026, 5, 11)
+                        every { createdAt } returns LocalDateTime.of(2026, 5, 11, 10, 0)
+                        every { createdBy } returns "leader1"
+                    }
+                every { weeklyReportRepository.findSummaryRows(weekStart, weekEnd) } returns listOf(row)
+
+                val result = service.findSummary(weekStart, weekEnd)
+
+                Then("해당 슬롯만 exists=true") {
+                    result.size shouldBe 2
+                    result.first { it.weekStart == LocalDate.of(2026, 5, 11) }.exists shouldBe true
+                    result.first { it.weekStart == LocalDate.of(2026, 5, 18) }.exists shouldBe false
+                }
+
+                Then("exists=true 슬롯은 audit 정보를 가진다") {
+                    val existing = result.first { it.exists }
+                    existing.createdBy shouldBe "leader1"
+                    existing.createdAt shouldBe LocalDateTime.of(2026, 5, 11, 10, 0)
+                }
+            }
+
+            When("권한 없는 사용자가 호출하면") {
+                every { authorizationService.currentUser() } returns workerUser
+                every { authorizationService.requireAdminOrLeader(workerUser) } throws
+                    CustomException(ErrorCode.PERMISSION_DENIED)
+
+                val exception =
+                    shouldThrow<CustomException> {
+                        service.findSummary(weekStart, weekEnd)
+                    }
+
+                Then("PERMISSION_DENIED 예외가 발생한다") {
+                    exception.code shouldBe ErrorCode.PERMISSION_DENIED
+                }
+            }
+        }
+    })


### PR DESCRIPTION
  ## Summary
  - GET 엔드포인트 3종 (`/weekly-reports`, `/weekly-reports/{id}`, `/weekly-reports/summary`)
  풀세트
  - ADMIN/Leader 권한 체크 + 단위 테스트 (14개)

  closes #56