### PR TITLE
feat(user): UserResponse 대표 역할(effectiveRole) 추가

### DIFF
--- a/src/main/kotlin/com/pluxity/weekly/auth/authorization/UserType.kt
+++ b/src/main/kotlin/com/pluxity/weekly/auth/authorization/UserType.kt
@@ -2,9 +2,21 @@ package com.pluxity.weekly.auth.authorization
 
 enum class UserType(
     val roleName: String,
+    val priority: Int,
 ) {
-    ADMIN("ADMIN"),
-    PM("PM"),
-    PO("PO"),
-    TEAM_LEADER("LEADER"),
+    ADMIN("ADMIN", 1),
+    PO("PO", 2),
+    PM("PM", 3),
+    TEAM_LEADER("LEADER", 4),
+    WORKER("WORKER", 5),
+    ;
+
+    companion object {
+        fun effectiveRoleName(ownedRoleNames: Set<String>): String =
+            entries
+                .filter { it.roleName in ownedRoleNames }
+                .minByOrNull { it.priority }
+                ?.roleName
+                ?: WORKER.roleName
+    }
 }

--- a/src/main/kotlin/com/pluxity/weekly/auth/user/dto/UserResponse.kt
+++ b/src/main/kotlin/com/pluxity/weekly/auth/user/dto/UserResponse.kt
@@ -1,5 +1,6 @@
 package com.pluxity.weekly.auth.user.dto
 
+import com.pluxity.weekly.auth.authorization.UserType
 import com.pluxity.weekly.auth.user.entity.User
 import io.swagger.v3.oas.annotations.media.Schema
 
@@ -21,6 +22,8 @@ data class UserResponse(
     val shouldChangePassword: Boolean,
     @field:Schema(description = "역할 목록")
     val roles: List<RoleResponse>,
+    @field:Schema(description = "대표 역할 (우선순위 ADMIN > PO > PM > LEADER, 없으면 WORKER)", example = "PM")
+    val effectiveRole: String,
 )
 
 fun User.toResponse(): UserResponse =
@@ -33,4 +36,5 @@ fun User.toResponse(): UserResponse =
         email = this.email,
         shouldChangePassword = this.isPasswordChangeRequired(),
         roles = this.userRoles.sortedByDescending { it.role.id }.map { it.role.toResponse() },
+        effectiveRole = UserType.effectiveRoleName(this.userRoles.map { it.role.name.uppercase() }.toSet()),
     )

--- a/src/test/kotlin/com/pluxity/weekly/auth/authorization/UserTypeTest.kt
+++ b/src/test/kotlin/com/pluxity/weekly/auth/authorization/UserTypeTest.kt
@@ -1,0 +1,44 @@
+package com.pluxity.weekly.auth.authorization
+
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+
+class UserTypeTest :
+    BehaviorSpec({
+
+        Given("대표 역할(effectiveRole) 선정") {
+            When("역할이 하나만 있으면") {
+                Then("그 역할명이 그대로 반환된다") {
+                    UserType.effectiveRoleName(setOf("PM")) shouldBe "PM"
+                    UserType.effectiveRoleName(setOf("LEADER")) shouldBe "LEADER"
+                }
+            }
+
+            When("역할이 여러 개 있으면") {
+                Then("우선순위(ADMIN > PO > PM > LEADER)가 가장 높은 역할이 선택된다") {
+                    UserType.effectiveRoleName(setOf("PM", "PO")) shouldBe "PO"
+                    UserType.effectiveRoleName(setOf("LEADER", "PM")) shouldBe "PM"
+                    UserType.effectiveRoleName(setOf("LEADER", "ADMIN", "PM")) shouldBe "ADMIN"
+                }
+            }
+
+            When("역할 집합이 비어 있으면") {
+                Then("기본값 WORKER 가 반환된다") {
+                    UserType.effectiveRoleName(emptySet()) shouldBe "WORKER"
+                }
+            }
+
+            When("enum 에 매칭되지 않는 역할만 있으면") {
+                Then("기본값 WORKER 가 반환된다") {
+                    UserType.effectiveRoleName(setOf("WORKER")) shouldBe "WORKER"
+                    UserType.effectiveRoleName(setOf("CEO")) shouldBe "WORKER"
+                }
+            }
+
+            When("매칭되는 역할과 알 수 없는 역할이 섞여 있으면") {
+                Then("매칭되는 것 중 우선순위가 높은 역할이 선택된다") {
+                    UserType.effectiveRoleName(setOf("CEO", "PM")) shouldBe "PM"
+                }
+            }
+        }
+    })


### PR DESCRIPTION
## 요약
- `UserResponse`에 `effectiveRole` 단일 필드 추가
- 여러 역할 보유 시 우선순위(ADMIN > PO > PM > LEADER) 최상위 1개, 매칭 없으면 WORKER
- FE의 역할 표시·권한 분기 통일용

Closes #63

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced role priority system to automatically determine effective user role when multiple roles are assigned
  * User profiles now include effective role information based on priority levels

* **Tests**
  * Added comprehensive test coverage for role priority and effective role selection logic

<!-- end of auto-generated comment: release notes by coderabbit.ai -->