### PR TITLE
refactor: chat 도메인 정리 + LLM retry 안정성 개선

### DIFF
--- a/promptfoo/promptfooconfig.yaml
+++ b/promptfoo/promptfooconfig.yaml
@@ -46,7 +46,7 @@ tests:
     assert:
       - type: is-json
       - type: javascript
-        value: "JSON.parse(output).actions.includes('create') && JSON.parse(output).target === 'project'"
+        value: "JSON.parse(output).action === 'create' && JSON.parse(output).target === 'project'"
 
   - description: "[intent] 이름 포함 프로젝트 생성"
     vars:
@@ -57,7 +57,7 @@ tests:
       - type: javascript
         value: |
           const o = JSON.parse(output);
-          return o.actions.includes('create') && o.target === 'project' && o.name === 'PMS';
+          return o.action === 'create' && o.target === 'project' && o.name === 'PMS';
 
   - description: "[intent] 태스크 생성"
     vars:
@@ -66,7 +66,7 @@ tests:
     assert:
       - type: is-json
       - type: javascript
-        value: "JSON.parse(output).actions.includes('create') && JSON.parse(output).target === 'task'"
+        value: "JSON.parse(output).action === 'create' && JSON.parse(output).target === 'task'"
 
   - description: "[intent] 업무 그룹 생성"
     vars:
@@ -75,7 +75,7 @@ tests:
     assert:
       - type: is-json
       - type: javascript
-        value: "JSON.parse(output).actions.includes('create') && JSON.parse(output).target === 'epic'"
+        value: "JSON.parse(output).action === 'create' && JSON.parse(output).target === 'epic'"
 
   ## read
   - description: "[intent] 태스크 조회"
@@ -85,7 +85,7 @@ tests:
     assert:
       - type: is-json
       - type: javascript
-        value: "JSON.parse(output).actions.includes('read') && JSON.parse(output).target === 'task'"
+        value: "JSON.parse(output).action === 'read' && JSON.parse(output).target === 'task'"
 
   - description: "[intent] 리뷰 대기 조회"
     vars:
@@ -94,7 +94,7 @@ tests:
     assert:
       - type: is-json
       - type: javascript
-        value: "JSON.parse(output).actions.includes('read') && JSON.parse(output).target === 'review'"
+        value: "JSON.parse(output).action === 'read' && JSON.parse(output).target === 'review'"
 
   ## review_request
   - description: "[intent] 완료 → review_request"
@@ -104,7 +104,7 @@ tests:
     assert:
       - type: is-json
       - type: javascript
-        value: "JSON.parse(output).actions.includes('review_request') && JSON.parse(output).target === 'task'"
+        value: "JSON.parse(output).action === 'review_request' && JSON.parse(output).target === 'task'"
 
   - description: "[intent] 검수 요청"
     vars:
@@ -113,7 +113,7 @@ tests:
     assert:
       - type: is-json
       - type: javascript
-        value: "JSON.parse(output).actions.includes('review_request') && JSON.parse(output).target === 'task'"
+        value: "JSON.parse(output).action === 'review_request' && JSON.parse(output).target === 'task'"
 
   ## update
   - description: "[intent] 태스크 수정"
@@ -123,7 +123,7 @@ tests:
     assert:
       - type: is-json
       - type: javascript
-        value: "JSON.parse(output).actions.includes('update') && JSON.parse(output).target === 'task'"
+        value: "JSON.parse(output).action === 'update' && JSON.parse(output).target === 'task'"
 
   ## delete
   - description: "[intent] 프로젝트 삭제"
@@ -133,7 +133,7 @@ tests:
     assert:
       - type: is-json
       - type: javascript
-        value: "JSON.parse(output).actions.includes('delete') && JSON.parse(output).target === 'project'"
+        value: "JSON.parse(output).action === 'delete' && JSON.parse(output).target === 'project'"
 
   ## assign / unassign
   - description: "[intent] 업무 그룹 배정"
@@ -143,7 +143,7 @@ tests:
     assert:
       - type: is-json
       - type: javascript
-        value: "JSON.parse(output).actions.includes('assign') && JSON.parse(output).target === 'epic'"
+        value: "JSON.parse(output).action === 'assign' && JSON.parse(output).target === 'epic'"
 
   - description: "[intent] 업무 그룹 배정 해제"
     vars:
@@ -152,7 +152,7 @@ tests:
     assert:
       - type: is-json
       - type: javascript
-        value: "JSON.parse(output).actions.includes('unassign') && JSON.parse(output).target === 'epic'"
+        value: "JSON.parse(output).action === 'unassign' && JSON.parse(output).target === 'epic'"
 
   ## review_request - 다른 트리거 워드
   - description: "[intent] 끝냈어 → review_request"
@@ -162,7 +162,7 @@ tests:
     assert:
       - type: is-json
       - type: javascript
-        value: "JSON.parse(output).actions.includes('review_request') && JSON.parse(output).target === 'task'"
+        value: "JSON.parse(output).action === 'review_request' && JSON.parse(output).target === 'task'"
 
   - description: "[intent] 다 했어 → review_request"
     vars:
@@ -171,7 +171,7 @@ tests:
     assert:
       - type: is-json
       - type: javascript
-        value: "JSON.parse(output).actions.includes('review_request') && JSON.parse(output).target === 'task'"
+        value: "JSON.parse(output).action === 'review_request' && JSON.parse(output).target === 'task'"
 
   ## create with hint
   - description: "[intent] 업무 그룹에 태스크 추가 → create + hint"
@@ -183,7 +183,7 @@ tests:
       - type: javascript
         value: |
           const o = JSON.parse(output);
-          return o.actions.includes('create') && o.target === 'task' && o.epic === '백엔드';
+          return o.action === 'create' && o.target === 'task' && o.epic === '백엔드';
 
   ## clarify
   - description: "[intent] 모호한 입력 → clarify"
@@ -193,7 +193,7 @@ tests:
     assert:
       - type: is-json
       - type: javascript
-        value: "JSON.parse(output).actions.includes('clarify')"
+        value: "JSON.parse(output).action === 'clarify'"
 
   ## team
   - description: "[intent] 팀 조회"
@@ -203,7 +203,7 @@ tests:
     assert:
       - type: is-json
       - type: javascript
-        value: "JSON.parse(output).actions.includes('read') && JSON.parse(output).target === 'team'"
+        value: "JSON.parse(output).action === 'read' && JSON.parse(output).target === 'team'"
 
   # ──────────────────────────────────────
   # intent-prompt history tests
@@ -213,53 +213,53 @@ tests:
   - description: "[intent-history] 아까 만든거 수정 → update + id 참조"
     vars:
       userMessage: "아까 만든거 마감일을 금요일로"
-      history: "--- 히스토리 #1 | 질문: 로그인 태스크 만들어줘 | target: task | actions: [create] | 결과: create task id=13 ---"
+      history: "--- 히스토리 #1 | 질문: 로그인 태스크 만들어줘 | target: task | action: create | 결과: create task id=13 ---"
     prompts: [intent]
     assert:
       - type: is-json
       - type: javascript
         value: |
           const o = JSON.parse(output);
-          return o.actions.includes('update') && o.target === 'task' && o.id === 13;
+          return o.action === 'update' && o.target === 'task' && o.id === 13;
 
   ## 히스토리 참조 - 이전 create 결과의 id를 이어받아 delete
   - description: "[intent-history] 그거 삭제 → delete + id 참조"
     vars:
       userMessage: "그거 삭제해줘"
