### PR TITLE
 feat(chat): chat 디버그 로그 + LLM 토큰/비용 집계

### DIFF
--- a/src/main/kotlin/com/pluxity/weekly/chat/config/LlmProperties.kt
+++ b/src/main/kotlin/com/pluxity/weekly/chat/config/LlmProperties.kt
@@ -1,6 +1,7 @@
 package com.pluxity.weekly.chat.config
 
 import org.springframework.boot.context.properties.ConfigurationProperties
+import java.math.BigDecimal
 
 @ConfigurationProperties(prefix = "llm")
 data class LlmProperties(
@@ -31,6 +32,8 @@ data class OpenRouterProperties(
     val baseUrl: String = "https://openrouter.ai/api",
     val apiKey: String = "",
     val model: String = "",
+    val inputPricePerMillion: BigDecimal = BigDecimal("0.30"),
+    val outputPricePerMillion: BigDecimal = BigDecimal("2.50"),
 ) {
     val isEnabled: Boolean
         get() = apiKey.isNotBlank() && model.isNotBlank()

--- a/src/main/kotlin/com/pluxity/weekly/chat/entity/ChatLog.kt
+++ b/src/main/kotlin/com/pluxity/weekly/chat/entity/ChatLog.kt
@@ -1,0 +1,39 @@
+package com.pluxity.weekly.chat.entity
+
+import com.pluxity.weekly.core.entity.IdentityIdEntity
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.Table
+import java.math.BigDecimal
+
+@Entity
+@Table(name = "chat_logs")
+class ChatLog(
+    @Column(name = "user_id", nullable = false)
+    val userId: Long,
+    @Column(name = "request_message", columnDefinition = "TEXT", nullable = false)
+    val requestMessage: String,
+    @Column(name = "success", nullable = false)
+    val success: Boolean,
+    // 1차 LLM(의도 추출) 결과 — 실패 시 null
+    @Column(name = "intent_result", columnDefinition = "TEXT")
+    val intentResult: String? = null,
+    // 2차 LLM(액션 생성) 결과 — weekly_report 우회/실패 시 null
+    @Column(name = "action_result", columnDefinition = "TEXT")
+    val actionResult: String? = null,
+    // 실패 시 예외 메시지 (success=false일 때 기록)
+    @Column(name = "error_message", columnDefinition = "TEXT")
+    val errorMessage: String? = null,
+    // 토큰은 단가가 다른 input(prompt)/output(completion)을 분리 저장 (cost 산출 근거)
+    @Column(name = "intent_input_tokens", nullable = false)
+    val intentInputTokens: Int = 0,
+    @Column(name = "intent_output_tokens", nullable = false)
+    val intentOutputTokens: Int = 0,
+    @Column(name = "action_input_tokens", nullable = false)
+    val actionInputTokens: Int = 0,
+    @Column(name = "action_output_tokens", nullable = false)
+    val actionOutputTokens: Int = 0,
+    // USD. input/output 토큰 × 단가로 산출 (저장 시점 단가 고정)
+    @Column(name = "cost", nullable = false, precision = 16, scale = 8)
+    val cost: BigDecimal = BigDecimal.ZERO,
+) : IdentityIdEntity()

--- a/src/main/kotlin/com/pluxity/weekly/chat/entity/ChatLog.kt
+++ b/src/main/kotlin/com/pluxity/weekly/chat/entity/ChatLog.kt
@@ -36,4 +36,7 @@ class ChatLog(
     // USD. input/output 토큰 × 단가로 산출 (저장 시점 단가 고정)
     @Column(name = "cost", nullable = false, precision = 16, scale = 8)
     val cost: BigDecimal = BigDecimal.ZERO,
+    // cost 산출에 쓰인 모델 (저장 시점 스냅샷 — 단가 이력 추적용)
+    @Column(name = "model", nullable = false, length = 128)
+    val model: String = "",
 ) : IdentityIdEntity()

--- a/src/main/kotlin/com/pluxity/weekly/chat/llm/LlmService.kt
+++ b/src/main/kotlin/com/pluxity/weekly/chat/llm/LlmService.kt
@@ -8,12 +8,14 @@ import com.pluxity.weekly.chat.llm.dto.GeminiPart
 import com.pluxity.weekly.chat.llm.dto.GeminiRequest
 import com.pluxity.weekly.chat.llm.dto.GeminiResponse
 import com.pluxity.weekly.chat.llm.dto.IntentResult
+import com.pluxity.weekly.chat.llm.dto.LlmResult
 import com.pluxity.weekly.chat.llm.dto.Message
 import com.pluxity.weekly.chat.llm.dto.OllamaChatRequest
 import com.pluxity.weekly.chat.llm.dto.OllamaChatResponse
 import com.pluxity.weekly.chat.llm.dto.OllamaOptions
 import com.pluxity.weekly.chat.llm.dto.OpenAiChatRequest
 import com.pluxity.weekly.chat.llm.dto.OpenAiChatResponse
+import com.pluxity.weekly.chat.llm.dto.TokenUsage
 import com.pluxity.weekly.chat.llm.dto.WeeklyReportClassifyResult
 import com.pluxity.weekly.chat.llm.dto.WeeklyReportMatchResult
 import com.pluxity.weekly.config.WebClientFactory
@@ -27,8 +29,6 @@ import org.springframework.web.reactive.function.client.bodyToMono
 import tools.jackson.databind.ObjectMapper
 
 private val log = KotlinLogging.logger {}
-
-// TODO: 일일 토큰 사용량 제한 및 모니터링 추가
 
 @Service
 class LlmService(
@@ -70,12 +70,12 @@ class LlmService(
         }
     }
 
-    fun extractIntent(messages: List<Message>): IntentResult {
+    fun extractIntent(messages: List<Message>): LlmResult<IntentResult> {
         var lastException: Exception? = null
         repeat(MAX_RETRIES) { attempt ->
             try {
-                val content = callLlm(messages)
-                return parseIntent(content)
+                val result = callLlm(messages)
+                return LlmResult(parseIntent(result.value), result.usage)
             } catch (e: CustomException) {
                 throw e
             } catch (e: Exception) {
@@ -90,13 +90,13 @@ class LlmService(
         throw CustomException(ErrorCode.LLM_SERVICE_UNAVAILABLE)
     }
 
-    fun generate(messages: List<Message>): List<LlmAction> {
+    fun generate(messages: List<Message>): LlmResult<List<LlmAction>> {
         var lastException: Exception? = null
         repeat(MAX_RETRIES) { attempt ->
             try {
-                val content = callLlm(messages)
-                log.info { "llm response : $content" }
-                return parseActions(content)
+                val result = callLlm(messages)
+                log.info { "llm response : ${result.value}" }
+                return LlmResult(parseActions(result.value), result.usage)
             } catch (e: CustomException) {
                 throw e
             } catch (e: Exception) {
@@ -112,7 +112,7 @@ class LlmService(
         var lastException: Exception? = null
         repeat(MAX_RETRIES) { attempt ->
             try {
-                val content = callLlm(messages)
+                val content = callLlm(messages).value
                 log.info { "llm classify response : $content" }
                 return parseClassify(content)
             } catch (e: CustomException) {
@@ -130,7 +130,7 @@ class LlmService(
         var lastException: Exception? = null
         repeat(MAX_RETRIES) { attempt ->
             try {
-                val content = callLlm(messages)
+                val content = callLlm(messages).value
                 log.info { "llm match response : $content" }
                 return parseMatch(content)
             } catch (e: CustomException) {
@@ -144,7 +144,7 @@ class LlmService(
         throw CustomException(ErrorCode.LLM_SERVICE_UNAVAILABLE)
     }
 
-    private fun callLlm(messages: List<Message>): String =
+    private fun callLlm(messages: List<Message>): LlmResult<String> =
         when {
             properties.openrouter.isEnabled -> callOpenRouter(messages)
             properties.gemini.isEnabled -> callGemini(messages)
@@ -152,7 +152,7 @@ class LlmService(
             else -> throw CustomException(ErrorCode.LLM_SERVICE_UNAVAILABLE)
         }
 
-    private fun callOpenRouter(messages: List<Message>): String {
+    private fun callOpenRouter(messages: List<Message>): LlmResult<String> {
         val props = properties.openrouter
         val request =
             OpenAiChatRequest(
@@ -177,14 +177,20 @@ class LlmService(
                 .block()
                 ?: throw CustomException(ErrorCode.LLM_INVALID_RESPONSE)
 
-        return response.choices
-            ?.firstOrNull()
-            ?.message
-            ?.content
-            ?: throw CustomException(ErrorCode.LLM_INVALID_RESPONSE)
+        val content =
+            response.choices
+                ?.firstOrNull()
+                ?.message
+                ?.content
+                ?: throw CustomException(ErrorCode.LLM_INVALID_RESPONSE)
+        val usage =
+            response.usage
+                ?.let { TokenUsage(it.promptTokens, it.completionTokens, it.totalTokens) }
+                ?: TokenUsage()
+        return LlmResult(content, usage)
     }
 
-    private fun callOllama(messages: List<Message>): String {
+    private fun callOllama(messages: List<Message>): LlmResult<String> {
         val props = properties.ollama
         val request =
             OllamaChatRequest(
@@ -209,11 +215,14 @@ class LlmService(
                 .block()
                 ?: throw CustomException(ErrorCode.LLM_INVALID_RESPONSE)
 
-        return response.message?.content
-            ?: throw CustomException(ErrorCode.LLM_INVALID_RESPONSE)
+        val content =
+            response.message?.content
+                ?: throw CustomException(ErrorCode.LLM_INVALID_RESPONSE)
+        // TODO: Ollama 토큰 사용량(prompt_eval_count/eval_count) 추출 — 현재는 OpenRouter만 실값
+        return LlmResult(content)
     }
 
-    private fun callGemini(messages: List<Message>): String {
+    private fun callGemini(messages: List<Message>): LlmResult<String> {
         val props = properties.gemini
         val systemMessage = messages.firstOrNull { it.role == "system" }
         val userMessages = messages.filter { it.role != "system" }
@@ -250,14 +259,17 @@ class LlmService(
                 .block()
                 ?: throw CustomException(ErrorCode.LLM_INVALID_RESPONSE)
 
-        return response
-            .candidates
-            ?.firstOrNull()
-            ?.content
-            ?.parts
-            ?.firstOrNull()
-            ?.text
-            ?: throw CustomException(ErrorCode.LLM_INVALID_RESPONSE)
+        val content =
+            response
+                .candidates
+                ?.firstOrNull()
+                ?.content
+                ?.parts
+                ?.firstOrNull()
+                ?.text
+                ?: throw CustomException(ErrorCode.LLM_INVALID_RESPONSE)
+        // TODO: Gemini 토큰 사용량(usageMetadata) 추출 — 현재는 OpenRouter만 실값
+        return LlmResult(content)
     }
 
     private fun parseClassify(raw: String): WeeklyReportClassifyResult {

--- a/src/main/kotlin/com/pluxity/weekly/chat/llm/LlmService.kt
+++ b/src/main/kotlin/com/pluxity/weekly/chat/llm/LlmService.kt
@@ -70,77 +70,42 @@ class LlmService(
         }
     }
 
-    fun extractIntent(messages: List<Message>): LlmResult<IntentResult> {
+    fun extractIntent(messages: List<Message>): LlmResult<IntentResult> = callWithRetry(messages, "Intent 추출", ::parseIntent)
+
+    fun generate(messages: List<Message>): LlmResult<List<LlmAction>> = callWithRetry(messages, "LLM 액션 생성", ::parseActions)
+
+    fun classifyWeeklyReport(messages: List<Message>): LlmResult<WeeklyReportClassifyResult> =
+        callWithRetry(messages, "LLM classify", ::parseClassify)
+
+    fun matchWeeklyReport(messages: List<Message>): LlmResult<WeeklyReportMatchResult> = callWithRetry(messages, "LLM match", ::parseMatch)
+
+    /**
+     * LLM 호출 + 재시도 공통 골격. 타입별로 변하는 parse 만 주입받는다.
+     * - CustomException 은 즉시 전파(재시도 안 함)
+     * - 그 외 예외는 MAX_RETRIES 까지 지수 backoff 후 재시도, 모두 실패 시 LLM_SERVICE_UNAVAILABLE
+     */
+    private fun <T> callWithRetry(
+        messages: List<Message>,
+        label: String,
+        parse: (String) -> T,
+    ): LlmResult<T> {
         var lastException: Exception? = null
         repeat(MAX_RETRIES) { attempt ->
             try {
                 val result = callLlm(messages)
-                return LlmResult(parseIntent(result.value), result.usage)
+                log.info { "$label 응답: ${result.value}" }
+                return LlmResult(parse(result.value), result.usage)
             } catch (e: CustomException) {
                 throw e
             } catch (e: Exception) {
                 lastException = e
-                log.warn { "Intent 추출 실패 (시도 ${attempt + 1}/$MAX_RETRIES): ${e.message}" }
+                log.warn { "$label 실패 (시도 ${attempt + 1}/$MAX_RETRIES): ${e.message}" }
                 if (attempt < MAX_RETRIES - 1) {
                     Thread.sleep(retryBackoffMs(attempt))
                 }
             }
         }
-        log.error(lastException) { "Intent 추출 $MAX_RETRIES 회 재시도 실패" }
-        throw CustomException(ErrorCode.LLM_SERVICE_UNAVAILABLE)
-    }
-
-    fun generate(messages: List<Message>): LlmResult<List<LlmAction>> {
-        var lastException: Exception? = null
-        repeat(MAX_RETRIES) { attempt ->
-            try {
-                val result = callLlm(messages)
-                log.info { "llm response : ${result.value}" }
-                return LlmResult(parseActions(result.value), result.usage)
-            } catch (e: CustomException) {
-                throw e
-            } catch (e: Exception) {
-                lastException = e
-                log.warn { "LLM 호출 실패 (시도 ${attempt + 1}/$MAX_RETRIES): ${e.message}" }
-            }
-        }
-        log.error(lastException) { "LLM 서비스 $MAX_RETRIES 회 재시도 실패" }
-        throw CustomException(ErrorCode.LLM_SERVICE_UNAVAILABLE)
-    }
-
-    fun classifyWeeklyReport(messages: List<Message>): LlmResult<WeeklyReportClassifyResult> {
-        var lastException: Exception? = null
-        repeat(MAX_RETRIES) { attempt ->
-            try {
-                val result = callLlm(messages)
-                log.info { "llm classify response : ${result.value}" }
-                return LlmResult(parseClassify(result.value), result.usage)
-            } catch (e: CustomException) {
-                throw e
-            } catch (e: Exception) {
-                lastException = e
-                log.warn { "LLM classify 호출 실패 (시도 ${attempt + 1}/$MAX_RETRIES): ${e.message}" }
-            }
-        }
-        log.error(lastException) { "LLM classify $MAX_RETRIES 회 재시도 실패" }
-        throw CustomException(ErrorCode.LLM_SERVICE_UNAVAILABLE)
-    }
-
-    fun matchWeeklyReport(messages: List<Message>): LlmResult<WeeklyReportMatchResult> {
-        var lastException: Exception? = null
-        repeat(MAX_RETRIES) { attempt ->
-            try {
-                val result = callLlm(messages)
-                log.info { "llm match response : ${result.value}" }
-                return LlmResult(parseMatch(result.value), result.usage)
-            } catch (e: CustomException) {
-                throw e
-            } catch (e: Exception) {
-                lastException = e
-                log.warn { "LLM match 호출 실패 (시도 ${attempt + 1}/$MAX_RETRIES): ${e.message}" }
-            }
-        }
-        log.error(lastException) { "LLM match $MAX_RETRIES 회 재시도 실패" }
+        log.error(lastException) { "$label $MAX_RETRIES 회 재시도 실패" }
         throw CustomException(ErrorCode.LLM_SERVICE_UNAVAILABLE)
     }
 
@@ -272,39 +237,14 @@ class LlmService(
         return LlmResult(content)
     }
 
-    private fun parseClassify(raw: String): WeeklyReportClassifyResult {
-        val json = stripCodeFence(raw).trim()
-        if (json.isBlank()) {
-            throw CustomException(ErrorCode.LLM_INVALID_RESPONSE)
-        }
-        return try {
-            objectMapper.readValue(json, WeeklyReportClassifyResult::class.java)
-        } catch (e: Exception) {
-            log.error(e) { "LLM classify 응답 JSON 파싱 실패: $json" }
-            throw CustomException(ErrorCode.LLM_INVALID_RESPONSE)
-        }
-    }
+    private fun parseClassify(raw: String): WeeklyReportClassifyResult =
+        decodeJson(raw, "LLM classify") { objectMapper.readValue(it, WeeklyReportClassifyResult::class.java) }
 
-    private fun parseMatch(raw: String): WeeklyReportMatchResult {
-        val json = stripCodeFence(raw).trim()
-        if (json.isBlank()) {
-            throw CustomException(ErrorCode.LLM_INVALID_RESPONSE)
-        }
-        return try {
-            objectMapper.readValue(json, WeeklyReportMatchResult::class.java)
-        } catch (e: Exception) {
-            log.error(e) { "LLM match 응답 JSON 파싱 실패: $json" }
-            throw CustomException(ErrorCode.LLM_INVALID_RESPONSE)
-        }
-    }
+    private fun parseMatch(raw: String): WeeklyReportMatchResult =
+        decodeJson(raw, "LLM match") { objectMapper.readValue(it, WeeklyReportMatchResult::class.java) }
 
-    private fun parseActions(raw: String): List<LlmAction> {
-        val json = stripCodeFence(raw).trim()
-        if (json.isBlank()) {
-            throw CustomException(ErrorCode.LLM_INVALID_RESPONSE)
-        }
-
-        return try {
+    private fun parseActions(raw: String): List<LlmAction> =
+        decodeJson(raw, "LLM 액션") { json ->
             if (json.trimStart().startsWith("[")) {
                 objectMapper.readValue(
                     json,
@@ -313,22 +253,27 @@ class LlmService(
             } else {
                 listOf(objectMapper.readValue(json, LlmAction::class.java))
             }
-        } catch (_: Exception) {
-            log.error { "LLM 응답 JSON 파싱 실패: $json" }
-            throw CustomException(ErrorCode.LLM_INVALID_RESPONSE)
         }
-    }
 
-    internal fun parseIntent(raw: String): IntentResult {
+    internal fun parseIntent(raw: String): IntentResult = decodeJson(raw, "Intent") { objectMapper.readValue(it, IntentResult::class.java) }
+
+    /**
+     * 공통 JSON 파싱 골격: 코드펜스 제거 → blank 검증 → decode. 실패 시 LLM_INVALID_RESPONSE.
+     * 타입별로 변하는 decode 만 주입받는다.
+     */
+    private fun <T> decodeJson(
+        raw: String,
+        label: String,
+        decode: (String) -> T,
+    ): T {
         val json = stripCodeFence(raw).trim()
         if (json.isBlank()) {
             throw CustomException(ErrorCode.LLM_INVALID_RESPONSE)
         }
-
         return try {
-            objectMapper.readValue(json, IntentResult::class.java)
-        } catch (_: Exception) {
-            log.error { "Intent JSON 파싱 실패: $json" }
+            decode(json)
+        } catch (e: Exception) {
+            log.error(e) { "$label JSON 파싱 실패: $json" }
             throw CustomException(ErrorCode.LLM_INVALID_RESPONSE)
         }
     }

--- a/src/main/kotlin/com/pluxity/weekly/chat/llm/LlmService.kt
+++ b/src/main/kotlin/com/pluxity/weekly/chat/llm/LlmService.kt
@@ -108,13 +108,13 @@ class LlmService(
         throw CustomException(ErrorCode.LLM_SERVICE_UNAVAILABLE)
     }
 
-    fun classifyWeeklyReport(messages: List<Message>): WeeklyReportClassifyResult {
+    fun classifyWeeklyReport(messages: List<Message>): LlmResult<WeeklyReportClassifyResult> {
         var lastException: Exception? = null
         repeat(MAX_RETRIES) { attempt ->
             try {
-                val content = callLlm(messages).value
-                log.info { "llm classify response : $content" }
-                return parseClassify(content)
+                val result = callLlm(messages)
+                log.info { "llm classify response : ${result.value}" }
+                return LlmResult(parseClassify(result.value), result.usage)
             } catch (e: CustomException) {
                 throw e
             } catch (e: Exception) {
@@ -126,13 +126,13 @@ class LlmService(
         throw CustomException(ErrorCode.LLM_SERVICE_UNAVAILABLE)
     }
 
-    fun matchWeeklyReport(messages: List<Message>): WeeklyReportMatchResult {
+    fun matchWeeklyReport(messages: List<Message>): LlmResult<WeeklyReportMatchResult> {
         var lastException: Exception? = null
         repeat(MAX_RETRIES) { attempt ->
             try {
-                val content = callLlm(messages).value
-                log.info { "llm match response : $content" }
-                return parseMatch(content)
+                val result = callLlm(messages)
+                log.info { "llm match response : ${result.value}" }
+                return LlmResult(parseMatch(result.value), result.usage)
             } catch (e: CustomException) {
                 throw e
             } catch (e: Exception) {

--- a/src/main/kotlin/com/pluxity/weekly/chat/llm/dto/LlmApiDto.kt
+++ b/src/main/kotlin/com/pluxity/weekly/chat/llm/dto/LlmApiDto.kt
@@ -1,8 +1,22 @@
 package com.pluxity.weekly.chat.llm.dto
 
+import com.fasterxml.jackson.annotation.JsonProperty
+
 data class Message(
     val role: String,
     val content: String,
+)
+
+/** LLM 호출 결과 + 토큰 사용량을 함께 실어 나르는 캐리어. */
+data class LlmResult<T>(
+    val value: T,
+    val usage: TokenUsage = TokenUsage(),
+)
+
+data class TokenUsage(
+    val promptTokens: Int = 0,
+    val completionTokens: Int = 0,
+    val totalTokens: Int = 0,
 )
 
 // Ollama
@@ -35,6 +49,13 @@ data class OpenAiChatRequest(
 
 data class OpenAiChatResponse(
     val choices: List<OpenAiChoice>? = null,
+    val usage: OpenAiUsage? = null,
+)
+
+data class OpenAiUsage(
+    @param:JsonProperty("prompt_tokens") val promptTokens: Int = 0,
+    @param:JsonProperty("completion_tokens") val completionTokens: Int = 0,
+    @param:JsonProperty("total_tokens") val totalTokens: Int = 0,
 )
 
 data class OpenAiChoice(

--- a/src/main/kotlin/com/pluxity/weekly/chat/llm/dto/LlmApiDto.kt
+++ b/src/main/kotlin/com/pluxity/weekly/chat/llm/dto/LlmApiDto.kt
@@ -17,7 +17,14 @@ data class TokenUsage(
     val promptTokens: Int = 0,
     val completionTokens: Int = 0,
     val totalTokens: Int = 0,
-)
+) {
+    operator fun plus(other: TokenUsage): TokenUsage =
+        TokenUsage(
+            promptTokens = promptTokens + other.promptTokens,
+            completionTokens = completionTokens + other.completionTokens,
+            totalTokens = totalTokens + other.totalTokens,
+        )
+}
 
 // Ollama
 data class OllamaChatRequest(

--- a/src/main/kotlin/com/pluxity/weekly/chat/repository/ChatLogRepository.kt
+++ b/src/main/kotlin/com/pluxity/weekly/chat/repository/ChatLogRepository.kt
@@ -1,0 +1,6 @@
+package com.pluxity.weekly.chat.repository
+
+import com.pluxity.weekly.chat.entity.ChatLog
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface ChatLogRepository : JpaRepository<ChatLog, Long>

--- a/src/main/kotlin/com/pluxity/weekly/chat/service/ChatLogService.kt
+++ b/src/main/kotlin/com/pluxity/weekly/chat/service/ChatLogService.kt
@@ -1,6 +1,7 @@
 package com.pluxity.weekly.chat.service
 
 import com.pluxity.weekly.chat.entity.ChatLog
+import com.pluxity.weekly.chat.llm.dto.TokenUsage
 import com.pluxity.weekly.chat.repository.ChatLogRepository
 import io.github.oshai.kotlinlogging.KotlinLogging
 import org.springframework.stereotype.Service
@@ -41,6 +42,26 @@ data class ChatLogData(
     var actionInputTokens: Int = 0,
     var actionOutputTokens: Int = 0,
 ) {
+    /** 1차(의도 추출) 결과·토큰 기록 */
+    fun recordIntent(
+        intentJson: String,
+        usage: TokenUsage,
+    ) {
+        intentResult = intentJson
+        intentInputTokens = usage.promptTokens
+        intentOutputTokens = usage.completionTokens
+    }
+
+    /** 2차(액션 생성/weekly) 결과·토큰 기록. weekly 는 본문 미저장이라 actionJson 생략 */
+    fun recordAction(
+        usage: TokenUsage,
+        actionJson: String? = null,
+    ) {
+        actionInputTokens = usage.promptTokens
+        actionOutputTokens = usage.completionTokens
+        actionResult = actionJson
+    }
+
     fun toEntity(): ChatLog =
         ChatLog(
             userId = userId,

--- a/src/main/kotlin/com/pluxity/weekly/chat/service/ChatLogService.kt
+++ b/src/main/kotlin/com/pluxity/weekly/chat/service/ChatLogService.kt
@@ -1,0 +1,74 @@
+package com.pluxity.weekly.chat.service
+
+import com.pluxity.weekly.chat.entity.ChatLog
+import com.pluxity.weekly.chat.repository.ChatLogRepository
+import io.github.oshai.kotlinlogging.KotlinLogging
+import org.springframework.stereotype.Service
+import java.math.BigDecimal
+import java.math.RoundingMode
+
+private val log = KotlinLogging.logger {}
+
+/**
+ * chat 1턴의 디버그 로그 저장 전담.
+ *
+ * 저장 실패가 chat 응답을 깨면 안 되므로 [record] 는 예외를 삼키고 로그만 남긴다.
+ * (알림 로그와 달리 도메인/응답과의 원자성이 목적이 아니라, 흐름 격리가 목적)
+ */
+@Service
+class ChatLogService(
+    private val chatLogRepository: ChatLogRepository,
+) {
+    fun record(data: ChatLogData) {
+        runCatching { chatLogRepository.save(data.toEntity()) }
+            .onFailure { e -> log.error(e) { "ChatLog 저장 실패 (무시): userId=${data.userId}" } }
+    }
+}
+
+/**
+ * processChat 진행 중 누적되는 로그 데이터. 단계별로 채워지다가 마지막에 [toEntity] 로 영속화된다.
+ * OpenRouter 외 provider(Gemini/Ollama)는 아직 사용량 미추출이라 토큰·cost 가 0으로 남는다.
+ */
+data class ChatLogData(
+    val userId: Long,
+    val requestMessage: String,
+    var success: Boolean = false,
+    var intentResult: String? = null,
+    var actionResult: String? = null,
+    var errorMessage: String? = null,
+    var intentInputTokens: Int = 0,
+    var intentOutputTokens: Int = 0,
+    var actionInputTokens: Int = 0,
+    var actionOutputTokens: Int = 0,
+) {
+    fun toEntity(): ChatLog =
+        ChatLog(
+            userId = userId,
+            requestMessage = requestMessage,
+            success = success,
+            intentResult = intentResult,
+            actionResult = actionResult,
+            errorMessage = errorMessage,
+            intentInputTokens = intentInputTokens,
+            intentOutputTokens = intentOutputTokens,
+            actionInputTokens = actionInputTokens,
+            actionOutputTokens = actionOutputTokens,
+            cost = calculateCost(intentInputTokens + actionInputTokens, intentOutputTokens + actionOutputTokens),
+        )
+
+    companion object {
+        // OpenRouter 모델 단가 (USD / 1M tokens). TODO: gemini 2.5 flash 고정이라 추후 모델 변경시 설정으로 분리
+        private val INPUT_PRICE_PER_M = BigDecimal("0.30")
+        private val OUTPUT_PRICE_PER_M = BigDecimal("2.50")
+        private val ONE_MILLION = BigDecimal(1_000_000)
+
+        fun calculateCost(
+            inputTokens: Int,
+            outputTokens: Int,
+        ): BigDecimal =
+            BigDecimal(inputTokens)
+                .multiply(INPUT_PRICE_PER_M)
+                .add(BigDecimal(outputTokens).multiply(OUTPUT_PRICE_PER_M))
+                .divide(ONE_MILLION, 8, RoundingMode.HALF_UP)
+    }
+}

--- a/src/main/kotlin/com/pluxity/weekly/chat/service/ChatLogService.kt
+++ b/src/main/kotlin/com/pluxity/weekly/chat/service/ChatLogService.kt
@@ -1,5 +1,6 @@
 package com.pluxity.weekly.chat.service
 
+import com.pluxity.weekly.chat.config.LlmProperties
 import com.pluxity.weekly.chat.entity.ChatLog
 import com.pluxity.weekly.chat.llm.dto.TokenUsage
 import com.pluxity.weekly.chat.repository.ChatLogRepository
@@ -19,9 +20,19 @@ private val log = KotlinLogging.logger {}
 @Service
 class ChatLogService(
     private val chatLogRepository: ChatLogRepository,
+    private val llmProperties: LlmProperties,
 ) {
     fun record(data: ChatLogData) {
-        runCatching { chatLogRepository.save(data.toEntity()) }
+        // 단가·모델은 현재 사용 중인 openrouter 설정 기준 (저장 시점 스냅샷)
+        val openrouter = llmProperties.openrouter
+        val cost =
+            ChatLogData.calculateCost(
+                inputTokens = data.totalInputTokens,
+                outputTokens = data.totalOutputTokens,
+                inputPricePerMillion = openrouter.inputPricePerMillion,
+                outputPricePerMillion = openrouter.outputPricePerMillion,
+            )
+        runCatching { chatLogRepository.save(data.toEntity(cost = cost, model = openrouter.model)) }
             .onFailure { e -> log.error(e) { "ChatLog 저장 실패 (무시): userId=${data.userId}" } }
     }
 }
@@ -42,6 +53,9 @@ data class ChatLogData(
     var actionInputTokens: Int = 0,
     var actionOutputTokens: Int = 0,
 ) {
+    val totalInputTokens: Int get() = intentInputTokens + actionInputTokens
+    val totalOutputTokens: Int get() = intentOutputTokens + actionOutputTokens
+
     /** 1차(의도 추출) 결과·토큰 기록 */
     fun recordIntent(
         intentJson: String,
@@ -62,7 +76,10 @@ data class ChatLogData(
         actionResult = actionJson
     }
 
-    fun toEntity(): ChatLog =
+    fun toEntity(
+        cost: BigDecimal,
+        model: String,
+    ): ChatLog =
         ChatLog(
             userId = userId,
             requestMessage = requestMessage,
@@ -74,22 +91,22 @@ data class ChatLogData(
             intentOutputTokens = intentOutputTokens,
             actionInputTokens = actionInputTokens,
             actionOutputTokens = actionOutputTokens,
-            cost = calculateCost(intentInputTokens + actionInputTokens, intentOutputTokens + actionOutputTokens),
+            cost = cost,
+            model = model,
         )
 
     companion object {
-        // OpenRouter 모델 단가 (USD / 1M tokens). TODO: gemini 2.5 flash 고정이라 추후 모델 변경시 설정으로 분리
-        private val INPUT_PRICE_PER_M = BigDecimal("0.30")
-        private val OUTPUT_PRICE_PER_M = BigDecimal("2.50")
         private val ONE_MILLION = BigDecimal(1_000_000)
 
         fun calculateCost(
             inputTokens: Int,
             outputTokens: Int,
+            inputPricePerMillion: BigDecimal,
+            outputPricePerMillion: BigDecimal,
         ): BigDecimal =
             BigDecimal(inputTokens)
-                .multiply(INPUT_PRICE_PER_M)
-                .add(BigDecimal(outputTokens).multiply(OUTPUT_PRICE_PER_M))
+                .multiply(inputPricePerMillion)
+                .add(BigDecimal(outputTokens).multiply(outputPricePerMillion))
                 .divide(ONE_MILLION, 8, RoundingMode.HALF_UP)
     }
 }

--- a/src/main/kotlin/com/pluxity/weekly/chat/service/ChatService.kt
+++ b/src/main/kotlin/com/pluxity/weekly/chat/service/ChatService.kt
@@ -30,6 +30,7 @@ class ChatService(
     private val redisTemplate: RedisTemplate<String, Any>,
     private val authorizationService: AuthorizationService,
     private val weeklyReportChatHandler: com.pluxity.weekly.report.service.WeeklyReportChatHandler,
+    private val chatLogService: ChatLogService,
 ) {
     companion object {
         private val RELEASE_LOCK_SCRIPT =
@@ -50,7 +51,7 @@ class ChatService(
         }
 
         try {
-            return processChat(message, userId.toString())
+            return processChat(message, userId)
         } finally {
             redisTemplate.execute(RELEASE_LOCK_SCRIPT, listOf(lockKey), lockValue)
         }
@@ -58,42 +59,64 @@ class ChatService(
 
     private fun processChat(
         message: String,
-        userId: String,
+        userId: Long,
     ): List<ChatActionResponse> {
-        // 히스토리 로드
-        val history = chatHistoryStore.load(userId)
-        if (history.isNotEmpty()) {
-            log.info { "히스토리 (${history.size}건):\n${history.joinToString("\n") { it.content }}" }
-        }
+        val userKey = userId.toString()
+        // 단계별로 채워 finally 에서 1회 저장 (디버깅용 로그)
+        val logData = ChatLogData(userId = userId, requestMessage = message)
 
-        // 1차: 의도 추출 (히스토리 포함)
-        val intentMessages = promptBuilder.buildIntentMessages(message, history)
-        val intent = llmService.extractIntent(intentMessages)
-        log.info { "1차 의도 추출 - action: ${intent.action}, target: ${intent.target}, id: ${intent.id}, response: $intent" }
-
-        // target별+action별+권한별 context 조회
-        val targetType = ChatTarget.fromOrNull(intent.target) ?: ChatTarget.TASK
-        val actionType = ChatActionType.fromOrNull(intent.action)
-        val context = contextBuilder.build(targetType, actionType)
-        log.info { "context:\n${objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(objectMapper.readTree(context))}" }
-
-        // weekly_report는 일반 LlmAction 흐름을 우회하고 별도 핸들러로
-        val responses =
-            if (targetType == ChatTarget.WEEKLY_REPORT) {
-                weeklyReportChatHandler.handle(intent, message, context)
-            } else {
-                // 2차: LlmAction 생성
-                val actionMessages = promptBuilder.buildActionMessages(message, intent, context)
-                val actions = llmService.generate(actionMessages).take(1)
-                log.info { "LLM 응답 액션:\n${objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(actions)}" }
-
-                // LlmAction → ChatActionResponse 변환
-                actions.map { chatActionRouter.route(it) }
+        try {
+            // 히스토리 로드
+            val history = chatHistoryStore.load(userKey)
+            if (history.isNotEmpty()) {
+                log.info { "히스토리 (${history.size}건):\n${history.joinToString("\n") { it.content }}" }
             }
 
-        if (targetType != ChatTarget.WEEKLY_REPORT) {
-            chatHistoryStore.recordChatTurn(userId, message, targetType.key, actionType?.key, responses)
+            // 1차: 의도 추출 (히스토리 포함)
+            val intentMessages = promptBuilder.buildIntentMessages(message, history)
+            val intentResult = llmService.extractIntent(intentMessages)
+            val intent = intentResult.value
+            logData.intentResult = objectMapper.writeValueAsString(intent)
+            logData.intentInputTokens = intentResult.usage.promptTokens
+            logData.intentOutputTokens = intentResult.usage.completionTokens
+            log.info { "1차 의도 추출 - action: ${intent.action}, target: ${intent.target}, id: ${intent.id}, response: $intent" }
+
+            // target별+action별+권한별 context 조회
+            val targetType = ChatTarget.fromOrNull(intent.target) ?: ChatTarget.TASK
+            val actionType = ChatActionType.fromOrNull(intent.action)
+            val context = contextBuilder.build(targetType, actionType)
+            log.info { "context:\n${objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(objectMapper.readTree(context))}" }
+
+            // weekly_report는 일반 LlmAction 흐름을 우회하고 별도 핸들러로
+            val responses =
+                if (targetType == ChatTarget.WEEKLY_REPORT) {
+                    weeklyReportChatHandler.handle(intent, message, context)
+                } else {
+                    // 2차: LlmAction 생성
+                    val actionMessages = promptBuilder.buildActionMessages(message, intent, context)
+                    val actionResult = llmService.generate(actionMessages)
+                    logData.actionInputTokens = actionResult.usage.promptTokens
+                    logData.actionOutputTokens = actionResult.usage.completionTokens
+                    val actions = actionResult.value.take(1)
+                    logData.actionResult = objectMapper.writeValueAsString(actions)
+                    log.info { "LLM 응답 액션:\n${objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(actions)}" }
+
+                    // LlmAction → ChatActionResponse 변환
+                    actions.map { chatActionRouter.route(it) }
+                }
+
+            if (targetType != ChatTarget.WEEKLY_REPORT) {
+                chatHistoryStore.recordChatTurn(userKey, message, targetType.key, actionType?.key, responses)
+            }
+
+            logData.success = true
+            return responses
+        } catch (e: Exception) {
+            logData.success = false
+            logData.errorMessage = e.message
+            throw e
+        } finally {
+            chatLogService.record(logData)
         }
-        return responses
     }
 }

--- a/src/main/kotlin/com/pluxity/weekly/chat/service/ChatService.kt
+++ b/src/main/kotlin/com/pluxity/weekly/chat/service/ChatService.kt
@@ -90,7 +90,10 @@ class ChatService(
             // weekly_report는 일반 LlmAction 흐름을 우회하고 별도 핸들러로
             val responses =
                 if (targetType == ChatTarget.WEEKLY_REPORT) {
-                    weeklyReportChatHandler.handle(intent, message, context)
+                    val weeklyResult = weeklyReportChatHandler.handle(intent, message, context)
+                    logData.actionInputTokens = weeklyResult.usage.promptTokens
+                    logData.actionOutputTokens = weeklyResult.usage.completionTokens
+                    weeklyResult.value
                 } else {
                     // 2차: LlmAction 생성
                     val actionMessages = promptBuilder.buildActionMessages(message, intent, context)

--- a/src/main/kotlin/com/pluxity/weekly/chat/service/ChatService.kt
+++ b/src/main/kotlin/com/pluxity/weekly/chat/service/ChatService.kt
@@ -6,8 +6,10 @@ import com.pluxity.weekly.chat.dto.ChatActionResponse
 import com.pluxity.weekly.chat.dto.ChatActionType
 import com.pluxity.weekly.chat.dto.ChatTarget
 import com.pluxity.weekly.chat.llm.LlmService
+import com.pluxity.weekly.chat.llm.dto.IntentResult
 import com.pluxity.weekly.core.constant.ErrorCode
 import com.pluxity.weekly.core.exception.CustomException
+import com.pluxity.weekly.report.service.WeeklyReportChatHandler
 import io.github.oshai.kotlinlogging.KotlinLogging
 import org.springframework.core.io.ClassPathResource
 import org.springframework.data.redis.core.RedisTemplate
@@ -29,7 +31,7 @@ class ChatService(
     private val objectMapper: ObjectMapper,
     private val redisTemplate: RedisTemplate<String, Any>,
     private val authorizationService: AuthorizationService,
-    private val weeklyReportChatHandler: com.pluxity.weekly.report.service.WeeklyReportChatHandler,
+    private val weeklyReportChatHandler: WeeklyReportChatHandler,
     private val chatLogService: ChatLogService,
 ) {
     companion object {
@@ -60,26 +62,12 @@ class ChatService(
     private fun processChat(
         message: String,
         userId: Long,
-    ): List<ChatActionResponse> {
-        val userKey = userId.toString()
-        // 단계별로 채워 finally 에서 1회 저장 (디버깅용 로그)
-        val logData = ChatLogData(userId = userId, requestMessage = message)
+    ): List<ChatActionResponse> =
+        withChatLog(userId, message) { logData ->
+            val userKey = userId.toString()
 
-        try {
-            // 히스토리 로드
-            val history = chatHistoryStore.load(userKey)
-            if (history.isNotEmpty()) {
-                log.info { "히스토리 (${history.size}건):\n${history.joinToString("\n") { it.content }}" }
-            }
-
-            // 1차: 의도 추출 (히스토리 포함)
-            val intentMessages = promptBuilder.buildIntentMessages(message, history)
-            val intentResult = llmService.extractIntent(intentMessages)
-            val intent = intentResult.value
-            logData.intentResult = objectMapper.writeValueAsString(intent)
-            logData.intentInputTokens = intentResult.usage.promptTokens
-            logData.intentOutputTokens = intentResult.usage.completionTokens
-            log.info { "1차 의도 추출 - action: ${intent.action}, target: ${intent.target}, id: ${intent.id}, response: $intent" }
+            // 1차: 의도 추출
+            val intent = resolveIntent(message, userKey, logData)
 
             // target별+action별+권한별 context 조회
             val targetType = ChatTarget.fromOrNull(intent.target) ?: ChatTarget.TASK
@@ -87,33 +75,33 @@ class ChatService(
             val context = contextBuilder.build(targetType, actionType)
             log.info { "context:\n${objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(objectMapper.readTree(context))}" }
 
-            // weekly_report는 일반 LlmAction 흐름을 우회하고 별도 핸들러로
+            // 2차: weekly_report는 별도 핸들러로 우회, 그 외는 일반 LlmAction 흐름 (프롬프트가 다름)
             val responses =
                 if (targetType == ChatTarget.WEEKLY_REPORT) {
-                    val weeklyResult = weeklyReportChatHandler.handle(intent, message, context)
-                    logData.actionInputTokens = weeklyResult.usage.promptTokens
-                    logData.actionOutputTokens = weeklyResult.usage.completionTokens
-                    weeklyResult.value
+                    runWeeklyReport(intent, message, context, logData)
                 } else {
-                    // 2차: LlmAction 생성
-                    val actionMessages = promptBuilder.buildActionMessages(message, intent, context)
-                    val actionResult = llmService.generate(actionMessages)
-                    logData.actionInputTokens = actionResult.usage.promptTokens
-                    logData.actionOutputTokens = actionResult.usage.completionTokens
-                    val actions = actionResult.value.take(1)
-                    logData.actionResult = objectMapper.writeValueAsString(actions)
-                    log.info { "LLM 응답 액션:\n${objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(actions)}" }
-
-                    // LlmAction → ChatActionResponse 변환
-                    actions.map { chatActionRouter.route(it) }
+                    generateActions(intent, message, context, logData)
                 }
 
+            // weekly_report 턴은 history에 기록하지 않음
             if (targetType != ChatTarget.WEEKLY_REPORT) {
                 chatHistoryStore.recordChatTurn(userKey, message, targetType.key, actionType?.key, responses)
             }
+            responses
+        }
 
-            logData.success = true
-            return responses
+    /**
+     * chat 1턴 처리를 [ChatLogData] 수집으로 감싸는 골격.
+     * 성공/실패와 무관하게 finally 에서 1회 기록하고, 저장 실패는 [ChatLogService.record] 가 삼킨다.
+     */
+    private inline fun withChatLog(
+        userId: Long,
+        message: String,
+        block: (ChatLogData) -> List<ChatActionResponse>,
+    ): List<ChatActionResponse> {
+        val logData = ChatLogData(userId = userId, requestMessage = message)
+        return try {
+            block(logData).also { logData.success = true }
         } catch (e: Exception) {
             logData.success = false
             logData.errorMessage = e.message
@@ -121,5 +109,51 @@ class ChatService(
         } finally {
             chatLogService.record(logData)
         }
+    }
+
+    private fun loadHistory(userKey: String) =
+        chatHistoryStore.load(userKey).also { history ->
+            if (history.isNotEmpty()) {
+                log.info { "히스토리 (${history.size}건):\n${history.joinToString("\n") { it.content }}" }
+            }
+        }
+
+    private fun resolveIntent(
+        message: String,
+        userKey: String,
+        logData: ChatLogData,
+    ): IntentResult {
+        val history = loadHistory(userKey)
+        val intentMessages = promptBuilder.buildIntentMessages(message, history)
+        val result = llmService.extractIntent(intentMessages)
+        val intent = result.value
+        logData.recordIntent(objectMapper.writeValueAsString(intent), result.usage)
+        log.info { "1차 의도 추출 - action: ${intent.action}, target: ${intent.target}, id: ${intent.id}, response: $intent" }
+        return intent
+    }
+
+    private fun generateActions(
+        intent: IntentResult,
+        message: String,
+        context: String,
+        logData: ChatLogData,
+    ): List<ChatActionResponse> {
+        val actionMessages = promptBuilder.buildActionMessages(message, intent, context)
+        val result = llmService.generate(actionMessages)
+        val actions = result.value.take(1)
+        logData.recordAction(result.usage, objectMapper.writeValueAsString(actions))
+        log.info { "LLM 응답 액션:\n${objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(actions)}" }
+        return actions.map { chatActionRouter.route(it) }
+    }
+
+    private fun runWeeklyReport(
+        intent: IntentResult,
+        message: String,
+        context: String,
+        logData: ChatLogData,
+    ): List<ChatActionResponse> {
+        val result = weeklyReportChatHandler.handle(intent, message, context)
+        logData.recordAction(result.usage)
+        return result.value
     }
 }

--- a/src/main/kotlin/com/pluxity/weekly/report/service/WeeklyReportChatHandler.kt
+++ b/src/main/kotlin/com/pluxity/weekly/report/service/WeeklyReportChatHandler.kt
@@ -8,6 +8,7 @@ import com.pluxity.weekly.chat.dto.ChatTarget
 import com.pluxity.weekly.chat.exception.ChatClarifyException
 import com.pluxity.weekly.chat.llm.LlmService
 import com.pluxity.weekly.chat.llm.dto.IntentResult
+import com.pluxity.weekly.chat.llm.dto.LlmResult
 import com.pluxity.weekly.chat.llm.dto.WeeklyReportClassifyResult
 import com.pluxity.weekly.chat.service.ChatPromptBuilder
 import com.pluxity.weekly.report.dto.MatchedAgainstPrev
@@ -35,7 +36,7 @@ class WeeklyReportChatHandler(
         intent: IntentResult,
         message: String,
         context: String,
-    ): List<ChatActionResponse> {
+    ): LlmResult<List<ChatActionResponse>> {
         val action =
             intent.action
                 ?.let { ChatActionType.fromOrNull(it) }
@@ -49,22 +50,25 @@ class WeeklyReportChatHandler(
         }
     }
 
-    private fun handleRead(intent: IntentResult): List<ChatActionResponse> {
+    private fun handleRead(intent: IntentResult): LlmResult<List<ChatActionResponse>> {
         val user = authorizationService.currentUser()
         teamRepository.findByLeaderId(user.requiredId).firstOrNull()
             ?: throw ChatClarifyException("주간보고는 팀 리더만 조회할 수 있습니다.")
 
         val report = weeklyReportService.findForChat(intent.week)
-        return listOf(
-            ChatActionResponse(
-                action = ChatActionType.READ.key,
-                target = ChatTarget.WEEKLY_REPORT.key,
-                readResult = ChatReadResponse(weeklyReport = report),
+        // 조회는 LLM 미사용 → usage 0
+        return LlmResult(
+            listOf(
+                ChatActionResponse(
+                    action = ChatActionType.READ.key,
+                    target = ChatTarget.WEEKLY_REPORT.key,
+                    readResult = ChatReadResponse(weeklyReport = report),
+                ),
             ),
         )
     }
 
-    private fun handleDelete(intent: IntentResult): List<ChatActionResponse> {
+    private fun handleDelete(intent: IntentResult): LlmResult<List<ChatActionResponse>> {
         val user = authorizationService.currentUser()
         val team =
             teamRepository.findByLeaderId(user.requiredId).firstOrNull()
@@ -75,11 +79,14 @@ class WeeklyReportChatHandler(
             weeklyReportService.delete(team, weekStart)
                 ?: throw ChatClarifyException("해당 주차에 삭제할 주간보고가 없습니다.")
 
-        return listOf(
-            ChatActionResponse(
-                action = ChatActionType.DELETE.key,
-                target = ChatTarget.WEEKLY_REPORT.key,
-                id = deletedId,
+        // 삭제는 LLM 미사용 → usage 0
+        return LlmResult(
+            listOf(
+                ChatActionResponse(
+                    action = ChatActionType.DELETE.key,
+                    target = ChatTarget.WEEKLY_REPORT.key,
+                    id = deletedId,
+                ),
             ),
         )
     }
@@ -88,7 +95,7 @@ class WeeklyReportChatHandler(
         message: String,
         context: String,
         intent: IntentResult,
-    ): List<ChatActionResponse> {
+    ): LlmResult<List<ChatActionResponse>> {
         // 2차 LLM: classify (system=classify-prompt, user=context + 본문)
         val messages = promptBuilder.buildActionMessages(message, intent, context)
         val classify = llmService.classifyWeeklyReport(messages)
@@ -102,17 +109,20 @@ class WeeklyReportChatHandler(
         val team = teams.first()
 
         // 매칭은 tx 밖에서 best-effort 계산 → upsert에 전달 (실패해도 보고 저장은 성공)
-        val matched = matchAgainstPrev(team, classify)
-        val response = weeklyReportService.upsertFromClassify(team, message, classify, matched)
+        val matched = matchAgainstPrev(team, classify.value)
+        val response = weeklyReportService.upsertFromClassify(team, message, classify.value, matched.value)
 
-        return listOf(
-            ChatActionResponse(
-                action = ChatActionType.CREATE.key,
-                target = ChatTarget.WEEKLY_REPORT.key,
-                id = response.id,
-                readResult = ChatReadResponse(weeklyReport = response),
-            ),
-        )
+        val responses =
+            listOf(
+                ChatActionResponse(
+                    action = ChatActionType.CREATE.key,
+                    target = ChatTarget.WEEKLY_REPORT.key,
+                    id = response.id,
+                    readResult = ChatReadResponse(weeklyReport = response),
+                ),
+            )
+        // classify + match(조건부) 토큰 합산 → ChatLog action_* 으로 매핑됨
+        return LlmResult(responses, classify.usage + matched.usage)
     }
 
     /**
@@ -123,17 +133,17 @@ class WeeklyReportChatHandler(
     private fun matchAgainstPrev(
         team: Team,
         classify: WeeklyReportClassifyResult,
-    ): MatchedAgainstPrev? {
+    ): LlmResult<MatchedAgainstPrev?> {
         val prevNextWeek = weeklyReportService.findPrevWeekNextItems(team, classify.weekStart)
-        if (prevNextWeek.isEmpty()) return null
+        if (prevNextWeek.isEmpty()) return LlmResult(null)
         val prevById = numberItems(prevNextWeek, "P")
         val currById = numberItems(classify.formatted.thisWeek, "C")
         return try {
             val raw = llmService.matchWeeklyReport(promptBuilder.buildMatchMessages(prevById, currById))
-            enrichMatched(raw, prevById, currById)
+            LlmResult(enrichMatched(raw.value, prevById, currById), raw.usage)
         } catch (e: Exception) {
             log.warn(e) { "주간보고 매칭 실패 (team=${team.requiredId}) — 매칭 없이 저장" }
-            null
+            LlmResult(null)
         }
     }
 }

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -22,6 +22,8 @@ llm:
   openrouter:
     api-key: ${OPENROUTER_API_KEY:}
     model: ${OPENROUTER_MODEL:}
+    input-price-per-million: ${OPENROUTER_INPUT_PRICE:0.30}
+    output-price-per-million: ${OPENROUTER_OUTPUT_PRICE:2.50}
   temperature: 0.1
   timeout-ms: 60000
 

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -39,6 +39,8 @@ llm:
   openrouter:
     api-key: ${OPENROUTER_API_KEY:}
     model: ${OPENROUTER_MODEL:}
+    input-price-per-million: ${OPENROUTER_INPUT_PRICE:0.30}
+    output-price-per-million: ${OPENROUTER_OUTPUT_PRICE:2.50}
   temperature: 0.1
   timeout-ms: 60000
 

--- a/src/main/resources/application-stage.yml
+++ b/src/main/resources/application-stage.yml
@@ -22,6 +22,8 @@ llm:
   openrouter:
     api-key: ${OPENROUTER_API_KEY:}
     model: ${OPENROUTER_MODEL:}
+    input-price-per-million: ${OPENROUTER_INPUT_PRICE:0.30}
+    output-price-per-million: ${OPENROUTER_OUTPUT_PRICE:2.50}
   temperature: 0.1
   timeout-ms: 60000
 

--- a/src/main/resources/db/migration/V20260608_001__add_chat_logs.sql
+++ b/src/main/resources/db/migration/V20260608_001__add_chat_logs.sql
@@ -1,0 +1,26 @@
+-- chat 1턴의 LLM 파이프라인 기록 테이블 (디버깅용, append-only)
+-- 성공/실패 모두 기록하며, 응답 흐름과 분리되어 저장 실패는 무시된다
+-- 토큰은 단가가 다른 input/output 을 분리 저장하고 cost(USD)를 산출해 함께 기록
+-- OpenRouter 외 provider 는 아직 사용량 미추출이라 토큰·cost 가 0 으로 남는다
+
+CREATE TABLE chat_logs (
+    id                   BIGSERIAL     PRIMARY KEY,
+    user_id              BIGINT        NOT NULL,
+    request_message      TEXT          NOT NULL,
+    success              BOOLEAN       NOT NULL,
+    intent_result        TEXT,
+    action_result        TEXT,
+    error_message        TEXT,
+    intent_input_tokens  INTEGER       NOT NULL DEFAULT 0,
+    intent_output_tokens INTEGER       NOT NULL DEFAULT 0,
+    action_input_tokens  INTEGER       NOT NULL DEFAULT 0,
+    action_output_tokens INTEGER       NOT NULL DEFAULT 0,
+    cost                 NUMERIC(16,8) NOT NULL DEFAULT 0,
+    created_at           TIMESTAMP     NOT NULL,
+    updated_at           TIMESTAMP     NOT NULL,
+    created_by           VARCHAR(255),
+    updated_by           VARCHAR(255)
+);
+
+CREATE INDEX idx_chat_logs_user_id_id
+    ON chat_logs (user_id, id DESC);

--- a/src/main/resources/db/migration/V20260608_002__add_chat_logs_model.sql
+++ b/src/main/resources/db/migration/V20260608_002__add_chat_logs_model.sql
@@ -1,0 +1,4 @@
+-- chat_logs 에 cost 산출 기준 모델 스냅샷 컬럼 추가 (단가 이력 추적용)
+-- V20260608_001 은 이미 적용된 환경이 있어 수정하지 않고 신규 마이그레이션으로 분리
+
+ALTER TABLE chat_logs ADD COLUMN model VARCHAR(128) NOT NULL DEFAULT '';

--- a/src/test/kotlin/com/pluxity/weekly/chat/llm/dto/LlmApiDtoTest.kt
+++ b/src/test/kotlin/com/pluxity/weekly/chat/llm/dto/LlmApiDtoTest.kt
@@ -1,0 +1,53 @@
+package com.pluxity.weekly.chat.llm.dto
+
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import tools.jackson.databind.json.JsonMapper
+
+class LlmApiDtoTest :
+    BehaviorSpec({
+
+        Given("TokenUsage.plus") {
+            When("두 usage 를 더하면") {
+                val a = TokenUsage(promptTokens = 3988, completionTokens = 11, totalTokens = 3999)
+                val b = TokenUsage(promptTokens = 4259, completionTokens = 3536, totalTokens = 7795)
+                val sum = a + b
+
+                Then("필드별로 합산된다") {
+                    sum.promptTokens shouldBe 8247
+                    sum.completionTokens shouldBe 3547
+                    sum.totalTokens shouldBe 11794
+                }
+            }
+        }
+
+        Given("OpenAiChatResponse usage 역직렬화") {
+            val objectMapper = JsonMapper()
+
+            When("snake_case usage 가 포함된 응답을 파싱하면") {
+                val json =
+                    """
+                    {
+                      "choices": [{"message": {"content": "hi"}}],
+                      "usage": {"prompt_tokens": 2362, "completion_tokens": 9, "total_tokens": 2371}
+                    }
+                    """.trimIndent()
+                val response = objectMapper.readValue(json, OpenAiChatResponse::class.java)
+
+                Then("prompt_tokens/completion_tokens/total_tokens 가 매핑된다") {
+                    response.usage?.promptTokens shouldBe 2362
+                    response.usage?.completionTokens shouldBe 9
+                    response.usage?.totalTokens shouldBe 2371
+                }
+            }
+
+            When("usage 가 없는 응답을 파싱하면") {
+                val json = """{"choices": [{"message": {"content": "hi"}}]}"""
+                val response = objectMapper.readValue(json, OpenAiChatResponse::class.java)
+
+                Then("usage 는 null") {
+                    response.usage shouldBe null
+                }
+            }
+        }
+    })

--- a/src/test/kotlin/com/pluxity/weekly/chat/service/ChatLogServiceTest.kt
+++ b/src/test/kotlin/com/pluxity/weekly/chat/service/ChatLogServiceTest.kt
@@ -1,0 +1,89 @@
+package com.pluxity.weekly.chat.service
+
+import com.pluxity.weekly.chat.repository.ChatLogRepository
+import io.kotest.assertions.throwables.shouldNotThrowAny
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import java.math.BigDecimal
+
+class ChatLogServiceTest :
+    BehaviorSpec({
+
+        Given("ChatLogData.calculateCost") {
+            When("input/output 토큰으로 비용을 계산하면") {
+                Then("input 0.30/M + output 2.50/M 단가로 8자리 USD가 산출된다") {
+                    // 실측 케이스: input 8247 / output 3547 → 0.01134160
+                    ChatLogData.calculateCost(8247, 3547) shouldBe BigDecimal("0.01134160")
+                }
+            }
+
+            When("토큰이 0이면") {
+                Then("비용은 0") {
+                    ChatLogData.calculateCost(0, 0) shouldBe BigDecimal("0.00000000")
+                }
+            }
+
+            When("output만 1M 토큰이면") {
+                Then("output 단가(2.50/M)만 반영된다") {
+                    ChatLogData.calculateCost(0, 1_000_000) shouldBe BigDecimal("2.50000000")
+                }
+            }
+        }
+
+        Given("ChatLogData.toEntity") {
+            When("intent/action 토큰이 채워진 데이터를 변환하면") {
+                val data =
+                    ChatLogData(
+                        userId = 37L,
+                        requestMessage = "내 업무 보여줘",
+                        success = true,
+                        intentInputTokens = 2362,
+                        intentOutputTokens = 9,
+                        actionInputTokens = 4858,
+                        actionOutputTokens = 20,
+                    )
+                val entity = data.toEntity()
+
+                Then("필드가 매핑되고 cost는 intent+action 합산으로 계산된다") {
+                    entity.userId shouldBe 37L
+                    entity.requestMessage shouldBe "내 업무 보여줘"
+                    entity.success shouldBe true
+                    entity.intentInputTokens shouldBe 2362
+                    entity.intentOutputTokens shouldBe 9
+                    entity.actionInputTokens shouldBe 4858
+                    entity.actionOutputTokens shouldBe 20
+                    // (2362+4858)*0.30 + (9+20)*2.50 = 2166 + 72.5 = 2238.5 / 1e6
+                    entity.cost shouldBe BigDecimal("0.00223850")
+                }
+            }
+        }
+
+        Given("ChatLogService.record") {
+            val data = ChatLogData(userId = 1L, requestMessage = "msg", success = true)
+
+            When("저장이 정상이면") {
+                val repository: ChatLogRepository = mockk()
+                every { repository.save(any()) } answers { firstArg() }
+                val service = ChatLogService(repository)
+
+                service.record(data)
+
+                Then("repository.save 가 호출된다") {
+                    verify(exactly = 1) { repository.save(any()) }
+                }
+            }
+
+            When("저장이 예외를 던지면") {
+                val repository: ChatLogRepository = mockk()
+                every { repository.save(any()) } throws RuntimeException("DB down")
+                val service = ChatLogService(repository)
+
+                Then("예외를 삼키고 전파하지 않는다 (chat 흐름 보호)") {
+                    shouldNotThrowAny { service.record(data) }
+                }
+            }
+        }
+    })

--- a/src/test/kotlin/com/pluxity/weekly/chat/service/ChatLogServiceTest.kt
+++ b/src/test/kotlin/com/pluxity/weekly/chat/service/ChatLogServiceTest.kt
@@ -1,5 +1,7 @@
 package com.pluxity.weekly.chat.service
 
+import com.pluxity.weekly.chat.config.LlmProperties
+import com.pluxity.weekly.chat.config.OpenRouterProperties
 import com.pluxity.weekly.chat.repository.ChatLogRepository
 import io.kotest.assertions.throwables.shouldNotThrowAny
 import io.kotest.core.spec.style.BehaviorSpec
@@ -12,29 +14,32 @@ import java.math.BigDecimal
 class ChatLogServiceTest :
     BehaviorSpec({
 
+        val inputPrice = BigDecimal("0.30")
+        val outputPrice = BigDecimal("2.50")
+
         Given("ChatLogData.calculateCost") {
-            When("input/output 토큰으로 비용을 계산하면") {
-                Then("input 0.30/M + output 2.50/M 단가로 8자리 USD가 산출된다") {
+            When("input/output 토큰과 단가로 비용을 계산하면") {
+                Then("input·output 단가를 각각 적용해 8자리 USD가 산출된다") {
                     // 실측 케이스: input 8247 / output 3547 → 0.01134160
-                    ChatLogData.calculateCost(8247, 3547) shouldBe BigDecimal("0.01134160")
+                    ChatLogData.calculateCost(8247, 3547, inputPrice, outputPrice) shouldBe BigDecimal("0.01134160")
                 }
             }
 
             When("토큰이 0이면") {
                 Then("비용은 0") {
-                    ChatLogData.calculateCost(0, 0) shouldBe BigDecimal("0.00000000")
+                    ChatLogData.calculateCost(0, 0, inputPrice, outputPrice) shouldBe BigDecimal("0.00000000")
                 }
             }
 
             When("output만 1M 토큰이면") {
                 Then("output 단가(2.50/M)만 반영된다") {
-                    ChatLogData.calculateCost(0, 1_000_000) shouldBe BigDecimal("2.50000000")
+                    ChatLogData.calculateCost(0, 1_000_000, inputPrice, outputPrice) shouldBe BigDecimal("2.50000000")
                 }
             }
         }
 
         Given("ChatLogData.toEntity") {
-            When("intent/action 토큰이 채워진 데이터를 변환하면") {
+            When("토큰 데이터에 cost·model 을 주입해 변환하면") {
                 val data =
                     ChatLogData(
                         userId = 37L,
@@ -45,29 +50,54 @@ class ChatLogServiceTest :
                         actionInputTokens = 4858,
                         actionOutputTokens = 20,
                     )
-                val entity = data.toEntity()
+                val entity = data.toEntity(cost = BigDecimal("0.00223850"), model = "google/gemini-2.5-flash")
 
-                Then("필드가 매핑되고 cost는 intent+action 합산으로 계산된다") {
+                Then("필드·cost·model 이 그대로 매핑된다") {
                     entity.userId shouldBe 37L
                     entity.requestMessage shouldBe "내 업무 보여줘"
                     entity.success shouldBe true
                     entity.intentInputTokens shouldBe 2362
-                    entity.intentOutputTokens shouldBe 9
-                    entity.actionInputTokens shouldBe 4858
                     entity.actionOutputTokens shouldBe 20
-                    // (2362+4858)*0.30 + (9+20)*2.50 = 2166 + 72.5 = 2238.5 / 1e6
                     entity.cost shouldBe BigDecimal("0.00223850")
+                    entity.model shouldBe "google/gemini-2.5-flash"
+                }
+            }
+        }
+
+        Given("ChatLogData total 토큰") {
+            When("intent/action 토큰이 채워지면") {
+                val data =
+                    ChatLogData(
+                        userId = 1L,
+                        requestMessage = "msg",
+                        intentInputTokens = 100,
+                        intentOutputTokens = 10,
+                        actionInputTokens = 200,
+                        actionOutputTokens = 20,
+                    )
+                Then("input/output 별로 합산된다") {
+                    data.totalInputTokens shouldBe 300
+                    data.totalOutputTokens shouldBe 30
                 }
             }
         }
 
         Given("ChatLogService.record") {
+            val llmProperties =
+                LlmProperties(
+                    openrouter =
+                        OpenRouterProperties(
+                            model = "test-model",
+                            inputPricePerMillion = inputPrice,
+                            outputPricePerMillion = outputPrice,
+                        ),
+                )
             val data = ChatLogData(userId = 1L, requestMessage = "msg", success = true)
 
             When("저장이 정상이면") {
                 val repository: ChatLogRepository = mockk()
                 every { repository.save(any()) } answers { firstArg() }
-                val service = ChatLogService(repository)
+                val service = ChatLogService(repository, llmProperties)
 
                 service.record(data)
 
@@ -79,7 +109,7 @@ class ChatLogServiceTest :
             When("저장이 예외를 던지면") {
                 val repository: ChatLogRepository = mockk()
                 every { repository.save(any()) } throws RuntimeException("DB down")
-                val service = ChatLogService(repository)
+                val service = ChatLogService(repository, llmProperties)
 
                 Then("예외를 삼키고 전파하지 않는다 (chat 흐름 보호)") {
                     shouldNotThrowAny { service.record(data) }


### PR DESCRIPTION
  ## 개요
  chat의  LLM 파이프라인(의도 추출 → 액션 생성)을 디버깅용으로 `chat_logs`에 기록하고,
  OpenRouter 토큰 사용량에서 비용(USD)까지 산출한다.

## 변경 사항
 - **ChatLog 기록**: 사용자 원문, 1·2차 LLM 결과, 성공여부, 토큰(input/output 분리), cost, model 저장
  - **흐름 격리**: 저장 실패 시에도 chat 응답을 깨지 않도록 함
  - **토큰/비용 집계**: OpenRouter 응답에서 usage 추출(input/output 분리) → cost 산출
  - **weekly_report**: classify/match LLM 토큰까지 합산 집계
  - **단가 설정화**: LLM 단가를 하드코딩에서 config로 분리
  - **리팩토링**
    - LlmService: 호출/파싱 중복 제거 (`callWithRetry`, `decodeJson`)
    - ChatService: 오케스트레이션 정리 (단계 메서드 추출)