### PR TITLE
feat(project): ProjectResponse 진행률(progress) 추가

### DIFF
--- a/src/main/kotlin/com/pluxity/weekly/project/dto/ProjectResponse.kt
+++ b/src/main/kotlin/com/pluxity/weekly/project/dto/ProjectResponse.kt
@@ -28,6 +28,8 @@ data class ProjectResponse(
     val pmName: String?,
     @field:Schema(description = "참여자 목록")
     val members: List<ProjectMemberResponse>,
+    @field:Schema(description = "전체 진행률 (태스크 평균)", example = "45")
+    val progress: Int,
     @field:JsonUnwrapped
     val baseResponse: BaseResponse,
 )
@@ -49,6 +51,7 @@ data class ProjectMemberResponse(
 fun Project.toResponse(
     memberInfos: List<ProjectMemberResponse> = emptyList(),
     pmName: String? = null,
+    progress: Int = 0,
 ): ProjectResponse =
     ProjectResponse(
         id = this.requiredId,
@@ -60,5 +63,6 @@ fun Project.toResponse(
         pmId = this.pmId,
         pmName = pmName,
         members = memberInfos,
+        progress = progress,
         baseResponse = this.toBaseResponse(),
     )

--- a/src/main/kotlin/com/pluxity/weekly/project/service/ProjectService.kt
+++ b/src/main/kotlin/com/pluxity/weekly/project/service/ProjectService.kt
@@ -41,18 +41,23 @@ class ProjectService(
         val projects = projectRepository.findByFilter(scoped)
         if (projects.isEmpty()) return emptyList()
 
+        val projectIds = projects.map { it.requiredId }
         val memberMap =
             projectRepository
-                .findMembersByProjectIds(projects.map { it.requiredId })
+                .findMembersByProjectIds(projectIds)
                 .groupBy { it.projectId }
         val pmNameMap = resolvePmNames(projects.mapNotNull { it.pmId })
-        return projects.map { it.toResponse(memberMap[it.requiredId].orEmpty(), pmNameMap[it.pmId]) }
+        val progressMap = averageProgressByProjectIds(projectIds)
+        return projects.map {
+            it.toResponse(memberMap[it.requiredId].orEmpty(), pmNameMap[it.pmId], progressMap[it.requiredId] ?: 0)
+        }
     }
 
     fun findById(id: Long): ProjectResponse {
         val project = getById(id)
         val pmName = project.pmId?.let { userRepository.findByIdOrNull(it)?.name }
-        return project.toResponse(projectRepository.findMembersByProjectIds(listOf(project.requiredId)), pmName)
+        val progress = averageProgressByProjectIds(listOf(id))[id] ?: 0
+        return project.toResponse(projectRepository.findMembersByProjectIds(listOf(project.requiredId)), pmName, progress)
     }
 
     @Transactional
@@ -159,6 +164,14 @@ class ProjectService(
                 projectName = project.name,
             ),
         )
+    }
+
+    /** 프로젝트별 진행률(전체 태스크 progress 평균, 반올림 절삭). 태스크 없는 프로젝트는 키 없음 → 호출부 0 처리 */
+    private fun averageProgressByProjectIds(projectIds: List<Long>): Map<Long, Int> {
+        if (projectIds.isEmpty()) return emptyMap()
+        return taskRepository
+            .findAverageProgressByProjectIds(projectIds)
+            .associate { it.projectId to it.avgProgress.toInt() }
     }
 
     private fun resolvePmNames(pmIds: List<Long>): Map<Long, String> =

--- a/src/main/kotlin/com/pluxity/weekly/task/repository/TaskRepository.kt
+++ b/src/main/kotlin/com/pluxity/weekly/task/repository/TaskRepository.kt
@@ -104,4 +104,21 @@ interface TaskRepository :
     fun restoreByProjectId(
         @Param("projectId") projectId: Long,
     ): Int
+
+    @Query(
+        """
+        SELECT t.epic.project.id AS projectId, AVG(t.progress) AS avgProgress
+        FROM Task t
+        WHERE t.epic.project.id IN :projectIds
+        GROUP BY t.epic.project.id
+        """,
+    )
+    fun findAverageProgressByProjectIds(
+        @Param("projectIds") projectIds: List<Long>,
+    ): List<ProjectProgressRow>
+}
+
+interface ProjectProgressRow {
+    val projectId: Long
+    val avgProgress: Double
 }