-      history: "--- 히스토리 #1 | 질문: 로그인 태스크 만들어줘 | target: task | actions: [create] | 결과: create task id=13 ---"
+      history: "--- 히스토리 #1 | 질문: 로그인 태스크 만들어줘 | target: task | action: create | 결과: create task id=13 ---"
     prompts: [intent]
     assert:
       - type: is-json
       - type: javascript
         value: |
           const o = JSON.parse(output);
-          return o.actions.includes('delete') && o.target === 'task' && o.id === 13;
+          return o.action === 'delete' && o.target === 'task' && o.id === 13;
 
   ## 히스토리 참조 - read 결과에서 target 이어받기
   - description: "[intent-history] 그중에 진행중인 것만 → read + target 이어받기"
     vars:
       userMessage: "그중에 진행중인 것만"
-      history: "--- 히스토리 #1 | 질문: 내 태스크 보여줘 | target: task | actions: [read] | 결과: read task 5건 ---"
+      history: "--- 히스토리 #1 | 질문: 내 태스크 보여줘 | target: task | action: read | 결과: read task 5건 ---"
     prompts: [intent]
     assert:
       - type: is-json
       - type: javascript
         value: |
           const o = JSON.parse(output);
-          return o.actions.includes('read') && o.target === 'task';
+          return o.action === 'read' && o.target === 'task';
 
   ## 히스토리 참조 - 업무 그룹 read 후 태스크 create
   - description: "[intent-history] 거기에 태스크 추가 → create task + epic hint"
     vars:
       userMessage: "거기에 태스크 추가해줘"
-      history: "--- 히스토리 #1 | 질문: 백엔드 업무 그룹 보여줘 | target: epic | actions: [read] | 결과: read epic 3건 ---"
+      history: "--- 히스토리 #1 | 질문: 백엔드 업무 그룹 보여줘 | target: epic | action: read | 결과: read epic 3건 ---"
     prompts: [intent]
     assert:
       - type: is-json
       - type: javascript
         value: |
           const o = JSON.parse(output);
-          return o.actions.includes('create') && o.target === 'task';
+          return o.action === 'create' && o.target === 'task';
 
   # ──────────────────────────────────────
   # system-prompt tests (fixture: 스마트팩토리/모바일POS/사내포털)
@@ -269,7 +269,7 @@ tests:
   - description: "[system] MQTT 브로커 설정 완료 → review_request id=1001"
     vars:
       userMessage: "MQTT 브로커 설정 완료"
-      intent: '{"actions":["review_request"],"target":"task"}'
+      intent: '{"action":"review_request","target":"task"}'
     prompts: [system]
     assert:
       - type: is-json
@@ -283,7 +283,7 @@ tests:
   - description: "[system] 리포트 생성 완료 → missing_fields (동명)"
     vars:
       userMessage: "리포트 생성 완료"
-      intent: '{"actions":["review_request"],"target":"task"}'
+      intent: '{"action":"review_request","target":"task"}'
     prompts: [system]
     assert:
       - type: is-json
@@ -298,7 +298,7 @@ tests:
   - description: "[system] 내 태스크 조회 → assignee_id=3"
     vars:
       userMessage: "내 태스크 보여줘"
-      intent: '{"actions":["read"],"target":"task"}'
+      intent: '{"action":"read","target":"task"}'
     prompts: [system]
     assert:
       - type: is-json
@@ -312,7 +312,7 @@ tests:
   - description: "[system] 리뷰할거 → read review"
     vars:
       userMessage: "리뷰할거 보여줘"
-      intent: '{"actions":["read"],"target":"review"}'
+      intent: '{"action":"read","target":"review"}'
     prompts: [system]
     assert:
       - type: is-json
@@ -326,7 +326,7 @@ tests:
   - description: "[system] 결제 모듈에 태스크 추가 → epic_id=201"
     vars:
       userMessage: "결제 모듈에 PG사 연동 추가해줘"
-      intent: '{"actions":["create"],"target":"task","epic":"결제 모듈","name":"PG사 연동"}'
+      intent: '{"action":"create","target":"task","epic":"결제 모듈","name":"PG사 연동"}'
     prompts: [system]
     assert:
       - type: is-json
@@ -340,7 +340,7 @@ tests:
   - description: "[system] 카드 결제 연동 90% → update id=2001"
     vars:
       userMessage: "카드 결제 연동 90%"
-      intent: '{"actions":["update"],"target":"task"}'
+      intent: '{"action":"update","target":"task"}'
     prompts: [system]
     assert:
       - type: is-json
@@ -354,7 +354,7 @@ tests:
   - description: "[system] 바코드 생성 삭제 → delete id=2009"
     vars:
       userMessage: "바코드 생성 삭제해줘"
-      intent: '{"actions":["delete"],"target":"task"}'
+      intent: '{"action":"delete","target":"task"}'
     prompts: [system]
     assert:
       - type: is-json
@@ -368,7 +368,7 @@ tests:
   - description: "[system] 태스크 수정해줘 → missing_fields"
     vars:
       userMessage: "태스크 수정해줘"
-      intent: '{"actions":["update"],"target":"task"}'
+      intent: '{"action":"update","target":"task"}'
     prompts: [system]
     assert:
       - type: is-json
@@ -382,7 +382,7 @@ tests:
   - description: "[system] 센서 연동 업무 그룹에 김민지 할당 → assign"
     vars:
       userMessage: "센서 연동 업무 그룹에 김민지 할당해줘"
-      intent: '{"actions":["assign"],"target":"epic"}'
+      intent: '{"action":"assign","target":"epic"}'
     prompts: [system]
     assert:
       - type: is-json
@@ -396,7 +396,7 @@ tests:
   - description: "[system] 업무 그룹 만들어줘 → create, name 없음"
     vars:
       userMessage: "업무 그룹 만들어줘"
-      intent: '{"actions":["create"],"target":"epic"}'
+      intent: '{"action":"create","target":"epic"}'
     prompts: [system]
     assert:
       - type: is-json
@@ -410,7 +410,7 @@ tests:
   - description: "[system] 대시보드에 태스크 추가 → epic_id는 102 또는 202"
     vars:
       userMessage: "대시보드에 태스크 추가해줘"
-      intent: '{"actions":["create"],"target":"task","epic":"대시보드"}'
+      intent: '{"action":"create","target":"task","epic":"대시보드"}'
     prompts: [system]
     assert:
       - type: is-json
@@ -424,7 +424,7 @@ tests:
   - description: "[system] 데이터 파싱 모듈 마감일 4월 25일 → date"
     vars:
       userMessage: "데이터 파싱 모듈 마감일 4월 25일로 변경"
-      intent: '{"actions":["update"],"target":"task"}'
+      intent: '{"action":"update","target":"task"}'
     prompts: [system]
     assert:
       - type: is-json
@@ -438,7 +438,7 @@ tests:
   - description: "[system] 영수증 출력 시작 → IN_PROGRESS, progress=10"
     vars:
       userMessage: "영수증 출력 시작"
-      intent: '{"actions":["update"],"target":"task"}'
+      intent: '{"action":"update","target":"task"}'
     prompts: [system]
     assert:
       - type: is-json
@@ -452,7 +452,7 @@ tests:
   - description: "[system] 리뷰 요청해줘 → missing_fields"
     vars:
       userMessage: "리뷰 요청해줘"
-      intent: '{"actions":["review_request"],"target":"task"}'
+      intent: '{"action":"review_request","target":"task"}'
     prompts: [system]
     assert:
       - type: is-json
@@ -466,7 +466,7 @@ tests:
   - description: "[system] 스마트팩토리 진행중인 태스크 → filters"
     vars:
       userMessage: "스마트팩토리 진행중인 태스크 보여줘"
-      intent: '{"actions":["read"],"target":"task"}'
+      intent: '{"action":"read","target":"task"}'
     prompts: [system]
     assert:
       - type: is-json
@@ -480,7 +480,7 @@ tests:
   - description: "[system] 모바일 POS에 배송 업무 그룹 추가 → project_id=2"
     vars:
       userMessage: "모바일 POS에 배송 업무 그룹 추가해줘"
-      intent: '{"actions":["create"],"target":"epic","project":"모바일 POS","name":"배송"}'
+      intent: '{"action":"create","target":"epic","project":"모바일 POS","name":"배송"}'
     prompts: [system]
     assert:
       - type: is-json
@@ -494,7 +494,7 @@ tests:
   - description: "[system] CONTEXT에 없는 항목 → clarify"
     vars:
       userMessage: "잠자기 완료"
-      intent: '{"actions":["review_request"],"target":"task"}'
+      intent: '{"action":"review_request","target":"task"}'
     prompts: [system]
     assert:
       - type: is-json
@@ -508,7 +508,7 @@ tests:
   - description: "[system] 복수 미확정 → missing_fields는 id 1개만"
     vars:
       userMessage: "대시보드 업무 그룹에 할당해줘"
-      intent: '{"actions":["assign"],"target":"epic"}'
+      intent: '{"action":"assign","target":"epic"}'
     prompts: [system]
     assert:
       - type: is-json
@@ -531,7 +531,7 @@ tests:
     vars:
       contextFile: context-task-create.json
       userMessage: "센서 연동에 알람 규칙 추가, 담당자 김민지"
-      intent: '{"actions":["create"],"target":"task","epic":"센서 연동","name":"알람 규칙"}'
+      intent: '{"action":"create","target":"task","epic":"센서 연동","name":"알람 규칙"}'
     prompts: [system]
     assert:
       - type: is-json
@@ -547,7 +547,7 @@ tests:
     vars:
       contextFile: context-task-create.json
       userMessage: "센서 연동에 알람 규칙 추가"
-      intent: '{"actions":["create"],"target":"task","epic":"센서 연동","name":"알람 규칙"}'
+      intent: '{"action":"create","target":"task","epic":"센서 연동","name":"알람 규칙"}'
     prompts: [system]
     assert:
       - type: is-json
@@ -562,7 +562,7 @@ tests:
     vars:
       contextFile: context-task-create.json
       userMessage: "결제 모듈에 환불 처리 추가, 담당자 김민지"
-      intent: '{"actions":["create"],"target":"task","epic":"결제 모듈","name":"환불 처리"}'
+      intent: '{"action":"create","target":"task","epic":"결제 모듈","name":"환불 처리"}'
     prompts: [system]
     assert:
       - type: is-json
@@ -577,7 +577,7 @@ tests:
     vars:
       contextFile: context-task-create.json
       userMessage: "센서 연동에 API 설계 추가, 담당자 박서준"
-      intent: '{"actions":["create"],"target":"task","epic":"센서 연동","name":"API 설계"}'
+      intent: '{"action":"create","target":"task","epic":"센서 연동","name":"API 설계"}'
     prompts: [system]
     assert:
       - type: is-json
@@ -592,7 +592,7 @@ tests:
     vars:
       contextFile: context-task-create.json
       userMessage: "API 설계 만들어줘, 담당자 최우석"
-      intent: '{"actions":["create"],"target":"task","name":"API 설계"}'
+      intent: '{"action":"create","target":"task","name":"API 설계"}'
     prompts: [system]
     assert:
       - type: is-json
@@ -601,4 +601,3 @@ tests:
           const arr = JSON.parse(output);
           const o = arr[0];
           return o.action === 'create' && o.target === 'task' && o.assignee_id === 7;
-