--- a/src/test/kotlin/com/pluxity/weekly/project/service/ProjectServiceTest.kt
+++ b/src/test/kotlin/com/pluxity/weekly/project/service/ProjectServiceTest.kt
@@ -13,6 +13,7 @@ import com.pluxity.weekly.project.entity.ProjectStatus
 import com.pluxity.weekly.project.entity.dummyProject
 import com.pluxity.weekly.project.event.ProjectPmAssignedEvent
 import com.pluxity.weekly.project.repository.ProjectRepository
+import com.pluxity.weekly.task.repository.ProjectProgressRow
 import com.pluxity.weekly.task.repository.TaskRepository
 import com.pluxity.weekly.test.entity.dummyRole
 import com.pluxity.weekly.test.entity.dummyUser
@@ -58,6 +59,8 @@ class ProjectServiceTest :
             every { authorizationService.requireProjectManager(any(), any<Project>()) } just runs
             every { authorizationService.requireAdmin(any()) } just runs
             every { authorizationService.visibleProjectIds(any()) } returns null
+            // progress 집계는 케이스별로 덮어쓰며, 기본값은 "태스크 없음"(빈 결과 → 0)
+            every { taskRepository.findAverageProgressByProjectIds(any()) } returns emptyList()
         }
 
         Given("프로젝트 전체 조회") {
@@ -462,4 +465,68 @@ class ProjectServiceTest :
                 }
             }
         }
+
+        Given("프로젝트 진행률(progress) 계산") {
+            And("단건 조회(findById)") {
+                When("하위 태스크 progress 평균이 존재하면") {
+                    val entity = dummyProject(id = 40L, name = "진행률 프로젝트")
+                    every { projectRepository.findByIdOrNull(40L) } returns entity
+                    every { projectRepository.findMembersByProjectIds(listOf(40L)) } returns emptyList()
+                    every { taskRepository.findAverageProgressByProjectIds(listOf(40L)) } returns
+                        listOf(progressRow(40L, 45.9))
+
+                    val result = service.findById(40L)
+
+                    Then("소수점을 버린 정수 progress 가 반환된다") {
+                        result.progress shouldBe 45
+                    }
+                }
+
+                When("하위 태스크가 없으면(집계 결과 없음)") {
+                    val entity = dummyProject(id = 41L, name = "태스크 없는 프로젝트")
+                    every { projectRepository.findByIdOrNull(41L) } returns entity
+                    every { projectRepository.findMembersByProjectIds(listOf(41L)) } returns emptyList()
+                    every { taskRepository.findAverageProgressByProjectIds(listOf(41L)) } returns emptyList()
+
+                    val result = service.findById(41L)
+
+                    Then("progress 는 0 이다") {
+                        result.progress shouldBe 0
+                    }
+                }
+            }
+
+            And("전체 조회(findAll)") {
+                When("일부 프로젝트에만 태스크 평균이 있으면") {
+                    val entities =
+                        listOf(
+                            dummyProject(id = 1L, name = "A"),
+                            dummyProject(id = 2L, name = "B"),
+                            dummyProject(id = 3L, name = "C"),
+                        )
+                    every { projectRepository.findByFilter(any()) } returns entities
+                    every { projectRepository.findMembersByProjectIds(any()) } returns emptyList()
+                    every { userRepository.findAllById(any<List<Long>>()) } returns emptyList()
+                    every { taskRepository.findAverageProgressByProjectIds(listOf(1L, 2L, 3L)) } returns
+                        listOf(progressRow(1L, 80.0), progressRow(3L, 33.7))
+
+                    val result = service.findAll()
+
+                    Then("평균이 있는 프로젝트는 정수 progress, 없는 프로젝트는 0 이다") {
+                        result.first { it.id == 1L }.progress shouldBe 80
+                        result.first { it.id == 2L }.progress shouldBe 0
+                        result.first { it.id == 3L }.progress shouldBe 33
+                    }
+                }
+            }
+        }
     })
+
+private fun progressRow(
+    id: Long,
+    avg: Double,
+): ProjectProgressRow =
+    object : ProjectProgressRow {
+        override val projectId = id
+        override val avgProgress = avg
+    }


### PR DESCRIPTION
## 요약
- `ProjectResponse`에 `progress` 필드 추가 — 하위 전체 태스크 progress의 평균
- `findAll`/`findById` 모두 단일 집계 쿼리(`findAverageProgressByProjectIds`)로 계산해 N+1 회피
- 태스크가 없는 프로젝트는 0

Closes #64

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Projects now display overall progress metrics calculated from the average completion percentage of all associated project tasks, providing visibility into project status at a glance.

* **Tests**
  * Added comprehensive test coverage for project progress calculations, including scenarios with varying data availability and proper handling of edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->