--- a/src/main/kotlin/com/pluxity/weekly/auth/authorization/AuthorizationService.kt
+++ b/src/main/kotlin/com/pluxity/weekly/auth/authorization/AuthorizationService.kt
@@ -135,13 +135,12 @@ class AuthorizationService(
     fun checkChatPermission(
         user: User,
         target: ChatTarget,
-        actions: List<ChatActionType>,
+        action: ChatActionType?,
     ) {
-        val hasMutation = actions.any { it.isMutating }
-        if (!hasMutation) return
+        if (action?.isMutating != true) return
 
         when (target) {
-            ChatTarget.PROJECT -> if (ChatActionType.CREATE in actions) requireAdmin(user) else requireAdminOrPm(user)
+            ChatTarget.PROJECT -> if (action == ChatActionType.CREATE) requireAdmin(user) else requireAdminOrPm(user)
             ChatTarget.EPIC -> requireAdminOrPm(user)
             else -> Unit
         }

--- a/src/main/kotlin/com/pluxity/weekly/auth/user/entity/User.kt
+++ b/src/main/kotlin/com/pluxity/weekly/auth/user/entity/User.kt
@@ -50,7 +50,7 @@ class User(
     }
 
     fun addRoles(roles: List<Role>) {
-        val duplicateRoles = roles.filter { this.hasRole(it) }
+        val duplicateRoles = roles.filter { role -> userRoles.any { it.role.id == role.id } }
 
         if (duplicateRoles.isNotEmpty()) {
             val duplicateNames = duplicateRoles.joinToString(", ") { it.name }
@@ -61,7 +61,7 @@ class User(
     }
 
     fun addRole(role: Role) {
-        if (hasRole(role)) throw CustomException(ErrorCode.DUPLICATE_ROLE, role.name)
+        if (userRoles.any { it.role.id == role.id }) throw CustomException(ErrorCode.DUPLICATE_ROLE, role.name)
         val userRole = UserRole(user = this, role = role)
         this.userRoles.add(userRole)
     }
@@ -88,8 +88,6 @@ class User(
     }
 
     fun getRoles(): List<Role> = userRoles.map { it.role }
-
-    fun hasRole(role: Role): Boolean = userRoles.any { it.role.id == role.id }
 
     fun changeName(name: String) {
         this.name = name

--- a/src/main/kotlin/com/pluxity/weekly/chat/context/ContextBuilder.kt
+++ b/src/main/kotlin/com/pluxity/weekly/chat/context/ContextBuilder.kt
@@ -52,25 +52,25 @@ class ContextBuilder(
 ) {
     fun build(
         target: ChatTarget,
-        actions: List<ChatActionType>,
+        action: ChatActionType?,
     ): String {
         val user = authorizationService.currentUser()
 
-        authorizationService.checkChatPermission(user, target, actions)
+        authorizationService.checkChatPermission(user, target, action)
 
         val today = LocalDate.now().toString()
         val todayDayOfWeek = LocalDate.now().dayOfWeek.getDisplayName(TextStyle.FULL, Locale.KOREAN)
         val userRef = UserRef(id = user.requiredId, name = user.name)
 
-        val hasCreateOnly = ChatActionType.CREATE in actions && ChatActionType.UPDATE !in actions
-        val excludeDone = ChatActionType.UPDATE in actions || ChatActionType.DELETE in actions
+        val isCreate = action == ChatActionType.CREATE
+        val excludeDone = action == ChatActionType.UPDATE || action == ChatActionType.DELETE
 
         val context: ChatContext =
             when (target) {
                 ChatTarget.PROJECT -> buildProjectContext(today, todayDayOfWeek, userRef, excludeDone)
                 ChatTarget.EPIC -> buildEpicContext(today, todayDayOfWeek, userRef, excludeDone)
                 ChatTarget.TEAM -> buildTeamContext(today, todayDayOfWeek, userRef)
-                ChatTarget.TASK, ChatTarget.REVIEW -> buildTaskContext(today, todayDayOfWeek, userRef, hasCreateOnly, excludeDone)
+                ChatTarget.TASK, ChatTarget.REVIEW -> buildTaskContext(today, todayDayOfWeek, userRef, isCreate, excludeDone)
                 ChatTarget.WEEKLY_REPORT -> buildWeeklyReportContext(today, todayDayOfWeek, userRef, user)
             }
 

--- a/src/main/kotlin/com/pluxity/weekly/chat/llm/LlmService.kt
+++ b/src/main/kotlin/com/pluxity/weekly/chat/llm/LlmService.kt
@@ -81,6 +81,9 @@ class LlmService(
             } catch (e: Exception) {
                 lastException = e
                 log.warn { "Intent 추출 실패 (시도 ${attempt + 1}/$MAX_RETRIES): ${e.message}" }
+                if (attempt < MAX_RETRIES - 1) {
+                    Thread.sleep(retryBackoffMs(attempt))
+                }
             }
         }
         log.error(lastException) { "Intent 추출 $MAX_RETRIES 회 재시도 실패" }
@@ -320,6 +323,10 @@ class LlmService(
 
     companion object {
         private const val MAX_RETRIES = 3
+        private const val INITIAL_BACKOFF_MS = 1000L
+
+        // 1s, 2s, 4s 지수 증가
+        private fun retryBackoffMs(attempt: Int): Long = INITIAL_BACKOFF_MS shl attempt
 
         fun stripCodeFence(raw: String): String {
             val trimmed = raw.trim()

--- a/src/main/kotlin/com/pluxity/weekly/chat/llm/dto/IntentResult.kt
+++ b/src/main/kotlin/com/pluxity/weekly/chat/llm/dto/IntentResult.kt
@@ -1,7 +1,7 @@
 package com.pluxity.weekly.chat.llm.dto
 
 data class IntentResult(
-    val actions: List<String>,
+    val action: String? = null,
     val target: String? = null,
     val id: Long? = null,
     val project: String? = null,

--- a/src/main/kotlin/com/pluxity/weekly/chat/llm/dto/IntentResult.kt
+++ b/src/main/kotlin/com/pluxity/weekly/chat/llm/dto/IntentResult.kt
@@ -2,7 +2,7 @@ package com.pluxity.weekly.chat.llm.dto
 
 data class IntentResult(
     val actions: List<String>,
-    val target: String,
+    val target: String? = null,
     val id: Long? = null,
     val project: String? = null,
     val epic: String? = null,

--- a/src/main/kotlin/com/pluxity/weekly/chat/service/ChatHistoryStore.kt
+++ b/src/main/kotlin/com/pluxity/weekly/chat/service/ChatHistoryStore.kt
@@ -58,7 +58,7 @@ class ChatHistoryStore(
         userId: String,
         message: String,
         target: String,
-        actions: List<String>,
+        action: String?,
         responses: List<ChatActionResponse>,
     ) {
         val summary = buildActionSummary(responses)
@@ -66,7 +66,7 @@ class ChatHistoryStore(
         save(
             userId,
             "system",
-            "--- 히스토리 #$turnNumber | 질문: $message | target: $target | actions: $actions | 결과: $summary ---",
+            "--- 히스토리 #$turnNumber | 질문: $message | target: $target | action: ${action ?: "-"} | 결과: $summary ---",
         )
     }
 
@@ -81,7 +81,7 @@ class ChatHistoryStore(
         save(
             userId,
             "system",
-            "--- 히스토리 #$turnNumber | resolved | target: ${target ?: "-"} | actions: [$action] | 결과: $summary ---",
+            "--- 히스토리 #$turnNumber | resolved | target: ${target ?: "-"} | action: $action | 결과: $summary ---",
         )
     }
 

--- a/src/main/kotlin/com/pluxity/weekly/chat/service/ChatService.kt
+++ b/src/main/kotlin/com/pluxity/weekly/chat/service/ChatService.kt
@@ -69,12 +69,12 @@ class ChatService(
         // 1차: 의도 추출 (히스토리 포함)
         val intentMessages = promptBuilder.buildIntentMessages(message, history)
         val intent = llmService.extractIntent(intentMessages)
-        log.info { "1차 의도 추출 - action: ${intent.actions}, target: ${intent.target}, id: ${intent.id}, response: $intent" }
+        log.info { "1차 의도 추출 - action: ${intent.action}, target: ${intent.target}, id: ${intent.id}, response: $intent" }
 
         // target별+action별+권한별 context 조회
         val targetType = ChatTarget.fromOrNull(intent.target) ?: ChatTarget.TASK
-        val actionTypes = intent.actions.mapNotNull { ChatActionType.fromOrNull(it) }
-        val context = contextBuilder.build(targetType, actionTypes)
+        val actionType = ChatActionType.fromOrNull(intent.action)
+        val context = contextBuilder.build(targetType, actionType)
         log.info { "context:\n${objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(objectMapper.readTree(context))}" }
 
         // weekly_report는 일반 LlmAction 흐름을 우회하고 별도 핸들러로
@@ -92,7 +92,7 @@ class ChatService(
             }
 
         if (targetType != ChatTarget.WEEKLY_REPORT) {
-            chatHistoryStore.recordChatTurn(userId, message, targetType.key, actionTypes.map { it.key }, responses)
+            chatHistoryStore.recordChatTurn(userId, message, targetType.key, actionType?.key, responses)
         }
         return responses
     }

--- a/src/main/kotlin/com/pluxity/weekly/chat/service/ChatService.kt
+++ b/src/main/kotlin/com/pluxity/weekly/chat/service/ChatService.kt
@@ -92,7 +92,7 @@ class ChatService(
             }
 
         if (targetType != ChatTarget.WEEKLY_REPORT) {
-            chatHistoryStore.recordChatTurn(userId, message, intent.target, intent.actions, responses)
+            chatHistoryStore.recordChatTurn(userId, message, targetType.key, actionTypes.map { it.key }, responses)
         }
         return responses
     }

--- a/src/main/kotlin/com/pluxity/weekly/chat/service/SelectFieldResolver.kt
+++ b/src/main/kotlin/com/pluxity/weekly/chat/service/SelectFieldResolver.kt
@@ -8,11 +8,14 @@ import com.pluxity.weekly.chat.dto.ChatActionType
 import com.pluxity.weekly.chat.dto.ChatTarget
 import com.pluxity.weekly.chat.dto.LlmAction
 import com.pluxity.weekly.chat.dto.SelectField
+import com.pluxity.weekly.epic.entity.EpicStatus
 import com.pluxity.weekly.epic.repository.EpicRepository
 import com.pluxity.weekly.epic.service.EpicAssignmentService
 import com.pluxity.weekly.epic.service.EpicService
+import com.pluxity.weekly.project.entity.ProjectStatus
 import com.pluxity.weekly.project.repository.ProjectRepository
 import com.pluxity.weekly.project.service.ProjectService
+import com.pluxity.weekly.task.entity.TaskStatus
 import com.pluxity.weekly.task.repository.TaskRepository
 import org.springframework.data.domain.Sort
 import org.springframework.stereotype.Component
@@ -153,23 +156,46 @@ class SelectFieldResolver(
         return SelectField(field = "assigneeId", groups = groups)
     }
 
-    private fun resolveStatusCandidates(target: ChatTarget): SelectField {
-        val statuses =
+    private fun resolveStatusCandidates(
+        target: ChatTarget,
+        actionType: ChatActionType,
+    ): SelectField {
+        val names: List<String> =
             when (target) {
-                ChatTarget.PROJECT, ChatTarget.EPIC -> listOf("TODO", "IN_PROGRESS", "DONE")
-                else -> listOf("TODO", "IN_PROGRESS")
+                ChatTarget.PROJECT -> projectStatuses(actionType)
+                ChatTarget.EPIC -> epicStatuses(actionType)
+                ChatTarget.TASK -> taskStatuses(actionType)
+                else -> emptyList()
             }
-        return SelectField(
-            field = "status",
-            candidates = statuses.map { Candidate(it, it) },
-        )
+        return SelectField(field = "status", candidates = names.map { Candidate(it, it) })
     }
+
+    private fun projectStatuses(actionType: ChatActionType): List<String> =
+        when (actionType) {
+            ChatActionType.CREATE -> ProjectStatus.initStates
+            ChatActionType.UPDATE -> ProjectStatus.transitionStates
+            else -> emptyList()
+        }.map { it.name }
+
+    private fun epicStatuses(actionType: ChatActionType): List<String> =
+        when (actionType) {
+            ChatActionType.CREATE -> EpicStatus.initStates
+            ChatActionType.UPDATE -> EpicStatus.transitionStates
+            else -> emptyList()
+        }.map { it.name }
+
+    private fun taskStatuses(actionType: ChatActionType): List<String> =
+        when (actionType) {
+            ChatActionType.CREATE -> TaskStatus.initStates
+            ChatActionType.UPDATE -> TaskStatus.transitionStates
+            else -> emptyList()
+        }.map { it.name }
 
     private fun addSelectFields(
         action: LlmAction,
         result: MutableList<SelectField>,
     ) {
-        val type = ChatActionType.fromOrNull(action.action)
+        val type = ChatActionType.fromOrNull(action.action) ?: return
         if (type != ChatActionType.CREATE && type != ChatActionType.UPDATE) return
 
         val existingFields = result.map { it.field }.toSet()
@@ -180,7 +206,7 @@ class SelectFieldResolver(
                     result.add(resolveUserCandidates("pmId", listOf("PM", "PO")))
                 }
                 if ("status" !in existingFields) {
-                    result.add(resolveStatusCandidates(ChatTarget.PROJECT))
+                    result.add(resolveStatusCandidates(ChatTarget.PROJECT, type))
                 }
             }
             ChatTarget.EPIC -> {
@@ -191,7 +217,7 @@ class SelectFieldResolver(
                     result.add(resolveUserCandidates("userIds"))
                 }
                 if ("status" !in existingFields) {
-                    result.add(resolveStatusCandidates(ChatTarget.EPIC))
+                    result.add(resolveStatusCandidates(ChatTarget.EPIC, type))
                 }
             }
             ChatTarget.TASK -> {
@@ -202,7 +228,7 @@ class SelectFieldResolver(
                     resolveTaskAssigneeCandidates()?.let { result.add(it) }
                 }
                 if ("status" !in existingFields) {
-                    result.add(resolveStatusCandidates(ChatTarget.TASK))
+                    result.add(resolveStatusCandidates(ChatTarget.TASK, type))
                 }
             }
             ChatTarget.TEAM, ChatTarget.REVIEW, ChatTarget.WEEKLY_REPORT, null -> Unit

--- a/src/main/kotlin/com/pluxity/weekly/epic/entity/EpicStatus.kt
+++ b/src/main/kotlin/com/pluxity/weekly/epic/entity/EpicStatus.kt
@@ -4,4 +4,11 @@ enum class EpicStatus {
     TODO,
     IN_PROGRESS,
     DONE,
+    ;
+
+    companion object {
+        val initStates: List<EpicStatus> = listOf(TODO, IN_PROGRESS)
+
+        val transitionStates: List<EpicStatus> = listOf(TODO, IN_PROGRESS, DONE)
+    }
 }

--- a/src/main/kotlin/com/pluxity/weekly/epic/service/EpicService.kt
+++ b/src/main/kotlin/com/pluxity/weekly/epic/service/EpicService.kt
@@ -44,7 +44,7 @@ class EpicService(
     fun create(request: EpicRequest): Long {
         val user = authorizationService.currentUser()
         authorizationService.requireEpicManage(user, request.projectId)
-        if (request.status == EpicStatus.DONE) {
+        if (request.status !in EpicStatus.initStates) {
             throw CustomException(ErrorCode.INVALID_INITIAL_STATUS, request.status)
         }
         val project = getProjectById(request.projectId)

--- a/src/main/kotlin/com/pluxity/weekly/project/entity/ProjectStatus.kt
+++ b/src/main/kotlin/com/pluxity/weekly/project/entity/ProjectStatus.kt
@@ -4,4 +4,11 @@ enum class ProjectStatus {
     TODO,
     IN_PROGRESS,
     DONE,
+    ;
+
+    companion object {
+        val initStates: List<ProjectStatus> = listOf(TODO, IN_PROGRESS)
+
+        val transitionStates: List<ProjectStatus> = listOf(TODO, IN_PROGRESS, DONE)
+    }
 }

--- a/src/main/kotlin/com/pluxity/weekly/project/service/ProjectService.kt
+++ b/src/main/kotlin/com/pluxity/weekly/project/service/ProjectService.kt
@@ -59,7 +59,7 @@ class ProjectService(
     fun create(request: ProjectRequest): Long {
         val user = authorizationService.currentUser()
         authorizationService.requireAdmin(user)
-        if (request.status == ProjectStatus.DONE) {
+        if (request.status !in ProjectStatus.initStates) {
             throw CustomException(ErrorCode.INVALID_INITIAL_STATUS, request.status)
         }
         request.pmId?.let { ensurePmExists(it) }

--- a/src/main/kotlin/com/pluxity/weekly/report/service/WeeklyReportChatHandler.kt
+++ b/src/main/kotlin/com/pluxity/weekly/report/service/WeeklyReportChatHandler.kt
@@ -37,8 +37,7 @@ class WeeklyReportChatHandler(
         context: String,
     ): List<ChatActionResponse> {
         val action =
-            intent.actions
-                .firstOrNull()
+            intent.action
                 ?.let { ChatActionType.fromOrNull(it) }
                 ?: throw ChatClarifyException("주간보고 action을 결정할 수 없습니다.")
 

--- a/src/main/kotlin/com/pluxity/weekly/task/entity/TaskStatus.kt
+++ b/src/main/kotlin/com/pluxity/weekly/task/entity/TaskStatus.kt
@@ -5,4 +5,12 @@ enum class TaskStatus {
     IN_PROGRESS,
     IN_REVIEW,
     DONE,
+    ;
+
+    companion object {
+        val initStates: List<TaskStatus> = listOf(TODO, IN_PROGRESS)
+
+        // DONE은 REVIEW_REQUEST 흐름에서만 전이, IN_REVIEW는 REVIEW_REQUEST 액션이 설정
+        val transitionStates: List<TaskStatus> = listOf(TODO, IN_PROGRESS)
+    }
 }

--- a/src/main/resources/llm/intent-prompt.txt
+++ b/src/main/resources/llm/intent-prompt.txt
@@ -1,6 +1,6 @@
 /no_think
 
-너는 의도 분류기다. 사용자 메시지에서 actions와 target을 추출하라.
+너는 의도 분류기다. 사용자 메시지에서 action과 target을 추출하라.
 JSON 1개만 출력. 설명, 마크다운 절대 금지.
 
 ## target
@@ -14,7 +14,7 @@ JSON 1개만 출력. 설명, 마크다운 절대 금지.
 | review | "리뷰할거", "검수할거", "승인할거", "리뷰 큐", "검수 대기", "승인 대기" (read 전용) |
 | weekly_report | 본문 첫 줄에 "주간보고" 키워드가 있거나, "주간보고 작성/생성/등록/올리기" 명시적 표현 |
 
-## actions (배열, 1개만 포함)
+## action (단일 값)
 
 | action | 트리거 키워드 |
 |--------|-------------|
@@ -33,7 +33,7 @@ JSON 1개만 출력. 설명, 마크다운 절대 금지.
 2. team: CUD 요청이 와도 read로 처리.
 3. clarify: target + action 키워드가 있으면 clarify 금지. ("태스크 생성" → create, "태스크 수정" -> update, "업무 그룹 할당" -> assign 등)
 4. action 키워드가 있으면 대상 이름이 없어도 해당 action으로 분류.
-5. 복합 지시 미지원. actions에는 1개만.
+5. 복합 지시 미지원. action은 단일 값.
 6. weekly_report:
    - "주간보고 작성/생성/등록/올리기" 또는 첫 줄에 "주간보고" 키워드 포함 → create
    - "내 주간보고/이번주 주간보고/지난주 주간보고" 같은 짧은 조회 표현 → read
@@ -48,54 +48,66 @@ JSON 1개만 출력. 설명, 마크다운 절대 금지.
 
 ## 힌트 규칙
 
-actions에 "create"가 포함되거나, 직전 히스토리가 clarify로 끝난 경우:
-- project: 언급된 프로젝트명 (없으면 생략)
-- epic: 언급된 업무 그룹명 (없으면 생략)
-- name: 대상의 이름 (없으면 생략)
+action이 "create"이거나, 직전 히스토리가 clarify로 끝난 경우:
+- project: "○○ 프로젝트" 표현에서 ○○ 부분 (없으면 생략)
+- epic: "○○ 업무 그룹" 또는 "○○ 에픽" 표현에서 ○○ 부분 (없으면 생략)
+- name: 새로 만들 대상의 이름. 보통 "추가/생성/만들어줘" 동사 앞에 위치.
+  - target이 task면 "○○ 태스크 추가" 의 ○○ = name
+  - target이 epic이면 "○○ 업무 그룹 만들어줘" 의 ○○ = name (단, 이때 epic 필드는 생략)
 - 위 조건에 해당하지 않으면 이 필드들은 전부 생략.
+
+⚠️ 한 문장에 명사구가 여러 개일 때 위치 기반 구분:
+- "[A] 업무 그룹에 [B] 태스크 추가" → epic="A", name="B"
+  ("업무 그룹" 바로 앞 = epic, "태스크" 바로 앞 = name)
+- "[A] 프로젝트에 [B] 업무 그룹 만들어줘" → project="A", target="epic", name="B"
+  ("프로젝트" 바로 앞 = project, target이 epic이면 그 앞 = name)
+- "[A] 프로젝트에 [B] 업무 그룹에 [C] 태스크 추가" → project="A", epic="B", name="C"
 
 ## 대화 히스토리 참조
 
 "그중에", "아까 그거", "방금 것" 등 이전 대화를 참조하는 표현:
 1. 히스토리 최근 항목에서 target을 이어받는다.
 2. 히스토리 결과에 id가 있으면 (예: create task id=13) id 필드에 포함.
-3. 새 action 키워드가 있으면 actions는 새로 판단.
+3. 새 action 키워드가 있으면 action은 새로 판단.
 4. 참조 대상이 불명확하면 clarify.
 
 ## 예시
 
-"프로젝트 만들어줘" → {"actions":["create"],"target":"project"}
-"PMS 프로젝트 만들어줘" → {"actions":["create"],"target":"project","name":"PMS"}
-"PMS 프로젝트에 백엔드 개발 업무 그룹 만들어줘" → {"actions":["create"],"target":"epic","project":"PMS","name":"백엔드 개발"}
-"백엔드 업무 그룹에 API 설계 태스크 추가해줘" → {"actions":["create"],"target":"task","epic":"백엔드","name":"API 설계"}
-"내 태스크 보여줘" → {"actions":["read"],"target":"task"}
-"리뷰할거 보여줘" → {"actions":["read"],"target":"review"}
-"DB 설계 완료" → {"actions":["review_request"],"target":"task"}
-"크롤러 개발 리뷰 올려줘" → {"actions":["review_request"],"target":"task"}
-"알파 프로젝트 삭제해줘" → {"actions":["delete"],"target":"project"}
-"알파 대시보드 업무 그룹에 홍길동 할당해줘" → {"actions":["assign"],"target":"epic","project":"알파","epic":"대시보드"}
-"데이터 파이프라인 업무 그룹에 인원 할당" → {"actions":["assign"],"target":"epic","epic":"데이터 파이프라인"}
-"업무 그룹에 할당해줘" → {"actions":["assign"],"target":"epic"}
-"대시보드 업무 그룹에서 홍길동 빼줘" → {"actions":["unassign"],"target":"epic","epic":"대시보드"}
-"업무 그룹에서 인원 빼줘" → {"actions":["unassign"],"target":"epic"}
-"진행중" → {"actions":["clarify"],"target":"task"}
-"[개발팀 5/20 주간보고]\n홍길동\n- 이번주: A 완료\n- 다음주: B 시작" → {"actions":["create"],"target":"weekly_report"}
-"주간보고 작성해줘\n홍길동\n- 이번주: A 완료" → {"actions":["create"],"target":"weekly_report"}
-"이번주 주간보고:\n홍길동\n- A 완료" → {"actions":["create"],"target":"weekly_report"}
-"주간보고 생성해줘" → {"actions":["create"],"target":"weekly_report"}
-"내 이번주 주간보고 보여줘" → {"actions":["read"],"target":"weekly_report","week":"this"}
-"지난주 우리 팀 주간보고" → {"actions":["read"],"target":"weekly_report","week":"last"}
-"주간보고 보여줘" → {"actions":["read"],"target":"weekly_report"}
-"4월 6일 주간보고 보여줘" → {"actions":["read"],"target":"weekly_report","week":"2026-04-06"}  ← 오늘 날짜 기준 연도 보정
-"이번주 주간보고 삭제" → {"actions":["delete"],"target":"weekly_report","week":"this"}
-"저번주 주간보고 지워줘" → {"actions":["delete"],"target":"weekly_report","week":"last"}
+"프로젝트 만들어줘" → {"action":"create","target":"project"}
+"PMS 프로젝트 만들어줘" → {"action":"create","target":"project","name":"PMS"}
+"PMS 프로젝트에 백엔드 개발 업무 그룹 만들어줘" → {"action":"create","target":"epic","project":"PMS","name":"백엔드 개발"}
+"백엔드 업무 그룹에 API 설계 태스크 추가해줘" → {"action":"create","target":"task","epic":"백엔드","name":"API 설계"}
+"결제 모듈 업무 그룹에 환불 처리 태스크 추가" → {"action":"create","target":"task","epic":"결제 모듈","name":"환불 처리"}
+"센서 연동 업무 그룹에 알람 규칙 태스크 만들어줘" → {"action":"create","target":"task","epic":"센서 연동","name":"알람 규칙"}
+"PMS 프로젝트에 데이터 파이프라인 업무 그룹에 ETL 태스크 추가" → {"action":"create","target":"task","project":"PMS","epic":"데이터 파이프라인","name":"ETL"}
+"내 태스크 보여줘" → {"action":"read","target":"task"}
+"리뷰할거 보여줘" → {"action":"read","target":"review"}
+"DB 설계 완료" → {"action":"review_request","target":"task"}
+"크롤러 개발 리뷰 올려줘" → {"action":"review_request","target":"task"}
+"알파 프로젝트 삭제해줘" → {"action":"delete","target":"project"}
+"알파 대시보드 업무 그룹에 홍길동 할당해줘" → {"action":"assign","target":"epic","project":"알파","epic":"대시보드"}
+"데이터 파이프라인 업무 그룹에 인원 할당" → {"action":"assign","target":"epic","epic":"데이터 파이프라인"}
+"업무 그룹에 할당해줘" → {"action":"assign","target":"epic"}
+"대시보드 업무 그룹에서 홍길동 빼줘" → {"action":"unassign","target":"epic","epic":"대시보드"}
+"업무 그룹에서 인원 빼줘" → {"action":"unassign","target":"epic"}
+"진행중" → {"action":"clarify","target":"task"}
+"[개발팀 5/20 주간보고]\n홍길동\n- 이번주: A 완료\n- 다음주: B 시작" → {"action":"create","target":"weekly_report"}
+"주간보고 작성해줘\n홍길동\n- 이번주: A 완료" → {"action":"create","target":"weekly_report"}
+"이번주 주간보고:\n홍길동\n- A 완료" → {"action":"create","target":"weekly_report"}
+"주간보고 생성해줘" → {"action":"create","target":"weekly_report"}
+"내 이번주 주간보고 보여줘" → {"action":"read","target":"weekly_report","week":"this"}
+"지난주 우리 팀 주간보고" → {"action":"read","target":"weekly_report","week":"last"}
+"주간보고 보여줘" → {"action":"read","target":"weekly_report"}
+"4월 6일 주간보고 보여줘" → {"action":"read","target":"weekly_report","week":"2026-04-06"}  ← 오늘 날짜 기준 연도 보정
+"이번주 주간보고 삭제" → {"action":"delete","target":"weekly_report","week":"this"}
+"저번주 주간보고 지워줘" → {"action":"delete","target":"weekly_report","week":"last"}
 
 히스토리 예시:
 히스토리: "--- #1 | 질문: 로그인 태스크 만들어줘 | 결과: create task id=13 ---"
-"아까 만든거 마감일을 금요일로" → {"actions":["update"],"target":"task","id":13}
-"그거 삭제해줘" → {"actions":["delete"],"target":"task","id":13}
+"아까 만든거 마감일을 금요일로" → {"action":"update","target":"task","id":13}
+"그거 삭제해줘" → {"action":"delete","target":"task","id":13}
 
-출력: {"actions":[".."],"target":".."}
+출력: {"action":"..","target":".."}
 id는 히스토리 참조 시에만, 실제 정수(예: 13)로만 포함. id를 모르면 필드 자체를 생략.
 "pending", "none", "" 같은 문자열 placeholder 절대 금지.
 week는 weekly_report read/delete에서 주차 표현이 있을 때만 포함.

--- a/src/main/resources/llm/system-prompt.txt
+++ b/src/main/resources/llm/system-prompt.txt
@@ -5,7 +5,7 @@ JSON 배열만 출력. 설명, 마크다운, 부가 텍스트 절대 금지.
 
 ## INTENT (1차 분류 결과 — 참고)
 
-입력에 [INTENT] 블록이 있으면 1차 의도 분류 결과다. target과 actions를 참고하되, CONTEXT와 입력 내용을 기반으로 최종 판단하라.
+입력에 [INTENT] 블록이 있으면 1차 의도 분류 결과다. target과 action을 참고하되, CONTEXT와 입력 내용을 기반으로 최종 판단하라.
 - project, epic, name 힌트가 있으면 CONTEXT 매칭에 활용.
 - INTENT에 id가 있으면 이전 대화 참조. update/delete 시 그대로 사용.
 

--- a/src/test/kotlin/com/pluxity/weekly/chat/service/SelectFieldResolverStatusTest.kt
+++ b/src/test/kotlin/com/pluxity/weekly/chat/service/SelectFieldResolverStatusTest.kt
@@ -1,0 +1,134 @@
+package com.pluxity.weekly.chat.service
+
+import com.pluxity.weekly.auth.user.repository.UserRepository
+import com.pluxity.weekly.chat.dto.LlmAction
+import com.pluxity.weekly.chat.dto.SelectField
+import com.pluxity.weekly.epic.dto.EpicResponse
+import com.pluxity.weekly.epic.repository.EpicRepository
+import com.pluxity.weekly.epic.service.EpicAssignmentService
+import com.pluxity.weekly.epic.service.EpicService
+import com.pluxity.weekly.project.dto.ProjectResponse
+import com.pluxity.weekly.project.repository.ProjectRepository
+import com.pluxity.weekly.project.service.ProjectService
+import com.pluxity.weekly.task.repository.TaskRepository
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
+import io.kotest.matchers.collections.shouldNotContain
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.mockk.every
+import io.mockk.mockk
+import org.springframework.data.domain.Sort
+
+class SelectFieldResolverStatusTest :
+    BehaviorSpec({
+
+        val projectRepository: ProjectRepository = mockk()
+        val epicRepository: EpicRepository = mockk()
+        val taskRepository: TaskRepository = mockk()
+        val userRepository: UserRepository = mockk()
+        val projectService: ProjectService = mockk()
+        val epicService: EpicService = mockk()
+        val epicAssignmentService: EpicAssignmentService = mockk()
+
+        val resolver =
+            SelectFieldResolver(
+                projectRepository,
+                epicRepository,
+                taskRepository,
+                userRepository,
+                projectService,
+                epicService,
+                epicAssignmentService,
+            )
+
+        // 기본 mock: status 후보 검증과 무관한 의존성은 비어있거나 더미를 반환
+        every { userRepository.findAllBy(any<Sort>()) } returns emptyList()
+        every { projectService.findAll() } returns
+            listOf(
+                mockk<ProjectResponse> {
+                    every { id } returns 1L
+                    every { name } returns "더미 프로젝트"
+                },
+            )
+        every { epicService.findAll() } returns
+            listOf(
+                mockk<EpicResponse> {
+                    every { id } returns 10L
+                    every { name } returns "더미 에픽"
+                    every { members } returns emptyList()
+                },
+            )
+
+        fun statusField(action: LlmAction): SelectField? =
+            resolver.resolve(action).firstOrNull { it.field == "status" }
+
+        fun statusNames(action: LlmAction): List<String> =
+            statusField(action)?.candidates?.map { it.id } ?: emptyList()
+
+        Given("PROJECT 대상") {
+            When("CREATE 액션") {
+                val action = LlmAction(action = "create", target = "project")
+                Then("status 후보는 TODO / IN_PROGRESS 만 — DONE 으로는 신규 생성 불가") {
+                    statusField(action).shouldNotBeNull()
+                    statusNames(action) shouldContainExactlyInAnyOrder listOf("TODO", "IN_PROGRESS")
+                    statusNames(action) shouldNotContain "DONE"
+                }
+            }
+            When("UPDATE 액션") {
+                val action = LlmAction(action = "update", target = "project", id = 1L)
+                Then("status 후보는 TODO / IN_PROGRESS / DONE 모두 포함") {
+                    statusNames(action) shouldContainExactlyInAnyOrder listOf("TODO", "IN_PROGRESS", "DONE")
+                }
+            }
+        }
+
+        Given("EPIC 대상") {
+            When("CREATE 액션") {
+                val action = LlmAction(action = "create", target = "epic")
+                Then("status 후보는 TODO / IN_PROGRESS 만") {
+                    statusNames(action) shouldContainExactlyInAnyOrder listOf("TODO", "IN_PROGRESS")
+                    statusNames(action) shouldNotContain "DONE"
+                }
+            }
+            When("UPDATE 액션") {
+                val action = LlmAction(action = "update", target = "epic", id = 1L)
+                Then("status 후보는 TODO / IN_PROGRESS / DONE 모두 포함") {
+                    statusNames(action) shouldContainExactlyInAnyOrder listOf("TODO", "IN_PROGRESS", "DONE")
+                }
+            }
+        }
+
+        Given("TASK 대상") {
+            When("CREATE 액션") {
+                val action = LlmAction(action = "create", target = "task")
+                Then("status 후보는 TODO / IN_PROGRESS 만") {
+                    statusNames(action) shouldContainExactlyInAnyOrder listOf("TODO", "IN_PROGRESS")
+                }
+            }
+            When("UPDATE 액션") {
+                val action = LlmAction(action = "update", target = "task", id = 1L)
+                Then("status 후보는 TODO / IN_PROGRESS 만 (DONE / IN_REVIEW 는 리뷰 흐름 전용)") {
+                    statusNames(action) shouldContainExactlyInAnyOrder listOf("TODO", "IN_PROGRESS")
+                    statusNames(action) shouldNotContain "DONE"
+                    statusNames(action) shouldNotContain "IN_REVIEW"
+                }
+            }
+        }
+
+        Given("CREATE / UPDATE 외 액션") {
+            When("READ 액션") {
+                val action = LlmAction(action = "read", target = "project")
+                Then("status 후보는 생성되지 않는다") {
+                    statusField(action).shouldBeNull()
+                }
+            }
+            When("DELETE 액션") {
+                val action = LlmAction(action = "delete", target = "project", id = 1L)
+                Then("status 후보는 생성되지 않는다") {
+                    statusField(action).shouldBeNull()
+                }
+            }
+        }
+    })
+

--- a/src/test/kotlin/com/pluxity/weekly/chat/service/SelectFieldResolverStatusTest.kt
+++ b/src/test/kotlin/com/pluxity/weekly/chat/service/SelectFieldResolverStatusTest.kt
@@ -60,11 +60,9 @@ class SelectFieldResolverStatusTest :
                 },
             )
 
-        fun statusField(action: LlmAction): SelectField? =
-            resolver.resolve(action).firstOrNull { it.field == "status" }
+        fun statusField(action: LlmAction): SelectField? = resolver.resolve(action).firstOrNull { it.field == "status" }
 
-        fun statusNames(action: LlmAction): List<String> =
-            statusField(action)?.candidates?.map { it.id } ?: emptyList()
+        fun statusNames(action: LlmAction): List<String> = statusField(action)?.candidates?.map { it.id } ?: emptyList()
 
         Given("PROJECT 대상") {
             When("CREATE 액션") {
@@ -131,4 +129,3 @@ class SelectFieldResolverStatusTest :
             }
         }
     })
-

--- a/src/test/kotlin/com/pluxity/weekly/epic/entity/EpicStatusTest.kt
+++ b/src/test/kotlin/com/pluxity/weekly/epic/entity/EpicStatusTest.kt
@@ -1,0 +1,29 @@
+package com.pluxity.weekly.epic.entity
+
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
+import io.kotest.matchers.collections.shouldNotContain
+
+class EpicStatusTest :
+    BehaviorSpec({
+        Given("EpicStatus.initStates") {
+            When("신규 생성 시 선택 가능한 상태 목록을 조회하면") {
+                Then("TODO 와 IN_PROGRESS 만 포함된다") {
+                    EpicStatus.initStates shouldContainExactlyInAnyOrder
+                        listOf(EpicStatus.TODO, EpicStatus.IN_PROGRESS)
+                }
+                Then("DONE 으로는 신규 생성할 수 없다") {
+                    EpicStatus.initStates shouldNotContain EpicStatus.DONE
+                }
+            }
+        }
+
+        Given("EpicStatus.transitionStates") {
+            When("관리자가 직접 변경 가능한 상태 목록을 조회하면") {
+                Then("TODO / IN_PROGRESS / DONE 모두 포함된다") {
+                    EpicStatus.transitionStates shouldContainExactlyInAnyOrder
+                        listOf(EpicStatus.TODO, EpicStatus.IN_PROGRESS, EpicStatus.DONE)
+                }
+            }
+        }
+    })

--- a/src/test/kotlin/com/pluxity/weekly/project/entity/ProjectStatusTest.kt
+++ b/src/test/kotlin/com/pluxity/weekly/project/entity/ProjectStatusTest.kt
@@ -1,0 +1,29 @@
+package com.pluxity.weekly.project.entity
+
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
+import io.kotest.matchers.collections.shouldNotContain
+
+class ProjectStatusTest :
+    BehaviorSpec({
+        Given("ProjectStatus.initStates") {
+            When("신규 생성 시 선택 가능한 상태 목록을 조회하면") {
+                Then("TODO 와 IN_PROGRESS 만 포함된다") {
+                    ProjectStatus.initStates shouldContainExactlyInAnyOrder
+                        listOf(ProjectStatus.TODO, ProjectStatus.IN_PROGRESS)
+                }
+                Then("DONE 으로는 신규 생성할 수 없다") {
+                    ProjectStatus.initStates shouldNotContain ProjectStatus.DONE
+                }
+            }
+        }
+
+        Given("ProjectStatus.transitionStates") {
+            When("관리자가 직접 변경 가능한 상태 목록을 조회하면") {
+                Then("TODO / IN_PROGRESS / DONE 모두 포함된다") {
+                    ProjectStatus.transitionStates shouldContainExactlyInAnyOrder
+                        listOf(ProjectStatus.TODO, ProjectStatus.IN_PROGRESS, ProjectStatus.DONE)
+                }
+            }
+        }
+    })

--- a/src/test/kotlin/com/pluxity/weekly/task/entity/TaskStatusTest.kt
+++ b/src/test/kotlin/com/pluxity/weekly/task/entity/TaskStatusTest.kt
@@ -1,0 +1,32 @@
+package com.pluxity.weekly.task.entity
+
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
+import io.kotest.matchers.collections.shouldNotContain
+
+class TaskStatusTest :
+    BehaviorSpec({
+        Given("TaskStatus.initStates") {
+            When("신규 생성 시 선택 가능한 상태 목록을 조회하면") {
+                Then("TODO 와 IN_PROGRESS 만 포함된다") {
+                    TaskStatus.initStates shouldContainExactlyInAnyOrder
+                        listOf(TaskStatus.TODO, TaskStatus.IN_PROGRESS)
+                }
+            }
+        }
+
+        Given("TaskStatus.transitionStates") {
+            When("관리자가 직접 변경 가능한 상태 목록을 조회하면") {
+                Then("TODO 와 IN_PROGRESS 만 포함된다 (DONE / IN_REVIEW 는 리뷰 흐름 전용)") {
+                    TaskStatus.transitionStates shouldContainExactlyInAnyOrder
+                        listOf(TaskStatus.TODO, TaskStatus.IN_PROGRESS)
+                }
+                Then("DONE 은 직접 변경 불가") {
+                    TaskStatus.transitionStates shouldNotContain TaskStatus.DONE
+                }
+                Then("IN_REVIEW 도 직접 변경 불가") {
+                    TaskStatus.transitionStates shouldNotContain TaskStatus.IN_REVIEW
+                }
+            }
+        }
+    })


### PR DESCRIPTION
  ## Summary

  - chat status 선택 후보 정책을 도메인 enum(initStates/transitionStates)으로 집중
  - IntentResult.target/action을 nullable + 단건화로 LLM 응답 다양성 흡수
  - LlmService.extractIntent retry에 1s/2s 지수 backoff 추가 (즉시 3회 폭주 → 회복 시간 확보)
  - User.hasRole(Role) 오버로딩 제거로 인가 코드 의미 명확화